### PR TITLE
Allow mult. users to serve from the same machine

### DIFF
--- a/lib/EnsEMBL/REST/View/HTML.pm
+++ b/lib/EnsEMBL/REST/View/HTML.pm
@@ -28,7 +28,7 @@ __PACKAGE__->config(
     TEMPLATE_EXTENSION => '.tt',
     RENDER_DIE => 1,
     WRAPPER => 'wrapper.tt',
-    COMPILE_DIR => File::Spec->catdir(File::Spec->tmpdir(),'ensrest', 'template_cache'),
+    COMPILE_DIR => File::Spec->catdir(File::Spec->tmpdir(), $ENV{USER}, 'ensrest', 'template_cache'),
     STASH => Template::Stash::XS->new(),
 );
 


### PR DESCRIPTION
EnsEMBL::REST::Controller::Compara only deals
Otherwise, I can't run the server on farm3-head4 (for instance) because /tmp/ensrest is already there and owned by someone else 
