### PR TITLE
Path to HAL files

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -220,6 +220,8 @@ jsonp=1
 <Controller::GenomicAlignment>
   # Sets the default compara to use when finding the best compara fails. Defaults to multi
   # default_compara=multi
+  # Sets the base location of data-files (usually contains multi/hal_files/*.hal)
+  # compara_base_dir_location = /path/to/data/
 </Controller::GenomicAlignment>
 
 <Controller::Variaton>

--- a/lib/EnsEMBL/REST/Controller/GenomicAlignment.pm
+++ b/lib/EnsEMBL/REST/Controller/GenomicAlignment.pm
@@ -26,6 +26,7 @@ require EnsEMBL::REST;
 BEGIN { extends 'Catalyst::Controller::REST'; }
 
 has 'default_compara' => ( is => 'ro', isa => 'Str', default => 'multi' );
+has 'compara_base_dir_location' => ( is => 'ro', isa => 'Str' );
 has 'max_slice_length' => ( isa => 'Num', is => 'ro', default => 1e6);
 
 __PACKAGE__->config(
@@ -56,6 +57,8 @@ sub get_adaptors :Private {
     my $asa = $compara_dba->get_AlignSliceAdaptor();
     my $gata = $compara_dba->get_GenomicAlignTreeAdaptor();
     my $gaba = $compara_dba->get_GenomicAlignBlockAdaptor();
+
+    $mlssa->base_dir_location($self->compara_base_dir_location());
     
     $c->stash(
       compara_dba => $compara_dba,


### PR DESCRIPTION
Hi guys, and happy new year !

During e87 @lairdm told me that we're not configuring the path to access HAL files is not great at all (it's a euphemism). I think it's hard-coded at the moment. Instead, the path should be configured in the main configuration file, and the endpoint should tell the API "This is where you'll find the data".

Here I'm adding a parameter to to the configuration file and pass it to the Compara API (there is a matching change on our side).
I'd still like to keep the same directory structure as on the web server, which is /DATA/PATH/multi/hal_files/*.hal (/DATA/PATH is the bit that's changed in ensembl_rest.conf). Would that fit you ?
If that's OK, then you would just have to rsync Web's /DATA/PATH/multi/ with yours and all the file-based data would work on both sides.

Matthieu

PS: Web directory structure 
```
├── anolis_carolinensis
│   └── AnoCar2.0
│       └── rnaseq
├── astyanax_mexicanus
│   └── AstMex102
│       └── rnaseq
...
├── homo_sapiens
│   ├── GRCh37
│   │   ├── compara
│   │   ├── dna_methylation_feature
│   │   ├── result_feature
│   │   ├── result_set
│   │   ├── rnaseq
│   │   ├── segmentation_file
│   │   └── variation_genotype
│   └── GRCh38
│       ├── compara
│       ├── dna_methylation_feature
│       ├── external_feature_file
│       ├── result_feature
│       ├── result_set
│       ├── rnaseq
│       ├── segmentation_file
│       └── variation_genotype
...
├── multi
│   └── hal_files (only contains murinae_genbank_835.hal at the moment)
...
```