### PR TITLE
Correct typo in ld_pairwise_get endpoint value

### DIFF
--- a/root/documentation/ld.conf
+++ b/root/documentation/ld.conf
@@ -145,7 +145,7 @@
   </ld_region_get>
   <ld_pairwise_get>
     description=Computes and returns LD values between the given variants.    
-    endpoint=ld/:species/pairwise/:id1:/id2
+    endpoint=ld/:species/pairwise/:id1/:id2
     method=GET
     group=Linkage Disequilibrium
     output=json


### PR DESCRIPTION
The endpoint desc had :/ instead of /: