### PR TITLE
correct error in GA4GH docs

### DIFF
--- a/root/documentation/gacallset.conf
+++ b/root/documentation/gacallset.conf
@@ -32,12 +32,12 @@
     group=Variation GA4GH
     output=json
     <params>
-      <variantSetIds>
+      <variantSetId>
         type=String
-        description=Return callSets for specific variant sets
+        description=Return callSets for a specific variant set
         example=__VAR(GA4GH_variantSetId)__
         required=1
-      </variantSetIds>
+      </variantSetId>
       <name>
         type=String
         description=Return callSets by name  


### PR DESCRIPTION
Search by multiple VariantSetIds removed in v0.6.0a1 but docs not fully updated.