### PR TITLE
Master

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -304,6 +304,7 @@ sub _include_user_params {
     transcript_id
     phastCons
     distance
+    ambiguity
 
     pick
     pick_allele

--- a/t/vep.t
+++ b/t/vep.t
@@ -121,7 +121,7 @@ eq_or_diff($json, $vep_output, 'Example vep region get message');
 
 
 # test with non-toplevel sequence (should transform to toplevel)
-$vep_get = '/vep/homo_sapiens/region/HSCHR6_CTG1:1000001-1000001:1/G?content-type=application/json&ambiguity=1';
+$vep_get = '/vep/homo_sapiens/region/HSCHR6_CTG1:1000001-1000001:1/G?content-type=application/json';
 $vep_output = [
   {
     'assembly_name' => 'GRCh37',
@@ -145,7 +145,6 @@ $vep_output = [
 ];
 $json = json_GET($vep_get,'GET a VEP region on a non-toplevel sequence');
 
-$DB::single =1 ;
 my $vep_post = '/vep/homo_sapiens/region';
 my $vep_post_body = '{ "variants" : ["7 34381884 var1 C T . . .",
                                      "7 86442404 var2 T C . . ."]}';

--- a/t/vep.t
+++ b/t/vep.t
@@ -567,6 +567,7 @@ is_deeply(
 $vep_hgvs_get = '/vep/homo_sapiens/hgvs/6:g.1102327G>T?content-type=application/json&ambiguity=1';
 $vep_output = [{
   allele_string => 'G/T',
+  ambiguity => 'K',
   assembly_name => 'GRCh37',
   end => 1102327,
   id => '6:g.1102327G>T',
@@ -577,7 +578,7 @@ $vep_output = [{
   strand => 1,
   transcript_consequences => [
     {
-      ambiguity => 'K',
+
       amino_acids => 'W/L',
       biotype => 'protein_coding',
       cdna_end => 581,
@@ -602,7 +603,6 @@ $vep_output = [{
     }
   ]
 }];
-$DB::single = 1;
 $json = json_GET($vep_hgvs_get,'GET Ambiguity flag with HGVS notation');
 eq_or_diff($json, $vep_output, 'VEP Ambiguity Flag GET');
 

--- a/t/vep.t
+++ b/t/vep.t
@@ -121,7 +121,7 @@ eq_or_diff($json, $vep_output, 'Example vep region get message');
 
 
 # test with non-toplevel sequence (should transform to toplevel)
-$vep_get = '/vep/homo_sapiens/region/HSCHR6_CTG1:1000001-1000001:1/G?content-type=application/json';
+$vep_get = '/vep/homo_sapiens/region/HSCHR6_CTG1:1000001-1000001:1/G?content-type=application/json&ambiguity=1';
 $vep_output = [
   {
     'assembly_name' => 'GRCh37',
@@ -145,6 +145,7 @@ $vep_output = [
 ];
 $json = json_GET($vep_get,'GET a VEP region on a non-toplevel sequence');
 
+$DB::single =1 ;
 my $vep_post = '/vep/homo_sapiens/region';
 my $vep_post_body = '{ "variants" : ["7 34381884 var1 C T . . .",
                                      "7 86442404 var2 T C . . ."]}';
@@ -561,6 +562,52 @@ is_deeply(
   },
   'refseq transcripts'
 );
+
+
+# test ambiguity flag
+$vep_hgvs_get = '/vep/homo_sapiens/hgvs/6:g.1102327G>T?content-type=application/json&ambiguity=1';
+$vep_output = [{
+  allele_string => 'G/T',
+  assembly_name => 'GRCh37',
+  end => 1102327,
+  id => '6:g.1102327G>T',
+  input => '6:g.1102327G>T',
+  most_severe_consequence => 'missense_variant',
+  seq_region_name => '6',
+  start => 1102327,
+  strand => 1,
+  transcript_consequences => [
+    {
+      ambiguity => 'K',
+      amino_acids => 'W/L',
+      biotype => 'protein_coding',
+      cdna_end => 581,
+      cdna_start => 581,
+      cds_end => 311,
+      cds_start => 311,
+      codons => 'tGg/tTg',
+      consequence_terms => [
+        'missense_variant'
+      ],
+      gene_id => 'ENSG00000176515',
+      gene_symbol => 'AL033381.1',
+      gene_symbol_source => 'Clone_based_ensembl_gene',
+      impact => 'MODERATE',
+      polyphen_prediction => 'possibly_damaging',
+      polyphen_score => '0.514',
+      protein_end => 104,
+      protein_start => 104,
+      strand => 1,
+      transcript_id => 'ENST00000314040',
+      variant_allele => 'T'
+    }
+  ]
+}];
+$DB::single = 1;
+$json = json_GET($vep_hgvs_get,'GET Ambiguity flag with HGVS notation');
+eq_or_diff($json, $vep_output, 'VEP Ambiguity Flag GET');
+
+
 
 my $body = '{ "blurb" : "stink" }';
 # Test malformed messages


### PR DESCRIPTION
Added ambiguity flag into CL and REST VEP. Changes to ensembl-vep, ensembl-rest and public_plugins have all been made at the same time.

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

_One or more sentences describing in detail the proposed changes._

Added in ambiguity flag for VEP

### Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

Requested by Steve T as part of VEP changes

### Benefits

_If applicable, describe the advantages the changes will have._

Provides ambiguity code to the user

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

None

### Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

Pass, of course.

_Have you run the entire test suite and no regression was detected?_

Yes.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

eg. [/xenobiology/orthologs] Added allele ambiguity codes