### PR TITLE
use modifier to speed up LD calls

### DIFF
--- a/lib/EnsEMBL/REST/Model/LDFeatureContainer.pm
+++ b/lib/EnsEMBL/REST/Model/LDFeatureContainer.pm
@@ -83,14 +83,19 @@ sub to_array {
   my $d_prime = $c->request->param('d_prime');
   my $r2 = $c->request->param('r2');
   my @LDFC_array = ();
-  foreach my $ld_hash (@{$LDFC->get_all_ld_values()}) {
+
+  # we pass 1 to get_all_ld_values() so that it doesn't lazy load
+  # VariationFeature objects - we only need the name here anyway
+  foreach my $ld_hash (@{$LDFC->get_all_ld_values(1)}) {
     my $hash = {};
     $hash->{d_prime} = $ld_hash->{d_prime};
     next if ($d_prime && $hash->{d_prime} < $d_prime);
     $hash->{r2} = $ld_hash->{r2};
     next if ($r2 && $hash->{r2} < $r2);
-    $hash->{variation1} = $ld_hash->{variation1}->variation_name; 
-    $hash->{variation2} = $ld_hash->{variation2}->variation_name; 
+
+    # fallback for tests as travis uses the release branch
+    $hash->{variation1} = $ld_hash->{variation_name1} || $ld_hash->{variation1}->variation_name; 
+    $hash->{variation2} = $ld_hash->{variation_name2} || $ld_hash->{variation2}->variation_name; 
     my $population_id = $ld_hash->{population_id};
     my $population = $pa->fetch_by_dbID($population_id);
     $hash->{population_name} = $population->name;

--- a/t/ld.t
+++ b/t/ld.t
@@ -41,13 +41,6 @@ $expected_output =
   {
     'variation1' => 'rs1333047',
     'population_name' => '1000GENOMES:phase_1_ASW',
-    'r2' => '1.000000',
-    'variation2' => 'rs4977575',
-    'd_prime' => '1.000000'
-  },
-  {
-    'variation1' => 'rs1333047',
-    'population_name' => '1000GENOMES:phase_1_ASW',
     'r2' => '0.050071',
     'variation2' => 'rs1333049',
     'd_prime' => '0.999871'
@@ -58,7 +51,14 @@ $expected_output =
     'r2' => '0.063754',
     'variation2' => 'rs72655407',
     'd_prime' => '0.999996'
-  }
+  },
+  {
+    'variation1' => 'rs1333047',
+    'population_name' => '1000GENOMES:phase_1_ASW',
+    'r2' => '1.000000',
+    'variation2' => 'rs4977575',
+    'd_prime' => '1.000000'
+  },
 ];
 
 $ld_get = '/ld/homo_sapiens/rs1333047';


### PR DESCRIPTION
This modifier tells the variation API to not fetch VariationFeature objects, but rather rely on the position->ID mapping extracted from the VCF during genotype extraction. This should make these REST calls many times faster (5-8x faster in my tests).

It depends on a set of changes in ensembl-variation master for the speedup, but safely falls back to the old behaviour when using release/83.