### PR TITLE
JSONP was specified as a output format causing documentation problems.

### DIFF
--- a/root/documentation/sequence.conf
+++ b/root/documentation/sequence.conf
@@ -6,7 +6,6 @@
     method=GET
     output=fasta
     output=json
-    output=jsonp
     output=text
     output=yaml
     <params>
@@ -154,7 +153,6 @@
     method=GET
     output=fasta
     output=json
-    output=jsonp
     output=text
     output=yaml
     <params>


### PR DESCRIPTION
Problem raised by a reviewer. Branch has been made against b3aec9d so it can be cleanly applied against master and release/76.

We specified jsonp as an output format. This caused problems in the
documentation code which looked to see if JSONP was already specified as
an output format. It meant that callback was not added as a parameter
which is a bit poor. Removing jsonp as an output format fixes the error.
