### PR TITLE
Tidy of TravisCI tests Bio::DB::HTS setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,6 @@ before_install:
     - cd Bio-HTS
     - perl Build.PL --htslib $HTSLIB_DIR
     - ./Build
-    - cp blib/arch/auto/Bio/DB/HTS/Faidx/Faidx.so ..
-    - cp blib/arch/auto/Bio/DB/HTS/HTS.so ..
     - cd ../
 
 install:

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/ensembl-compara/modules:$PWD/ensembl-variation/modules:$PWD/ensembl-funcgen/modules:$PWD/ensembl-io/modules:$PWD/lib:$PWD/Bio-HTS/lib
+export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/ensembl-compara/modules:$PWD/ensembl-variation/modules:$PWD/ensembl-funcgen/modules:$PWD/ensembl-io/modules:$PWD/lib:$PWD/Bio-HTS/lib:$PWD/blib/arch/auto
 
 export PATH=$PATH:$PWD/tabix:$PWD/ensembl-variation/C_code
 export SKIP_TESTS=""

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/ensembl-compara/modules:$PWD/ensembl-variation/modules:$PWD/ensembl-funcgen/modules:$PWD/ensembl-io/modules:$PWD/lib:$PWD/Bio-HTS/lib:$PWD/blib/arch/auto/Bio/DB/HTS/Faidx:$PWD/blib/arch/auto/Bio/DB/HTS
+export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/ensembl-compara/modules:$PWD/ensembl-variation/modules:$PWD/ensembl-funcgen/modules:$PWD/ensembl-io/modules:$PWD/lib:$PWD/Bio-HTS/lib:$PWD/Bio-HTS/blib
 
 export PATH=$PATH:$PWD/tabix:$PWD/ensembl-variation/C_code
 export SKIP_TESTS=""

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/ensembl-compara/modules:$PWD/ensembl-variation/modules:$PWD/ensembl-funcgen/modules:$PWD/ensembl-io/modules:$PWD/lib:$PWD/Bio-HTS/lib:$PWD/blib/arch/auto
+export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/ensembl-compara/modules:$PWD/ensembl-variation/modules:$PWD/ensembl-funcgen/modules:$PWD/ensembl-io/modules:$PWD/lib:$PWD/Bio-HTS/lib:$PWD/blib/arch/auto/Bio/DB/HTS/Faidx:$PWD/blib/arch/auto/Bio/DB/HTS
 
 export PATH=$PATH:$PWD/tabix:$PWD/ensembl-variation/C_code
 export SKIP_TESTS=""

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/ensembl-compara/modules:$PWD/ensembl-variation/modules:$PWD/ensembl-funcgen/modules:$PWD/ensembl-io/modules:$PWD/lib:$PWD/Bio-HTS/lib:$PWD/Bio-HTS/blib
+export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/ensembl-compara/modules:$PWD/ensembl-variation/modules:$PWD/ensembl-funcgen/modules:$PWD/ensembl-io/modules:$PWD/lib:$PWD/Bio-HTS/lib:$PWD/Bio-HTS/blib/arch/auto/Bio/DB/HTS/Faidx:$PWD/Bio-HTS/blib/arch/auto/Bio/DB/HTS
 
 export PATH=$PATH:$PWD/tabix:$PWD/ensembl-variation/C_code
 export SKIP_TESTS=""


### PR DESCRIPTION
Shared object files no longer copied, PERL5LIB used to locate instead.