### PR TITLE
Correct summary_as_hash key

### DIFF
--- a/t/overlap.t
+++ b/t/overlap.t
@@ -201,7 +201,7 @@ my $base = '/overlap/region/homo_sapiens';
     consequence_type => 'intergenic_variant',
     feature_type => 'variation',
     seq_region_name => '6',
-    alt_alleles => [ qw/T -/]
+    alleles => [ qw/T -/]
   }, 'Checking one variation format');
   
   my $somatic_json = json_GET("$base/$region?feature=somatic_variation", 'Fetching somatic variations at '.$region);


### PR DESCRIPTION
The name give to the allele string in the VariationFeature summary_as_hash method is missleading, so has been updated. This updates the relevant REST test.