### PR TITLE
Compara performance improvements

### DIFF
--- a/lib/EnsEMBL/REST/Controller/GeneTree.pm
+++ b/lib/EnsEMBL/REST/Controller/GeneTree.pm
@@ -101,6 +101,7 @@ sub _set_genetree {
 
   my $prune_species     = $c->request->param('prune_species') ? [$c->request->param('prune_species')] : undef;
   my $prune_taxons      = $c->request->param('prune_taxon') ? [$c->request->param('prune_taxon')] : undef;
+  my ($subtree_filter)  = $c->request->param('subtree_node_id');
   my $aligned           = $c->request()->param('aligned') || $c->request()->param('phyloxml_aligned') ? 1 : 0;
   my $sequence          = $c->request()->param('sequence') || $c->request()->param('phyloxml_sequence') || 'protein';
   my $cigar_line        = $c->request()->param('cigar_line') ? 1 : 0;
@@ -110,6 +111,7 @@ sub _set_genetree {
   $gt->preload(
       -PRUNE_SPECIES => $prune_species,
       -PRUNE_TAXA => $prune_taxons,
+      -PRUNE_SUBTREE => $subtree_filter,
   );
 
   if($self->is_content_type($c, $CONTENT_TYPE_REGEX)) {

--- a/lib/EnsEMBL/REST/Controller/GeneTree.pm
+++ b/lib/EnsEMBL/REST/Controller/GeneTree.pm
@@ -118,6 +118,7 @@ sub _set_genetree {
     # If it wasn't a special format convert GT into a Hash data structure and let the normal serialisation
     # code deal with it.
     my $hash = Bio::EnsEMBL::Compara::Utils::GeneTreeHash->convert ($gt, -no_sequences => $no_sequences, -aligned => $aligned, -cdna => $cdna, -species_common_name => 0, -exon_boundaries => 0, -gaps => 0, -full_tax_info => 0, -cigar_line => $cigar_line);
+    $gt->release_tree();
     return $self->status_ok($c, entity => $hash);
   }
   return $self->status_ok($c, entity => $gt);

--- a/lib/EnsEMBL/REST/Controller/Homology.pm
+++ b/lib/EnsEMBL/REST/Controller/Homology.pm
@@ -20,6 +20,8 @@ package EnsEMBL::REST::Controller::Homology;
 use Moose;
 use namespace::autoclean;
 use Try::Tiny;
+use Bio::EnsEMBL::Compara::Utils::HomologyHash;
+
 require EnsEMBL::REST;
 
 EnsEMBL::REST->turn_on_config_serialisers(__PACKAGE__);
@@ -37,7 +39,7 @@ __PACKAGE__->config(
 my $CONTENT_TYPE_REGEX = qr/(?^:(?:text\/(?:javascript|xml)|application\/json))/;
 
 
-my $FORMAT_LOOKUP = { full => '_full_encoding', condensed => '_condensed_encoding' };
+my $FORMAT_LOOKUP = { full => 1, condensed => 1 };
 my $TYPE_TO_COMPARA_TYPE = { orthologues => 'ENSEMBL_ORTHOLOGUES', paralogues => 'ENSEMBL_PARALOGUES', projections => 'ENSEMBL_PROJECTIONS', all => ''};
 
 has default_compara => ( is => 'ro', isa => 'Str', default => 'multi' );
@@ -49,24 +51,11 @@ sub get_adaptors :Private {
     my $species = $c->stash()->{species};
     my $compara_dba = $c->model('Registry')->get_best_compara_DBAdaptor($species, $c->request()->param('compara'), $self->default_compara());
     my $gma = $compara_dba->get_GeneMemberAdaptor();
-    my $sma = $compara_dba->get_SeqMemberAdaptor();
     my $ha = $compara_dba->get_HomologyAdaptor();
-    my $mlssa = $compara_dba->get_MethodLinkSpeciesSetAdaptor();
-    my $ma = $compara_dba->get_MethodAdaptor();
-    my $gdba = $compara_dba->get_GenomeDBAdaptor();
-    my $asa = $compara_dba->get_AlignSliceAdaptor();
-    my $gata = $compara_dba->get_GenomicAlignTreeAdaptor();
-    my $gaba = $compara_dba->get_GenomicAlignBlockAdaptor();
     
     $c->stash(
       gene_member_adaptor => $gma,
       homology_adaptor => $ha,
-      method_link_species_set_adaptor => $mlssa,
-      genome_db_adaptor => $gdba,
-      align_slice_adaptor => $asa,
-      genomic_align_tree_adaptor => $gata,
-      genomic_align_block_adaptor => $gaba,
-      method_adaptor => $ma,
     );
   } catch {
     $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;
@@ -165,86 +154,19 @@ sub get_orthologs : Args(0) ActionClass('REST') {
   $c->stash(homology_data => \@final_homologies);
 }
 
-sub _full_encoding {
-  my ($self, $c, $homologies, $stable_id) = @_;
-  my @output;
-  
-  my $sequence_param = $c->request->param('sequence') || 'protein';
-  my $seq_type = $sequence_param eq 'protein' ? undef : 'cds';
-  my $aligned = $c->request->param('aligned');
-  $aligned = 1 unless defined $aligned;
-  my $cigar_line = $c->request->param('cigar_line');
-  $cigar_line = 1 unless defined $cigar_line;
-  
-  my $encode = sub {
-    my ($member) = @_;
-    my $gene = $member->gene_member();
-    my $genome_db = $gene->genome_db();
-    my $taxon_id = $genome_db->taxon_id();
-    my $result = {
-      id => $gene->stable_id(),
-      species => $genome_db->name(),
-      perc_id => ($member->perc_id()*1),
-      perc_pos => ($member->perc_pos()*1),
-      protein_id => $member->stable_id(),
-    };
-    $result->{cigar_line} = $member->cigar_line() if $cigar_line;
-    $result->{taxon_id} = ($taxon_id+0) if defined $taxon_id;
-    if($aligned && $member->cigar_line()) {
-      $result->{align_seq} = $member->alignment_string($seq_type);
-    }
-    else {
-      $result->{seq} = $member->other_sequence($seq_type);
-    }
-    return $result;
-  };
-  
-  Bio::EnsEMBL::Compara::MemberSet->_load_all_missing_sequences($seq_type, @{$homologies});
-  while(my $h = shift @{$homologies}) {
-    my ($src, $trg) = @{ $h->get_all_Members() };
-    my $e = {
-      type => $h->description(),
-      taxonomy_level => $h->taxonomy_level(),
-      dn_ds => $h->dnds_ratio(),
-      source => $encode->($src),
-      target => $encode->($trg),
-      method_link_type => $h->method_link_species_set()->method()->type(),
-    };
-    $e->{dn_ds} = $e->{dn_ds}*1 if defined $e->{dn_ds};
-    push(@output, $e);
-  }
-  return \@output;
-}
-
-sub _condensed_encoding {
-  my ($self, $c, $homologies, $stable_id) = @_;
-  $c->log()->debug('Starting condensed encoding');
-  my @output;
-  while(my $h = shift @{$homologies}) {
-    my ($src, $trg) = @{ $h->get_all_Members() };
-    my $gene_member = $trg->gene_member();
-    my $e = {
-      type => $h->description(),
-      taxonomy_level => $h->taxonomy_level(),
-      id => $gene_member->stable_id(),
-      protein_id => $trg->stable_id(),
-      species => $gene_member->genome_db->name(),
-      method_link_type => $h->method_link_species_set()->method()->type(),
-    };
-    push(@output, $e);
-  }
-  $c->log()->debug('Finished condensed encoding');
-  return \@output;
-}
 
 sub get_orthologs_GET {
   my ( $self, $c ) = @_;
 
   if($self->is_content_type($c, $CONTENT_TYPE_REGEX)) {
-    my $format = $c->request->param('format') || 'full';
-    my $target = $FORMAT_LOOKUP->{$format};
+    my $format          = $c->request->param('format') || 'full';
+    my $sequence_param  = $c->request->param('sequence') || 'protein';
+    my $seq_type        = $sequence_param eq 'protein' ? undef : 'cds';
+    my $aligned         = $c->request->param('aligned') // 1;
+    my $cigar_line      = $c->request->param('cigar_line') // 1;
+
     foreach my $ref (@{$c->stash->{homology_data}}) {
-        $ref->{homologies} = $self->$target($c, $ref->{homologies}, $ref->{id});
+        $ref->{homologies} = Bio::EnsEMBL::Compara::Utils::HomologyHash->convert($ref->{homologies}, -FORMAT_PRESET => $format, -SEQ_TYPE => $seq_type, -ALIGNED => $aligned, -CIGAR_LINE => $cigar_line);
     }
     return $self->status_ok( $c, entity => { data => $c->stash->{homology_data} } );
 

--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -485,6 +485,7 @@ after 'BUILD' => sub {
     $log->info('Triggering preload of the registry');
     $self->_registry();
     $self->_build_species_info();
+    $_->get_MethodLinkSpeciesSetAdaptor()->fetch_all() for @{ $self->get_all_DBAdaptors('compara') };
     $log->info('Done');
   }
   return;

--- a/lib/EnsEMBL/REST/Role/Tree.pm
+++ b/lib/EnsEMBL/REST/Role/Tree.pm
@@ -111,7 +111,11 @@ sub encode_nh {
   my $nh_format = $c->request->param('nh_format') || 'simple';
   my $root = $gt->root();
   my $str = $root->newick_format($nh_format);
-  $root->release_tree() if ($root->can('release_tree'));
+  if ($gt->can('release_tree')) {
+    $gt->release_tree();
+  } elsif ($root->can('release_tree')) {
+    $root->release_tree();
+  }
   return \$str;
 }
 

--- a/lib/EnsEMBL/REST/Role/Tree.pm
+++ b/lib/EnsEMBL/REST/Role/Tree.pm
@@ -69,7 +69,6 @@ sub encode_phyloxml {
     }
   } elsif ($c->namespace eq 'genetree') {
     #gene tree
-    $trees->preload();
     push @$roots, $trees;
   }
   $w->write_trees($roots);
@@ -98,8 +97,6 @@ sub encode_orthoxml {
   );
 
   my $tree = $c->stash->{$stash_key};
-  $tree->preload();
-
   $w->write_trees($tree);
   $w->finish();
 
@@ -112,7 +109,6 @@ sub encode_nh {
   $stash_key ||= 'rest';
   my $gt = $c->stash->{$stash_key};
   my $nh_format = $c->request->param('nh_format') || 'simple';
-  $gt->preload() if ($gt->can('preload'));
   my $root = $gt->root();
   my $str = $root->newick_format($nh_format);
   $root->release_tree() if ($root->can('release_tree'));


### PR DESCRIPTION
There are three categories of improvements:

1) Number of queries. I have added several helper methods in the Compara API that call `fetch_all_by_dbID_list()`. This is as you imagine much faster than calling `fetch_by_dbID()` repeatedly (PhyloXML export of a big tree down from 30 sec to 6 sec) and the helper methods are automatically called whenever needed in the Compara API. That's why I could remove a number a `preload()` call from ensembl-rest. Another consequence is that it now takes a constant number of queries to fetch the data for the gene-tree endpoints (used to depend on the number of taxa and chromosomes) and the homology endpoints (regardless of the number of actual homologies). This is essentially all done automatically in the Compara API

2) Memory leaks. I've simply called each endpoint 1000 times and found a number of places where the gene-trees were not released (they are circular dependencies in this part of the Compara API)

3) Automatic population of the Compara's FullCache adaptors in the Registry preload() method

Other changes:
1) I have moved some code to the Compara API, so that it can be used outside of the REST context.
2) I have added a "subtree_node_id" parameter to the gene-tree endpoints. This is needed by a new web view that shows the tree+multiple alignment of a subtree

There are no format changes, so no version upgrade to request