### PR TITLE
added is_circular attribute for topology of seq_regions

### DIFF
--- a/lib/EnsEMBL/REST/Controller/Assembly.pm
+++ b/lib/EnsEMBL/REST/Controller/Assembly.pm
@@ -59,6 +59,7 @@ sub seq_region: Chained('species') PathPart('') Args(1) ActionClass('REST') {
       coordinate_system => $slice->coord_system()->name(),
       assembly_exception_type => $slice->assembly_exception_type(),
       is_chromosome => $slice->is_chromosome(),
+      is_circular => ($slice->is_circular()||0),
       karyotype_band => $bands,
       assembly_name => $slice->coord_system()->version(),
     });
@@ -68,6 +69,7 @@ sub seq_region: Chained('species') PathPart('') Args(1) ActionClass('REST') {
       coordinate_system => $slice->coord_system()->name(),
       assembly_exception_type => $slice->assembly_exception_type(),
       is_chromosome => $slice->is_chromosome(),
+      is_circular => ($slice->is_circular()||0),
       assembly_name => $slice->coord_system()->version(),
     });
   }

--- a/t/assembly_info.t
+++ b/t/assembly_info.t
@@ -52,7 +52,7 @@ is_json_GET(
 
 is_json_GET(
   '/info/assembly/homo_sapiens/6',
-  {assembly_exception_type => 'REF', coordinate_system => 'chromosome', is_chromosome => 1, length => 171115067, assembly_name => 'GRCh37' },
+  {assembly_exception_type => 'REF', coordinate_system => 'chromosome', is_chromosome => 1, is_circular => 0, length => 171115067, assembly_name => 'GRCh37' },
   'Checking info of region 6 matches expected'
 );
 


### PR DESCRIPTION
Addition of topology information, using is_circular rather than topology for consistency with other endpoints.