### PR TITLE
 Changed ID -> id to match all the other endpoints.

### DIFF
--- a/t/overlap.t
+++ b/t/overlap.t
@@ -284,7 +284,7 @@ my $base = '/overlap/region/homo_sapiens';
 {
   my $region = '1:76429380..76430144';
   is_json_GET("$base/$region?feature=regulatory", [{
-    ID => 'ENSR00000105157',                   
+    id => 'ENSR00000105157',                   
     bound_end => 76430144,                     
     bound_start => 76429380,                   
     description => 'Open chromatin region',

--- a/t/regulatory.t
+++ b/t/regulatory.t
@@ -52,7 +52,7 @@ eq_or_diff($json, $output, 'GET list of all epigenomes');
 
 my $regulatory_feature = '/regulatory/species/homo_sapiens/id/ENSR00000105157/?content-type=application/json';
   $output = [{
-    ID              => 'ENSR00000105157',                   
+    id              => 'ENSR00000105157',                   
     bound_end       => 76430144,                     
     bound_start     => 76429380,                   
     description     => 'Open chromatin region',


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

Reflect changes in Funcgen Repo, changed ID -> id to match all the other endpoints. 


### Use case

http://rest.ensembl.org/overlap/region/human/7:140424943-140624564?feature=regulatory;content-type=application/json


### Benefits

_If applicable, describe the advantages the changes will have._

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes.




### Testing

Yes.

_If so, do the tests pass/fail?_

Pass, of course.

_Have you run the entire test suite and no regression was detected?_

No, only the ones where regulatory is used:
lookup.t
overlap.t
regulatory.t


### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians
