### PR TITLE
move to Bio::DB::HTS module from faidx_xs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: "perl"
 
 perl:
   - "5.14"
-  
+
 sudo: false
-  
+
 addons:
   apt:
     packages:
@@ -35,13 +35,14 @@ before_install:
     - git clone --branch master --depth 1 https://github.com/samtools/htslib.git
     - cd htslib
     - make
+    - export HTSLIB_DIR=$(pwd -P)
     - cd ../
-    - git clone --branch master --depth 1 https://github.com/Ensembl/faidx_xs.git
-    - cd faidx_xs
-    - perl Makefile.PL
-    - make
-    - cp lib/Faidx.pm ..
-    - cp blib/arch/auto/Faidx/Faidx.so ..
+    - git clone --branch master --depth 1 https://github.com/Ensembl/Bio-HTS
+    - cd Bio-HTS
+    - perl Build.PL --htslib $HTSLIB_DIR
+    - ./Build
+    - cp blib/arch/auto/Bio/DB/HTS/Faidx/Faidx.so ..
+    - cp blib/arch/auto/Bio/DB/HTS/HTS.so ..
     - cd ../
 
 install:

--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -21,7 +21,7 @@ use Moose;
 use Bio::EnsEMBL::Variation::VariationFeature;
 use namespace::autoclean;
 use Data::Dumper;
-use Faidx;
+use Bio::DB::HTS::Faidx;
 use Bio::EnsEMBL::Variation::Utils::VEP qw(get_all_consequences parse_line validate_vf read_cache_info @REG_FEAT_TYPES);
 use Bio::EnsEMBL::Slice;
 use Bio::EnsEMBL::Utils::Sequence qw(reverse_comp);
@@ -39,7 +39,7 @@ BEGIN {
 }
 
 has 'fasta_db' => (
-  isa => 'Faidx',
+  isa => 'Bio::DB::HTS::Faidx',
   is => 'ro',
   lazy => 1,
   builder => '_find_fasta_cache',
@@ -161,7 +161,7 @@ sub _give_POST_to_VEP {
     # Overwrite Slice->seq method to use a local disk cache when using Human
     my $consequences;
     if ($c->stash->{species} eq 'homo_sapiens' && defined($config->{fasta})) {
-      $c->log->debug('Farming human out to Faidx');
+      $c->log->debug('Farming human out to Bio::DB::HTS::Faidx');
       no warnings 'redefine';
       local *Bio::EnsEMBL::Slice::seq = $self->_new_slice_seq();
       $consequences = $self->get_consequences($c, $config, \@vfs);
@@ -414,7 +414,7 @@ sub _build_vf {
 sub _find_fasta_cache {
   my $self = shift;
   
-  my $fasta_db = Faidx->new($self->fasta);
+  my $fasta_db = Bio::DB::HTS::Faidx->new($self->fasta);
   
   return $fasta_db;
 }

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/ensembl-compara/modules:$PWD/ensembl-variation/modules:$PWD/ensembl-funcgen/modules:$PWD/ensembl-io/modules:$PWD/lib
+export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/ensembl-compara/modules:$PWD/ensembl-variation/modules:$PWD/ensembl-funcgen/modules:$PWD/ensembl-io/modules:$PWD/lib:$PWD/Bio-HTS/lib
 
 export PATH=$PATH:$PWD/tabix:$PWD/ensembl-variation/C_code
 export SKIP_TESTS=""


### PR DESCRIPTION
Changes have been made to the VEP to use Faidx (FASTA indexing from HTSlib) from Bio::DB::HTS rather than its own module. These changes are to accompany this.

Relevant pull requests are:
https://github.com/Ensembl/ensembl-variation/pull/25
https://github.com/Ensembl/ensembl-tools/pull/12