### PR TITLE
fixed example's input errors in documentation file

### DIFF
--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -389,7 +389,8 @@
     <examples>
       <json>
         path=/family/member/symbol/
-        capture=__VAR(gene_stable_id)__
+        capture=__VAR(species)__
+        capture=__VAR(gene_symbol)__
         content=application/json
       </json>
     </examples>
@@ -871,7 +872,7 @@
     <examples>
       <nh>
         path=/cafe/genetree/member/id/
-        capture=__VAR(genetree_stable_id)__
+        capture=__VAR(gene_stable_id)__
         content=text/x-nh
         <params>
           nh_format=simple
@@ -937,7 +938,8 @@
     <examples>
       <nh>
         path=/cafe/genetree/member/symbol/
-        capture=__VAR(genetree_stable_id)__
+        capture=__VAR(species)__
+        capture=__VAR(gene_symbol)__
         content=text/x-nh
         <params>
           nh_format=simple
@@ -945,7 +947,8 @@
       </nh>
       <json>
         path=/cafe/genetree/member/symbol/
-        capture=__VAR(gene_stable_id)__
+        capture=__VAR(species)__
+        capture=__VAR(gene_symbol)__
         content=application/json
       </json>
     </examples>


### PR DESCRIPTION
This was causing the examples on my test rest server to failed. The input parameters were clearly wrong so all the issues with the last pull request must have led to an untested version of the documentation file being pushed.  

All appear to be fixed now.