### PR TITLE
Copy a default configuration file on build step

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,6 +7,14 @@ use Module::Install::Catalyst; # Complain loudly if you don't have
                                # 'make dist' to create a standalone tarball.
 use Cwd            ();
 use File::Basename ();
+use File::Copy;
+
+my $default_config = File::Basename::dirname( Cwd::realpath($0) ).'/ensembl_rest.conf.default';
+if (-f $default_config) {
+	my $new_config = File::Basename::dirname( Cwd::realpath($0) ).'/ensembl_rest.conf';
+	copy($default_config, $new_config);
+}
+
 my $cpanfile_path = File::Basename::dirname( Cwd::realpath($0) ).'/cpanfile';
 do $cpanfile_path;
 


### PR DESCRIPTION
Affected from 'release/82' branch.

I tried to run on my VM side
vagrant@precise64:~/src/ensembl-rest$ perl script/ensembl_rest_server.pl
(over plack and other ways to run application I got the same result)

You must configure a default store type unless you use exactly one store plugin. at /usr/local/share/perl/5.14.2/Catalyst/Plugin/ConfigLoader.pm line 101.
Compilation failed in require at /usr/local/share/perl/5.14.2/Catalyst/ScriptRunner.pm line 50.

Looks like, application can't find a correct configuration file.
It's caused after using a default configuration file  'ensembl_rest.conf.default' instead of 'ensembl_rest.conf'.

If user want to solve such issue user should create an own configuration file.
I suggest to copy a default configuration file into correct one on build step(Or maybe make sense to improve documentation).
