### PR TITLE
fix family endpoint documentation

### DIFF
--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -257,6 +257,11 @@
         description=The type of sequence to bring back. Setting it to none results in no sequence being returned. Note: dependant on the setting for "aligned", If aligned=1, this will override sequence=none
         default=protein
       </sequence>
+      <member_source>
+        type=Enum(all, ensembl, uniprot)
+        description=The source of the family members that you want returned
+        default=all
+      </member_source>
       <db_type>
         type=String
         description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
@@ -295,17 +300,6 @@
         example=__VAR(compara_gene_stable_id)__
         required=1
       </id>
-      <db_type>
-        type=String
-        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
-        example=core
-      </db_type>
-      <object_type>
-        type=String
-        description=Filter by feature type
-        example=gene
-        example=transcript
-      </object_type>
       <compara>
         type=String
         description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data

--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -262,22 +262,6 @@
         description=The source of the family members that you want returned
         default=all
       </member_source>
-      <db_type>
-        type=String
-        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
-        example=core
-      </db_type>
-      <object_type>
-        type=String
-        description=Filter by feature type
-        example=gene
-        example=transcript
-      </object_type>
-      <member_source>
-        type=Enum(all, ensembl, uniprot)
-        description=The source of the family members that you want returned
-        default=all
-      </member_source>
     </params>
     <examples>
       <json>
@@ -350,24 +334,6 @@
         example=__VAR(species_common)__
         required=1
       </species>
-      <db_type>
-        type=String
-        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
-        default=core
-        example=core
-        example=otherfeatures
-      </db_type>
-      <external_db>
-        type=String
-        description=Filter by external database
-        example=__VAR(gene_symbol_db)__
-      </external_db>
-      <object_type>
-        type=String
-        description=Filter by feature type
-        example=gene
-        example=transcript
-      </object_type>
       <compara>
         type=String
         description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
@@ -389,6 +355,24 @@
         description=The source of the family members that you want returned
         default=all
       </member_source>
+      <db_type>
+        type=String
+        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
+        default=core
+        example=core
+        example=otherfeatures
+      </db_type>
+      <external_db>
+        type=String
+        description=Filter by external database
+        example=__VAR(gene_symbol_db)__
+      </external_db>
+      <object_type>
+        type=String
+        description=Filter by feature type
+        example=gene
+        example=transcript
+      </object_type>
     </params>
     <examples>
       <json>


### PR DESCRIPTION
### Description

Whilst comparing the e! and EG family endpoints, Matthieu found a couple of minor issues in our documentation:

https://rest.ensembl.org/documentation/info/family_member_id : db_type, object_type and species are not used in this endpoint (they're only used in the member_symbol endpoint)
https://rest.ensembl.org/documentation/info/family : the documentation is missing the member_source option

### Use case

https://rest.ensembl.org/documentation/info/family_member_id : db_type, object_type and species are not used in this endpoint (they're only used in the member_symbol endpoint)
https://rest.ensembl.org/documentation/info/family : the documentation is missing the member_source option


### Benefits

Clarity

### Possible Drawbacks

none

### Testing

N/A

Yes.

N/A

### Changelog

no
