### PR TITLE
Probe/Probeset fixes

### DIFF
--- a/lib/EnsEMBL/REST/Controller/Regulatory.pm
+++ b/lib/EnsEMBL/REST/Controller/Regulatory.pm
@@ -165,9 +165,9 @@ sub microarray_probe_GET {
 
 
 
-# /regulatory/species/:species/microarray/:microarray/probe_set/:probe_set/probe/:probe 
+# /regulatory/species/:species/microarray/:microarray/probe_set/:probe_set 
 # /regulatory/species/homo_sapiens/microarray/HC-G110/vendor/affy/
-sub microarray_probe_set: Chained('microarray') PathPart('probe_set') CaptureArgs(1) ActionClass('REST') { 
+sub microarray_probe_set: Chained('microarray') PathPart('probe_set') Args(1) ActionClass('REST') { 
   my ($self, $c, $probe_set) = @_;
   if(! defined $probe_set){
     $c->go('ReturnError', 'custom', [qq{ProbeSet name must be provided as part of the URL.}]);
@@ -175,30 +175,17 @@ sub microarray_probe_set: Chained('microarray') PathPart('probe_set') CaptureArg
 }
 
 sub microarray_probe_set_GET {
-  my ($self, $c, $probe_set) = @_;
-  $c->stash(probe_set => $probe_set); 
-}
+  my ($self, $c, $probeset) = @_;
 
-# /regulatory/species/:species/microarray/:microarray/probe_set/:probe_set/probe/:probe 
-# /regulatory/species/homo_sapiens/microarray/HG-U133_Plus_2/probe_set/202820_at/probe/1129:545;
-sub microarray_probe_set_probe: Chained('microarray_probe_set') PathPart('probe') Args(1) ActionClass('REST') { 
-  my ($self, $c, $probe) = @_;
-  if(! defined $probe){
-    $c->go('ReturnError', 'custom', [qq{Probe name must be provided as part of the URL.}]);
-  } 
-}
-sub microarray_probe_set_probe_GET {
-  my ($self, $c, $probe) = @_;
-
-  my $probe_info;
+  my $probeset_info;
   try {
-    $probe_info = $c->model('Regulatory')->get_probe_info($probe, $c->stash->{probe_set});
+    $probeset_info = $c->model('Regulatory')->get_probeset_info($probeset);
   }catch {
     $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;
     $c->go('ReturnError', 'custom', [qq{$_}]);
   };
 
-  $self->status_ok($c, entity => $probe_info);
+  $self->status_ok($c, entity => $probeset_info);
 }
 
 

--- a/root/documentation/regulatory.conf
+++ b/root/documentation/regulatory.conf
@@ -86,7 +86,7 @@
       </basic>
     </examples>
   </list_all_microarrays>
-  <array_info>
+  <array>
    description=Returns information about a specific microarray
    endpoint=regulatory/species/:species/microarray/:microarray/vendor/:vendor
    method=GET
@@ -124,9 +124,9 @@
         content=application/json
       </basic>
     </examples>
-  </array_info>
-  <probe_info>
-   description=Returns information about a specific probe of a microarray
+  </array>
+  <probe>
+   description=Returns information about a specific probe from a microarray
    endpoint=regulatory/species/:species/microarray/:microarray/probe/:probe
    method=GET
    group=Regulation
@@ -177,10 +177,10 @@
         </params>
       </basic>
     </examples>
-  </probe_info>
-  <probeset_info>
-   description=Returns information about a specific probe of a probe_set from a microarray
-   endpoint=regulatory/species/:species/microarray/:microarray/probe_set/:probe_set/probe/:probe
+  </probe>
+  <probe_set>
+   description=Returns information about a specific probe_set from a microarray
+   endpoint=regulatory/species/:species/microarray/:microarray/probe_set/:probe_set
    method=GET
    group=Regulation
    output=json
@@ -200,16 +200,10 @@
      </microarray>
      <probe_set>
        type=String
-       description=Probe-Set name
+       description=ProbeSet name
        example=202820_at
        required=1
      </probe_set>
-     <probe>
-       type=String
-       description=Probe name
-       example=1129:545;
-       required=1
-     </probe>
      <transcripts>
        type=Boolean(0,1)
        description=Displays the transcripts linked to this probe
@@ -229,8 +223,6 @@
         capture=HG-U133_Plus_2
         capture=probe_set
         capture=202820_at
-        capture=probe
-        capture=1129:545;
         content=application/json
         <params>
           transcript=1
@@ -238,5 +230,5 @@
         </params>
       </basic>
     </examples>
-  </probeset_info>
+  </probeset>
 </endpoints>

--- a/t/regulatory.t
+++ b/t/regulatory.t
@@ -90,7 +90,7 @@ $json = json_GET($microarray_probe,'GET Information about a specific probe');
 eq_or_diff($json, $output, 'GET Information about a specific probe');
 
 
-# regulatory/species/:species/microarray/:microarray/probe_set/:probe_set/probe/:probe
+# regulatory/species/:species/microarray/:microarray/probe_set/:probe_set
 my $microarray_probe_set = '/regulatory/species/homo_sapiens/microarray/HC-G110/probe_set/1000_at?content-type=application/json';
 $output =  {
   microarray => 'HC-G110',
@@ -100,8 +100,8 @@ $output =  {
     ],                                  
   size => 16                          
   } ;
-$json = json_GET($microarray_probe_set,'JSON: GET Information about a specific probe');
-eq_or_diff($json, $output, 'GET Information about a specific probes_set_');
+$json = json_GET($microarray_probe_set,'JSON: GET Information about a specific probe_set');
+eq_or_diff($json, $output, 'GET Information about a specific probes_set');
 
 done_testing();
 

--- a/t/regulatory.t
+++ b/t/regulatory.t
@@ -81,9 +81,9 @@ eq_or_diff($json, $output, 'GET Information about a specific microarray');
 
 my $microarray_probe = '/regulatory/species/homo_sapiens/microarray/HC-G110/probe/137:179;?content-type=application/json';
 $output =  {
-  microarray_name => 'HC-G110',
-  probe_length    => 25,
-  probe_name      => '137:179;',
+  microarray => 'HC-G110',
+  length    => 25,
+  name      => '137:179;',
   sequence        => 'TCTCCTTTGCTGAGGCCTCCAGCTT'
   } ;
 $json = json_GET($microarray_probe,'GET Information about a specific probe');
@@ -91,15 +91,16 @@ eq_or_diff($json, $output, 'GET Information about a specific probe');
 
 
 # regulatory/species/:species/microarray/:microarray/probe_set/:probe_set/probe/:probe
-my $microarray_probe_set_probe = '/regulatory/species/homo_sapiens/microarray/HC-G110/probe_set/1000_at/probe/137:179;?content-type=application/json';
+my $microarray_probe_set = '/regulatory/species/homo_sapiens/microarray/HC-G110/probe_set/1000_at?content-type=application/json';
 $output =  {
- microarray_name => 'HC-G110',
- probe_length    => 25,
- probe_name      => '137:179;',
- probe_set       => '1000_at',
- sequence        => 'TCTCCTTTGCTGAGGCCTCCAGCTT'  
+  microarray => 'HC-G110',
+  name => '1000_at',          
+  probes => [                         
+    '137:179;'                        
+    ],                                  
+  size => 16                          
   } ;
-$json = json_GET($microarray_probe_set_probe,'JSON: GET Information about a specific probe');
+$json = json_GET($microarray_probe_set,'JSON: GET Information about a specific probe');
 eq_or_diff($json, $output, 'GET Information about a specific probes_set_');
 
 done_testing();


### PR DESCRIPTION
Bugfix in probeset endpoint, probeset returns now only information about the set, no details about its probes.
Streamlined probe/probeset transcript mappings 
Updated regulatory.info