### PR TITLE
Enabling pre-load of the Registry

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -20,15 +20,15 @@ jsonp=1
   # user = anonymous
 
   host = ensembldb.ensembl.org
-  port = 5306
+  port = 3306
   user = anonymous
   
   # host = mysql.ebi.ac.uk
   # port = 4157
   # user = anonymous
  
-  version = 77
-  # verbose = 0
+  version = 82
+  verbose = 0
   
   ###### Registry file settings
   
@@ -67,6 +67,11 @@ jsonp=1
   # Set to control internal Ensembl API caching. Turn this off if your application is persistent (internal
   # caches are not shared, will rarely hit and increase your PSGI processes memory footprint)
   no_caching = 1
+
+  # Trigger a preload of the registry the moment the Model::Registry object is contrstructed. Otherwise we
+  # wait until the 1st request for an adaptor comes in. Use in conjunction with pre-fork PSGI deployments
+  # to stop registry reload issues
+  preload = 0
   
 </Model::Registry>
 

--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -68,6 +68,9 @@ has 'no_caching' => ( is => 'ro', isa => 'Bool' );
 has 'connection_sharing' => ( is => 'ro', isa => 'Bool' );
 has 'no_version_check' => ( is => 'ro', isa => 'Bool' );
 
+# Preload settings
+has 'preload' => ( is => 'ro', isa => 'Bool', default => 1 );
+
 has 'compara_cache' => ( is => 'ro', isa => 'HashRef[Str]', lazy => 1, default => sub { {} });
 
 has '_registry' => ( is => 'ro', lazy => 1, default => sub {
@@ -475,7 +478,19 @@ sub get_alias {
   return;
 }
 
-__PACKAGE__->meta->make_immutable;
+after 'BUILD' => sub {
+  my ($self) = @_;
+  if($self->preload()) {
+    my $log = $self->log();
+    $log->info('Triggering preload of the registry');
+    $self->_registry();
+    $self->_build_species_info();
+    $log->info('Done');
+  }
+  return;
+};
+
+__PACKAGE__->meta->make_immutable();
 
 1;
 


### PR DESCRIPTION
Object uses an after BUILD modifier to trigger the population of the
registry and associated lookups. Use with a pre-fork server to
avoid nasty running server process startup costs caused by reaping
processes.