### PR TITLE
Docs change - filter GA4GH variant calls returned

### DIFF
--- a/root/documentation/gavariant.conf
+++ b/root/documentation/gavariant.conf
@@ -42,7 +42,7 @@
       <callSetIds>
         type=String
         description= Return variant data for specific callSets
-        example=__VAR(GA4GH_callSetId)__
+        example=[ __VAR(GA4GH_callSetId)__ ]
         required=0
       </callSetIds>
       <referenceName>
@@ -80,7 +80,7 @@
         path=/ga4gh/variants/search
         accept=application/json
         content=application/json
-        body={ "variantSetId": __VAR(GA4GH_variantSetId)__, "referenceName": 22,"start": 17190024 ,"end":  17671934 ,  "pageToken":"", "pageSize": 1 }
+        body={ "variantSetId": __VAR(GA4GH_variantSetId)__, "callSetIds":[ "__VAR(GA4GH_callSetId)__"  , "__VAR(GA4GH_callSetId2)__" , "__VAR(GA4GH_callSetId3)__"   ], "referenceName": 22,"start": 17190024 ,"end":  17671934 ,  "pageToken":"", "pageSize": 3 }
       </basic>
     </examples>
 


### PR DESCRIPTION
Use 3 samples to filter 1KG genotypes for quicker rendering.

Requires: https://github.com/Ensembl/ensembl-rest_private/pull/11