### PR TITLE
New option to output the CIGAR line of the alignment

### DIFF
--- a/lib/EnsEMBL/REST/Controller/GeneTree.pm
+++ b/lib/EnsEMBL/REST/Controller/GeneTree.pm
@@ -103,10 +103,11 @@ sub _set_genetree {
     # code deal with it.
     my $aligned = $c->request()->param('aligned') || $c->request()->param('phyloxml_aligned') ? 1 : 0;
     my $sequence = $c->request()->param('sequence') || $c->request()->param('phyloxml_sequence') || 'protein';
+    my $cigar_line = $c->request()->param('cigar_line') ? 1 : 0;
     my $cdna = $sequence eq 'cdna' ? 1 : 0;
     my $no_sequences = $sequence eq 'none' ? 1 : 0;
     $gt->preload();
-    my $hash = Bio::EnsEMBL::Compara::Utils::GeneTreeHash->convert ($gt, -no_sequences => $no_sequences, -aligned => $aligned, -cdna => $cdna, -species_common_name => 0, -exon_boundaries => 0, -gaps => 0, -full_tax_info => 0);
+    my $hash = Bio::EnsEMBL::Compara::Utils::GeneTreeHash->convert ($gt, -no_sequences => $no_sequences, -aligned => $aligned, -cdna => $cdna, -species_common_name => 0, -exon_boundaries => 0, -gaps => 0, -full_tax_info => 0, -cigar_line => $cigar_line);
     return $self->status_ok($c, entity => $hash);
   }
   return $self->status_ok($c, entity => $gt);

--- a/lib/EnsEMBL/REST/Controller/Homology.pm
+++ b/lib/EnsEMBL/REST/Controller/Homology.pm
@@ -275,6 +275,8 @@ sub _full_encoding {
   my $seq_type = $c->request->param('sequence') || 'protein';
   my $aligned = $c->request->param('aligned');
   $aligned = 1 unless defined $aligned;
+  my $cigar_line = $c->request->param('cigar_line');
+  $cigar_line = 1 unless defined $cigar_line;
   
   my $encode = sub {
     my ($member) = @_;
@@ -286,9 +288,9 @@ sub _full_encoding {
       species => $genome_db->name(),
       perc_id => ($member->perc_id()*1),
       perc_pos => ($member->perc_pos()*1),
-      cigar_line => $member->cigar_line(),
       protein_id => $gene->get_canonical_SeqMember()->stable_id(),
     };
+    $result->{cigar_line} = $member->cigar_line() if $cigar_line;
     $result->{taxon_id} = ($taxon_id+0) if defined $taxon_id;
     if($aligned && $member->cigar_line()) {
       if($seq_type eq 'protein') {

--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -64,6 +64,11 @@
         description=The type of sequence to bring back. Setting it to none results in no sequence being returned
         default=protein
       </sequence>
+      <cigar_line>
+        type=Boolean
+        description=Return the aligned sequence encoded in CIGAR format
+        default=1
+      </cigar_line>
     </params>
     <examples>
       <basic>
@@ -173,6 +178,11 @@
         description=The type of sequence to bring back. Setting it to none results in no sequence being returned
         default=protein
       </sequence>
+      <cigar_line>
+        type=Boolean
+        description=Return the aligned sequence encoded in CIGAR format
+        default=1
+      </cigar_line>
     </params>
     <examples>
       <basic>
@@ -250,6 +260,11 @@
         description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
         default=0
       </aligned>
+      <cigar_line>
+        type=Boolean
+        description=Return the aligned sequence encoded in CIGAR format
+        default=0
+      </cigar_line>
       <sequence>
         type=Enum(none, cdna, protein)
         description=The type of sequence to bring back. Setting it to none results in no sequence being returned
@@ -342,6 +357,11 @@
         description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
         default=0
       </aligned>
+      <cigar_line>
+        type=Boolean
+        description=Return the aligned sequence encoded in CIGAR format
+        default=0
+      </cigar_line>
       <sequence>
         type=Enum(none, cdna, protein)
         description=The type of sequence to bring back. Setting it to none results in no sequence being returned
@@ -412,6 +432,11 @@
         description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
         default=0
       </aligned>
+      <cigar_line>
+        type=Boolean
+        description=Return the aligned sequence encoded in CIGAR format
+        default=0
+      </cigar_line>
       <sequence>
         type=Enum(none, cdna, protein)
         description=The type of sequence to bring back. Setting it to none results in no sequence being returned


### PR DESCRIPTION
cf RT #475008

- New option in the gene-tree end-points to output the cigar-lines. Default is False to preserve the current behaviour
- New option in the homology end-points to output the cigar-lines. Default is True to preserve the current behaviour. I would personally prefer the default to be False but it would mean changing the major version number :/
