### PR TITLE
Escape space characters in the URLs for example requests

### DIFF
--- a/root/documentation/examples/curl.tt
+++ b/root/documentation/examples/curl.tt
@@ -18,10 +18,10 @@ limitations under the License.
 <div class='tab-pane' id='curl[% p.value.id %]'>
 <pre class="pre-scrollable prettyprint linenums">[% FILTER html %]
 [% IF p.value.body -%]
-curl '[% p.value.example.host %][% p.value.uri %]' -H 'Content-type:[% p.value.content %]' \
+curl '[% p.value.example.host %][% p.value.uri | url %]' -H 'Content-type:[% p.value.content %]' \
 -H 'Accept:[% p.value.accept %]' -X POST -d '[% p.value.body %]'
 [% ELSE %]
-curl '[% p.value.example.host %][% p.value.uri %]' -H 'Content-type:[% p.value.content %]'
+curl '[% p.value.example.host %][% p.value.uri | url %]' -H 'Content-type:[% p.value.content %]'
 [% END %]
 [% END -%]
 </pre>

--- a/root/documentation/examples/java.tt
+++ b/root/documentation/examples/java.tt
@@ -33,7 +33,7 @@ public class EnsemblRest {
 
   public static void main(String[] args) throws Exception {
     String server = "[% p.value.example.host %]";
-    String ext = "[% p.value.uri %]";
+    String ext = "[% p.value.uri | url %]";
     URL url = new URL(server + ext);
 
     URLConnection connection = url.openConnection();

--- a/root/documentation/examples/perl.tt
+++ b/root/documentation/examples/perl.tt
@@ -26,7 +26,7 @@ my $http = HTTP::Tiny->new();
 
 my $server = '[% p.value.example.host %]';
 [% IF p.value.body -%]
-my $ext = '[% p.value.uri %]';
+my $ext = '[% p.value.uri | url %]';
 my $response = $http->request('POST', $server.$ext, {
   headers => { 
   	'Content-type' => '[% p.value.content %]',
@@ -35,7 +35,7 @@ my $response = $http->request('POST', $server.$ext, {
   content => '[% p.value.body %]'
 });
 [% ELSE -%]
-my $ext = '[% p.value.uri %]';
+my $ext = '[% p.value.uri | url %]';
 my $response = $http->get($server.$ext, {
   headers => { 'Content-type' => '[% p.value.content %]' }
 });

--- a/root/documentation/examples/ruby.tt
+++ b/root/documentation/examples/ruby.tt
@@ -21,7 +21,7 @@ require 'net/http'
 require 'uri'
 
 server='[% p.value.example.host %]'
-path = '[% p.value.uri %]'
+path = '[% p.value.uri | url %]'
 
 url = URI.parse(server)
 http = Net::HTTP.new(url.host, url.port)


### PR DESCRIPTION
For some endpoints species alias that contains space charactter could
appear in the URI path. In some languages and tools, URLs are not
automatically encoded. The space characters in the URLs cause failure
in the requests.

This change escapes space characters in the URLs for the example requests
for Curl, Java, Perl and Ruby, according to this document:
http://template-toolkit.org/docs/manual/Filters.html#section_url

Fixes ENSEMBL-4809.