### PR TITLE
Updated documentation to show where paramaters go

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -246,6 +246,7 @@
     output=json
     output=xml
     <params>
+      description=The required paramater is part of the request URL, while the optional paramaters must be included at the root level of the message object.
       <species>
         type=String
         description=Species name/alias


### PR DESCRIPTION
It's not clear in the documentation that the paramaters are used in different ways. The required paramater is part of the URL, while the optional paramaters must be part of the message root object. I found this out myself, as I followed the previous example of a single vep query (where the optional paramaters were appened as a query string).

I don't know if I quite got the format your documentation right. Please let me know / fix it if not.