### PR TITLE
Add searching compara dbs for a gene id at homology endpoint

### DIFF
--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -268,11 +268,15 @@ sub _build_lookup {
 sub get_best_compara_DBAdaptor {
   my ($self, $species, $request_compara_name, $default_compara) = @_;
   $default_compara = 'multi' if ! defined $default_compara;
-  my $compara_name = $request_compara_name || $self->get_compara_name_for_species($species);
-  if(!$compara_name) {
-    throw "Cannot find a suitable compara database for the species $species. Try specifying a compara parameter";
+
+  my $compara_name = $request_compara_name || ($species ? $self->get_compara_name_for_species($species) : undef);
+  my $dba;
+  if ( $compara_name ) {
+    $dba = $self->get_DBAdaptor($compara_name, 'compara', 'no alias check');
+    if ( !$dba ) {
+      throw "Cannot find a suitable compara database for the species $species. Try specifying a compara parameter";
+    }
   }
-  my $dba = $self->get_DBAdaptor($compara_name, 'compara', 'no alias check');
 
   # If the compara name we used was not the same then we've got another bite at the cherry
   if(! $dba && $compara_name ne $default_compara) {


### PR DESCRIPTION
In EnsemblGenomes we have vertebrate gene ids stored in compara pan homology
database. These ids are not loaded into stable_id_lookup database. When a user
wants to fetch homologues through a vertebrate gene id, it returns error because
the id is not found in stable_id_lookup database.

This change allows searching compara dbs at homology endpoint so that when a
vertebrate gene id is not found in the stable_id_lookup database, we continue to
search for it in compara dbs, so that the id could be used to fetch homologues
through EnsemblGenomes's rest endpoint.

Related to ENSEMBL-5061.