### PR TITLE
 Encode error text at HTML so it doesn't integrate into the DOM

### DIFF
--- a/root/documentation/info.tt
+++ b/root/documentation/info.tt
@@ -178,7 +178,8 @@ limitations under the License.
       }
       },
       error : function (resp, msg) {
-         $("#example[% p.value.id %]").append("<pre id=\"pre[% p.value.id %]\">" + resp.responseText + "</pre>");
+         $("#example[% p.value.id %]").append("<pre id=\"pre[% p.value.id %]\"></pre>");
+         $("#pre[% p.value.id %]").text(resp.responseText);
          $("#example[% p.value.id %]>img").remove();
       }
       };


### PR DESCRIPTION
Currently an error in the endpoint's response will integrate into the page's DOM (creating this odd looking header section).  This commit encodes the response as HTML elements, so it appears in the example output box as HTML code.
![screen shot 2016-11-01 at 13 42 23](https://cloud.githubusercontent.com/assets/6329861/19892208/bb927d2a-a03b-11e6-8bc9-7ba2fe91694e.png)
