### PR TITLE
The /info/comparas endpoint returns the version of the compara database, not the core database

### DIFF
--- a/t/info.t
+++ b/t/info.t
@@ -42,17 +42,20 @@ Catalyst::Test->import('EnsEMBL::REST');
 require EnsEMBL::REST;
 
 my $VERSION = software_version();
-my $schema_version = $dba->get_MetaContainer()->single_value_by_key('schema_version');
-$schema_version *= 1;
+my $core_schema_version = $dba->get_MetaContainer()->single_value_by_key('schema_version');
+$core_schema_version *= 1;
+
+my $compara_schema_version = $compara_dba->get_MetaContainer()->single_value_by_key('schema_version');
+$compara_schema_version *= 1;
 
 # info/comparas
 is_json_GET(
-  '/info/comparas', { comparas => [ { name => 'multi', release => $schema_version} ] }, "Comparas returns 1 DB"
+  '/info/comparas', { comparas => [ { name => 'multi', release => $compara_schema_version} ] }, "Comparas returns 1 DB"
 );
 
 # info/data
 is_json_GET(
-  '/info/data', {releases => [ $schema_version ]}, "only release available is $schema_version"
+  '/info/data', {releases => [ $core_schema_version ]}, "only release available is $core_schema_version"
 );
 
 # /info/ping
@@ -71,8 +74,8 @@ is_json_GET(
     return $info_species;
   };
 
-  my $expected = {species => [ { division => 'Ensembl', name => 'homo_sapiens', 'accession' => 'GCA_000001405.9', common_name => 'human', display_name => 'Human', taxon_id => '9606', groups => ['core', 'funcgen', 'variation'], aliases => [], release => $schema_version, assembly => 'GRCh37', strain => 'test_strain', strain_collection => 'human'} ]};
-  my $expected_hide_strain_info = {species => [ { division => 'Ensembl', name => 'homo_sapiens', 'accession' => 'GCA_000001405.9', common_name => 'human', display_name => 'Human', taxon_id => '9606', groups => ['core', 'funcgen', 'variation'], aliases => [], release => $schema_version, assembly => 'GRCh37'} ]};
+  my $expected = {species => [ { division => 'Ensembl', name => 'homo_sapiens', 'accession' => 'GCA_000001405.9', common_name => 'human', display_name => 'Human', taxon_id => '9606', groups => ['core', 'funcgen', 'variation'], aliases => [], release => $core_schema_version, assembly => 'GRCh37', strain => 'test_strain', strain_collection => 'human'} ]};
+  my $expected_hide_strain_info = {species => [ { division => 'Ensembl', name => 'homo_sapiens', 'accession' => 'GCA_000001405.9', common_name => 'human', display_name => 'Human', taxon_id => '9606', groups => ['core', 'funcgen', 'variation'], aliases => [], release => $core_schema_version, assembly => 'GRCh37'} ]};
   my $expected_empty_list = {species => [ ]};
 
   eq_or_diff_data(


### PR DESCRIPTION
### Description and Use case

The /info/comparas test assumes that the test compara database is in the same version as the test core database. This assumption is not always met (e.g. before branching the API, or when developing locally).
The commit solves the issue by comparing the version returned by the endpoint to the one of the database itself

### Benefits

No more Travis failures

### Possible Drawbacks

None

### Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

Pass, of course.

_Have you run the entire test suite and no regression was detected?_

Yes.

