### PR TITLE
Master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script: "./travisci/harness.sh"
 
 notifications:
   email:
-    on_success: always
-    on_failure: always
+    on_failure: change
   slack:
     secure: Q0MkdvATb4X2mhfFHugDe/EeDAD9mNn/K5atrKLt+vQ5gO6Pc/LkeLoFCBmO4GiJHrFf9UeE4qWCQ/xsRHVNK4qiukVvminRdF97DFWAzLZ3GqJvMYJxZx/JCiaUhjbLW+GVhPWo82WRHlW/kaqHc0qXyKnMkoHRf/kcZC2cA5E=
+    on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: "perl"
 
 perl:
-  - "5.14"
+  - "5.26"
 
 sudo: false
 
@@ -22,7 +22,7 @@ before_install:
     - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-vep.git
     - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
     - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-io.git
-    - git clone -b bioperl-release-1-6-1 --depth 1 https://github.com/bioperl/bioperl-live.git
+    - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
     - git clone --branch 1.3.2 --depth 1 https://github.com/samtools/htslib.git
     - cd htslib
     - make

--- a/cpanfile
+++ b/cpanfile
@@ -61,6 +61,7 @@ test_requires 'Test::Differences';
 test_requires 'Test::JSON';
 test_requires 'Test::XML::Simple';
 test_requires 'Test::XPath';
+test_requires 'Test::Deep';
 test_requires 'HTTP::Request::Common';
 test_requires 'Plack::Test';
 test_requires 'Net::CIDR::Lite';

--- a/lib/EnsEMBL/REST/Controller/Xrefs.pm
+++ b/lib/EnsEMBL/REST/Controller/Xrefs.pm
@@ -134,8 +134,7 @@ sub _encode :Private {
       info_type       => $dbe->info_type(),
       info_text       => $dbe->info_text(),
     };
-    given(ref($dbe)) {
-      when('Bio::EnsEMBL::IdentityXref') {
+    if (ref($dbe) eq 'Bio::EnsEMBL::IdentityXref') {
         $enc->{xref_identity}     = ($dbe->xref_identity()*1);
         $enc->{xref_start}        = ($dbe->xref_start()*1);
         $enc->{xref_end}          = ($dbe->xref_end()*1);
@@ -146,10 +145,8 @@ sub _encode :Private {
         $enc->{evalue}            = $dbe->evalue();
         $enc->{cigar_line}        = $dbe->cigar_line() if $dbe->cigar_line();
         $enc->{evalue}            = ($enc->{evalue}*1) if defined $enc->{evalue}; 
-      }
-      when('Bio::EnsEMBL::OntologyXref') {
+    } elsif (ref($dbe) eq 'Bio::EnsEMBL::OntologyXref') {
         $enc->{linkage_types} = $dbe->get_all_linkage_types();
-      }
     }
     push(@encoded, $enc);
   }

--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -322,10 +322,10 @@ sub get_species {
     my $new_info_list = [];
     foreach my $inf(@{$info}){
     my $new_info_hash = {};
-      foreach my $key(keys $inf){
-        $new_info_hash->{$key} = $inf->{$key} unless $key ~~ @hidden_keys;
+      foreach my $key(keys %$inf){
+        $new_info_hash->{$key} = $inf->{$key} unless grep {$_ eq $key} @hidden_keys;
       }
-    push ($new_info_list, $new_info_hash);
+    push (@$new_info_list, $new_info_hash);
     }
     return $new_info_list;
   }

--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -257,6 +257,11 @@
         description=The type of sequence to bring back. Setting it to none results in no sequence being returned. Note: dependant on the setting for "aligned", If aligned=1, this will override sequence=none
         default=protein
       </sequence>
+      <member_source>
+        type=Enum(all, ensembl, uniprot)
+        description=The source of the family members that you want returned
+        default=all
+      </member_source>
       <db_type>
         type=String
         description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
@@ -295,17 +300,6 @@
         example=__VAR(compara_gene_stable_id)__
         required=1
       </id>
-      <db_type>
-        type=String
-        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
-        example=core
-      </db_type>
-      <object_type>
-        type=String
-        description=Filter by feature type
-        example=gene
-        example=transcript
-      </object_type>
       <compara>
         type=String
         description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data

--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -249,14 +249,30 @@
       </compara>
       <aligned>
         type=Boolean
-        description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
+        description=Return the aligned string if true. Otherwise, return the original sequence (no insertions). Note: If aligned=1, this will override sequence=none
         default=1
       </aligned>
       <sequence>
         type=Enum(none, cdna, protein)
-        description=The type of sequence to bring back. Setting it to none results in no sequence being returned
+        description=The type of sequence to bring back. Setting it to none results in no sequence being returned. Note: dependant on the setting for "aligned", If aligned=1, this will override sequence=none
         default=protein
       </sequence>
+      <db_type>
+        type=String
+        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
+        example=core
+      </db_type>
+      <object_type>
+        type=String
+        description=Filter by feature type
+        example=gene
+        example=transcript
+      </object_type>
+      <member_source>
+        type=Enum(all, ensembl, uniprot)
+        description=The source of the family members that you want returned
+        default=all
+      </member_source>
     </params>
     <examples>
       <json>
@@ -279,12 +295,6 @@
         example=__VAR(compara_gene_stable_id)__
         required=1
       </id>
-      <species>
-        type=String
-        description=Species name/alias
-        example=__VAR(species)__
-        example=__VAR(species_common)__
-      </species>
       <db_type>
         type=String
         description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
@@ -304,12 +314,12 @@
       </compara>
       <aligned>
         type=Boolean
-        description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
+        description=Return the aligned string if true. Otherwise, return the original sequence (no insertions). Note: If aligned=1, this will override sequence=none
         default=1
       </aligned>
       <sequence>
         type=Enum(none, cdna, protein)
-        description=The type of sequence to bring back. Setting it to none results in no sequence being returned
+        description=The type of sequence to bring back. Setting it to none results in no sequence being returned. Note: dependant on the setting for "aligned", If aligned=1, this will override sequence=none
         default=protein
       </sequence>
       <member_source>
@@ -372,12 +382,12 @@
       </compara>
       <aligned>
         type=Boolean
-        description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
+        description=Return the aligned string if true. Otherwise, return the original sequence (no insertions). Note: If aligned=1, this will override sequence=none
         default=1
       </aligned>
       <sequence>
         type=Enum(none, cdna, protein)
-        description=The type of sequence to bring back. Setting it to none results in no sequence being returned
+        description=The type of sequence to bring back. Setting it to none results in no sequence being returned. Note: dependant on the setting for "aligned", If aligned=1, this will override sequence=none
         default=protein
       </sequence>
       <member_source>
@@ -439,13 +449,13 @@
       </nh_format>
       <prune_species>
         type=String
-        description=Prune the tree by species. Supports all species aliases
+        description=Prune the tree by species. Supports all species aliases. Will return a tree with only the species given
         example=__VAR(species_common)__
         example=__VAR(target_species)__
       </prune_species>
       <prune_taxon>
         type=Integer
-        description=Prune the tree by taxon
+        description=Prune the tree by taxon. Will return a tree with only the taxons given
         example=__VAR(taxon)__
         example=__VAR(target_taxon)__
       </prune_taxon>

--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -262,22 +262,6 @@
         description=The source of the family members that you want returned
         default=all
       </member_source>
-      <db_type>
-        type=String
-        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
-        example=core
-      </db_type>
-      <object_type>
-        type=String
-        description=Filter by feature type
-        example=gene
-        example=transcript
-      </object_type>
-      <member_source>
-        type=Enum(all, ensembl, uniprot)
-        description=The source of the family members that you want returned
-        default=all
-      </member_source>
     </params>
     <examples>
       <json>
@@ -350,24 +334,6 @@
         example=__VAR(species_common)__
         required=1
       </species>
-      <db_type>
-        type=String
-        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
-        default=core
-        example=core
-        example=otherfeatures
-      </db_type>
-      <external_db>
-        type=String
-        description=Filter by external database
-        example=__VAR(gene_symbol_db)__
-      </external_db>
-      <object_type>
-        type=String
-        description=Filter by feature type
-        example=gene
-        example=transcript
-      </object_type>
       <compara>
         type=String
         description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
@@ -389,6 +355,24 @@
         description=The source of the family members that you want returned
         default=all
       </member_source>
+      <db_type>
+        type=String
+        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
+        default=core
+        example=core
+        example=otherfeatures
+      </db_type>
+      <external_db>
+        type=String
+        description=Filter by external database
+        example=__VAR(gene_symbol_db)__
+      </external_db>
+      <object_type>
+        type=String
+        description=Filter by feature type
+        example=gene
+        example=transcript
+      </object_type>
     </params>
     <examples>
       <json>

--- a/t/eqtl.t
+++ b/t/eqtl.t
@@ -53,9 +53,10 @@ my $eqtl_a = Bio::EnsEMBL::HDF5::EQTLAdaptor->new(  -FILENAME => $hdf5, -CORE_DB
 $multi->add_DBAdaptor('eqtl', $eqtl_a);
 
 
-my $response = [
-{ minus_log10_p_value => '0.00618329914558938',
-  value => 0.985863302490807}];
+my $response = json_GET("/eqtl/id/homo_sapiens/ENSG00000223972?content-type=application/json;statistic=p-value;tissue=Whole_Blood;variant_name=rs4951859", "Return p-value for known gene and variant");
 
-is_json_GET("/eqtl/id/homo_sapiens/ENSG00000223972?content-type=application/json;statistic=p-value;tissue=Whole_Blood;variant_name=rs4951859", $response, "Return p-value for known gene and variant");
+# Floats rounded to prevent precision variations between architectures and compilation options
+cmp_ok(sprintf("%.6f",$response->[0]->{minus_log10_p_value}) , '==', sprintf("%.6f",0.00618329914558938) ,'p-value accurate to 6 d.p.');
+cmp_ok(sprintf("%.6f",$response->[0]->{value}) , '==', sprintf("%.6f",0.985863302490807) ,'value accurate to 6 d.p.');
+
 done_testing();

--- a/t/info.t
+++ b/t/info.t
@@ -25,11 +25,12 @@ BEGIN {
 }
 
 use Test::More;
+use Test::Deep;
+use Test::Differences;
 use Catalyst::Test ();
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::ApiVersion qw/software_version/;
 use Bio::EnsEMBL::Variation::Utils::Constants qw(%OVERLAP_CONSEQUENCES);
-use Test::Differences;
 use Data::Dumper;
 
 my $test = Bio::EnsEMBL::Test::MultiTestDB->new();
@@ -150,9 +151,8 @@ is_json_GET(
 {
   my $methods_json = json_GET('/info/compara/methods', 'Get the compara methods hash');
   cmp_ok(keys(%{$methods_json}), '==', 11, 'Ensuring we have the right number of compara methods available');
-  is_json_GET(
-    '/info/compara/methods?class=Homology', 
-    {'Homology.homology' => [qw/ENSEMBL_PROJECTIONS ENSEMBL_PARALOGUES ENSEMBL_ORTHOLOGUES/]}, 
+  cmp_deeply(json_GET('/info/compara/methods?class=Homology', 'Get Homology methods'), 
+    {'Homology.homology' => bag(qw/ENSEMBL_PROJECTIONS ENSEMBL_PARALOGUES ENSEMBL_ORTHOLOGUES/)}, 
     'Checking filtering brings back subsets of compara methods'
   );
 }
@@ -196,7 +196,7 @@ is_json_GET(
         data_types => ['variation']
       }
     ];
-  is_json_GET('/info/variation/homo_sapiens?filter=dbSNP', $expected, 'Checking dbSNP source filtering works');
+  cmp_bag(json_GET('/info/variation/homo_sapiens?filter=dbSNP',"Get dbSNP variants"), $expected, 'Checking dbSNP source filtering works');
 }
 
 #/info/variation/populations/:species
@@ -233,7 +233,7 @@ is_json_GET(
         'size' => '61'
       }
     ];
-  is_json_GET('/info/variation/populations/homo_sapiens?filter=LD', $expected, 'Checking filtering for LD population works');
+  cmp_bag(json_GET('/info/variation/populations/homo_sapiens?filter=LD',"LD variants"), $expected, 'Checking filtering for LD population works');
 }
 
 #/info/variation/consequence_types

--- a/t/ld.t
+++ b/t/ld.t
@@ -26,6 +26,7 @@ BEGIN {
 
 use Test::More;
 use Test::Differences;
+use Test::Deep;
 use Test::Warnings qw(warning);
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Data::Dumper;
@@ -68,7 +69,7 @@ action_bad($ld_get, 'A population name is required for this endpoint. Use GET /i
 
 $ld_get = '/ld/homo_sapiens/rs1333047/1000GENOMES:phase_1_ASW';
 $json = json_GET($ld_get, 'GET LD data for variant and population');
-eq_or_diff($json, $expected_output, "Example variant and population");
+cmp_bag($json, $expected_output, "Example variant and population");
 
 $expected_output = [
   {
@@ -111,7 +112,7 @@ $expected_output = [
 
 $ld_get = '/ld/homo_sapiens/rs1333047/1000GENOMES:phase_1_ASW?attribs=1';
 $json = json_GET($ld_get, 'GET LD data for variant and population');
-eq_or_diff($json, $expected_output, "Example variant, population, return location and consequence attribs");
+cmp_bag($json, $expected_output, "Example variant, population, return location and consequence attribs");
 
 $expected_output =
 [
@@ -126,19 +127,19 @@ $expected_output =
 
 $ld_get = '/ld/homo_sapiens/rs1333047/1000GENOMES:phase_1_ASW?d_prime=1.0';
 $json = json_GET($ld_get, 'GET LD data for variant, population and d_prime');
-eq_or_diff($json, $expected_output, "Example variant, population and d_prime");
+cmp_bag($json, $expected_output, "Example variant, population and d_prime");
 
 $ld_get = '/ld/homo_sapiens/rs1333047/1000GENOMES:phase_1_ASW?d_prime=1.0;window_size=500';
 $json = json_GET($ld_get, 'GET LD data for variant, population, d_prime and window_size');
-eq_or_diff($json, $expected_output, "Example variant, population, d_prime and window_size");
+cmp_bag($json, $expected_output, "Example variant, population, d_prime and window_size");
 
 $ld_get = '/ld/homo_sapiens/rs1333047/1000GENOMES:phase_1_ASW?d_prime=1.0;window_size=499.123';
 $json = json_GET($ld_get, 'GET LD data for variant, population, d_prime and window_size');
-eq_or_diff($json, $expected_output, "Example variant, population, d_prime and window_size");
+cmp_bag($json, $expected_output, "Example variant, population, d_prime and window_size");
 
 $ld_get = '/ld/homo_sapiens/rs1333047/1000GENOMES:phase_1_ASW?d_prime=1.0;window_size=0';
 $json = json_GET($ld_get, 'GET LD data for variant, population, d_prime and window_size');
-eq_or_diff($json, $expected_output, "Example variant, population, d_prime and window_size");
+cmp_bag($json, $expected_output, "Example variant, population, d_prime and window_size");
 
 $ld_get = '/ld/homo_sapiens/rs1333047/1000GENOMES:phase_1_ASW?d_prime=1.0;window_size=500kb';
 action_bad($ld_get, 'window_size needs to be a value bewteen 0 and 1000');
@@ -178,7 +179,7 @@ $expected_output =
 
 my $ld_region_get = '/ld/homo_sapiens/region/9:22125265..22125505/1000GENOMES:phase_1_ASW';
 $json = json_GET($ld_region_get, 'GET LD data for region and population');
-eq_or_diff($json, $expected_output, "Example region, population");
+cmp_bag($json, $expected_output, "Example region, population");
 
 $expected_output =
 [  
@@ -193,7 +194,7 @@ $expected_output =
 
 $ld_region_get = '/ld/homo_sapiens/region/9:22125265..22125505/1000GENOMES:phase_1_ASW?r2=0.5';
 $json = json_GET($ld_region_get, 'GET LD data for region and population, r2');
-eq_or_diff($json, $expected_output, "Example region, population, r2");
+cmp_bag($json, $expected_output, "Example region, population, r2");
 
 $ld_region_get = '/ld/homo_sapiens/region/9:22125265..23125505/1000GENOMES:phase_1_ASW?r2=0.5';
 action_bad($ld_region_get, 'Specified region is too large');
@@ -212,14 +213,14 @@ $expected_output =
 ];
 my $ld_pairwise_get = '/ld/homo_sapiens/pairwise/rs1333047/rs4977575?population_name=1000GENOMES:phase_1_ASW';
 $json = json_GET($ld_pairwise_get, 'GET pairwise LD data for a population');
-eq_or_diff($json, $expected_output, "Example pairwise LD id1, id2, population");
+cmp_bag($json, $expected_output, "Example pairwise LD id1, id2, population");
 
 $ld_pairwise_get = '/ld/homo_sapiens/pairwise/rs1333047?population_name=1000GENOMES:phase_1_ASW';
 action_bad($ld_pairwise_get, 'Two variant names are required for this endpoint.');
 
 $ld_pairwise_get = '/ld/homo_sapiens/pairwise/rs1333047/rs4977575';
 warning { $json = json_GET($ld_pairwise_get, 'GET pairwise LD data for all LD populations') };
-eq_or_diff($json, $expected_output, "Example pairwise LD id1, id2");
+cmp_bag($json, $expected_output, "Example pairwise LD id1, id2");
 
 $ld_pairwise_get = '/ld/homo_sapiens/pairwise/rs1333047/rs1234567?population_name=1000GENOMES:phase_1_ASW';
 action_bad($ld_pairwise_get, 'Could not fetch variation object for id');

--- a/t/lookup.t
+++ b/t/lookup.t
@@ -25,6 +25,7 @@ BEGIN {
 }
 
 use Test::More;
+use Test::Deep;
 use Catalyst::Test ();
 use Bio::EnsEMBL::Test::MultiTestDB;
 
@@ -44,7 +45,7 @@ my $full_response = {
   biotype => 'protein_coding', display_name => 'AL033381.1', logic_name => 'ensembl', source => 'ensembl',
   description => 'Uncharacterized protein; cDNA FLJ34594 fis, clone KIDNE2009109  [Source:UniProtKB/TrEMBL;Acc:Q8NAX6]'
 };
-is_json_GET("/lookup/$basic_id", $full_response, 'Get of a known ID to the old URL will return a value');
+cmp_deeply(json_GET("/lookup/$basic_id",'lookup a gene'), $full_response, 'Get of a known ID to the old URL will return a value');
 
 my $expanded_response = {
   %{$condensed_response},
@@ -59,7 +60,7 @@ my $expanded_response = {
                 ]
                 }]
                 };
-is_json_GET("/lookup/id/$basic_id?expand=1;format=condensed", $expanded_response, 'Get of a known ID with expanded option will return transcripts as well');
+cmp_deeply(json_GET("/lookup/id/$basic_id?expand=1;format=condensed",'lookup an expanded gene'), $expanded_response, 'Get of a known ID with expanded option will return transcripts as well');
 
 my $id_with_phenotype = 'ENSG00000137273';
 my $phenotype_response = {
@@ -68,7 +69,7 @@ my $phenotype_response = {
     {genes => undef,source => 'GOA',study => 'PMID:8626802',trait => 'positive regulation of transcription from RNA polymerase II promoter', variants => undef},
     {genes => undef,source => 'GOA',study => 'PMID:8626802',trait => 'soft palate development',variants => undef}
    ],};
-is_json_GET("/lookup/id/$id_with_phenotype?phenotypes=1;format=condensed", $phenotype_response, 'Get of a known gene ID with phenotypes option will return phenotypes as well');
+cmp_deeply(json_GET("/lookup/id/$id_with_phenotype?phenotypes=1;format=condensed",'lookup a gene with phenotypes'), $phenotype_response, 'Get of a known gene ID with phenotypes option will return phenotypes as well');
 
 my $utr_response = {
   %{$condensed_response},
@@ -89,9 +90,9 @@ my $utr_response = {
                 }]
                 };
 
-is_json_GET("/lookup/id/$basic_id?expand=1;utr=1;format=condensed", $utr_response, 'Get of a known ID with utr option will return UTRs as well');
+cmp_deeply(json_GET("/lookup/id/$basic_id?expand=1;utr=1;format=condensed",'lookup gene with UTRs'), $utr_response, 'Get of a known ID with utr option will return UTRs as well');
 
-is_json_GET("/lookup/symbol/homo_sapiens/$symbol?expand=1;format=condensed", $expanded_response, 'Get of a known symbol returns the same result as with stable id');
+cmp_deeply(json_GET("/lookup/symbol/homo_sapiens/$symbol?expand=1;format=condensed",'lookup symbol with expand'), $expanded_response, 'Get of a known symbol returns the same result as with stable id');
 json_GET("/lookup/symbol/homo_sapiens/$symbol?expand=1", "Extended response works");
 
 action_bad("/lookup/id/${basic_id}extra", 'ID should not be found. Fail');
@@ -101,8 +102,8 @@ action_bad("/lookup/id/${basic_id}extra", 'ID should not be found. Fail');
 $basic_id = 'ENST00000314040';
 $condensed_response = {object_type => 'Transcript', db_type => 'core', species => 'homo_sapiens', id => $basic_id};
 
-is_json_GET("/lookup/id/$basic_id?format=condensed", $condensed_response, 'Get of a known ID will return a value');
-is_json_GET("/lookup/$basic_id?format=condensed", $condensed_response, 'Get of a known ID to the old URL will return a value');
+cmp_deeply(json_GET("/lookup/id/$basic_id?format=condensed",'lookup transcript in condensed format'), $condensed_response, 'Get of a known ID will return a value');
+cmp_deeply(json_GET("/lookup/$basic_id?format=condensed", 'lookup transcript via old URL'), $condensed_response, 'Get of a known ID to the old URL will return a value');
 
 $full_response = {
   %{$condensed_response},
@@ -110,7 +111,7 @@ $full_response = {
   biotype => 'protein_coding', display_name => 'AL033381.1-201', logic_name => 'ensembl', source => 'ensembl',
   is_canonical => 1,
 };
-is_json_GET("/lookup/$basic_id", $full_response, 'Full response contains all Transcript information');
+cmp_deeply(json_GET("/lookup/$basic_id",'lookup transcript'), $full_response, 'Full response contains all Transcript information');
 
 $expanded_response = {
   %{$condensed_response},
@@ -122,7 +123,7 @@ $expanded_response = {
                  {object_type => 'Exon', db_type => 'core', species => 'homo_sapiens', id => 'ENSE00001271869'}
                 ]
                 };
-is_json_GET("/lookup/id/$basic_id?expand=1;format=condensed", $expanded_response, 'Get of a known ID with expanded option will return transcripts as well');
+cmp_deeply(json_GET("/lookup/id/$basic_id?expand=1;format=condensed",'Expanded transcript by ID'), $expanded_response, 'Get of a known ID with expanded option will return transcripts as well');
 
 $utr_response = {
   %{$condensed_response},
@@ -140,7 +141,7 @@ $utr_response = {
                 ]
                 };
 
-is_json_GET("/lookup/id/$basic_id?expand=1;utr=1;format=condensed", $utr_response, 'Get of a known ID with utr option will return UTRs as well');
+cmp_deeply(json_GET("/lookup/id/$basic_id?expand=1;utr=1;format=condensed",'Transcript by ID with UTR'), $utr_response, 'Get of a known ID with utr option will return UTRs as well');
 
 
 # Test POST endpoints
@@ -176,7 +177,7 @@ my $id_response = {
 # use Data::Dumper;
 # my $tribble = do_POST("/lookup/id",$id_body);
 # note('trouble at mill:'.Dumper $tribble);
-is_json_POST("/lookup/id",$id_body,$id_response,"Try to do an ID post query");
+cmp_deeply(json_POST("/lookup/id",$id_body,'POST lookup by ID'),$id_response,"Try to do an ID post query");
 
 my $symbol_response = {
     'AL033381.1' => {                                                                                                         
@@ -221,6 +222,6 @@ my $symbol_body = qq{
 }
 };
 
-is_json_POST("/lookup/symbol/homo_sapiens",$symbol_body,$symbol_response,"Try to POST symbol query");
+cmp_deeply(json_POST("/lookup/symbol/homo_sapiens",$symbol_body,'POST lookup by symbol'),$symbol_response,"Try to POST symbol query");
 
 done_testing();

--- a/t/map.t
+++ b/t/map.t
@@ -25,6 +25,7 @@ BEGIN {
 }
 
 use Test::More;
+use Test::Deep;
 use Catalyst::Test ();
 use Bio::EnsEMBL::Test::MultiTestDB;
 
@@ -33,8 +34,8 @@ Catalyst::Test->import('EnsEMBL::REST');
 
 #Assembly mapping
 {
-  is_json_GET(
-    '/map/homo_sapiens/GRCh37/6/GRCh37',
+  cmp_deeply(json_GET(
+    '/map/homo_sapiens/GRCh37/6/GRCh37', 'map homo_sapiens'),
     {"mappings" => [{
       "original" => {
         "seq_region_name" => "6","strand" => 1,
@@ -79,8 +80,8 @@ my $basic_mapping = { mappings => [
 
 #cDNA mapping
 {
-  is_json_GET(
-    '/map/cdna/ENST00000314040/292..297',
+  cmp_deeply(json_GET(
+    '/map/cdna/ENST00000314040/292..297', 'map transcript the hard way'),
     $basic_mapping,
     'Mapping transcript cDNA to multi-region position to genome'
   );
@@ -88,8 +89,8 @@ my $basic_mapping = { mappings => [
 
 #CDS mapping
 {
-  is_json_GET(
-    '/map/cds/ENST00000314040/22..27',
+  cmp_deeply(json_GET(
+    '/map/cds/ENST00000314040/22..27', 'map cds the hard way'),
     $basic_mapping,
     'Mapping transcript CDS to multi-region position to genome'
   );
@@ -97,8 +98,8 @@ my $basic_mapping = { mappings => [
 
 #protein mapping
 {
-  is_json_GET(
-    '/map/translation/ENSP00000320396/8..9',
+  cmp_deeply(json_GET(
+    '/map/translation/ENSP00000320396/8..9','map translation the hard way'),
     $basic_mapping,
     'Mapping protein to multi-region position to genome'
   );
@@ -114,8 +115,8 @@ my $basic_mapping_cdna_including_original_region = { mappings => [
   ]};
 #cDNA mapping with include_original_region option
 {
-  is_json_GET(
-    '/map/cdna/ENST00000314040/292..297?include_original_region=1',
+  cmp_deeply(json_GET(
+    '/map/cdna/ENST00000314040/292..297?include_original_region=1', 'map cdna'),
     $basic_mapping_cdna_including_original_region,
     'Mapping transcript cDNA to multi-region position to genome with include_original_region option'
   );
@@ -132,8 +133,8 @@ my $basic_mapping_cds_including_original_region = {mappings => [
 
 #CDS mapping with include_original_region option
 {
-  is_json_GET(
-    '/map/cds/ENST00000314040/22..27?include_original_region=1',
+  cmp_deeply(json_GET(
+    '/map/cds/ENST00000314040/22..27?include_original_region=1', 'map cds with original region'),
     $basic_mapping_cds_including_original_region,
     'Mapping transcript CDS to multi-region position to genome with include_original_region option'
   );
@@ -142,8 +143,8 @@ my $basic_mapping_cds_including_original_region = {mappings => [
 # The following tests are for objects with different types but the same stable id.     
 #cDNA mapping
 {
-  is_json_GET(
-    '/map/cdna/CCDS10020.1/100..300',
+  cmp_deeply(json_GET(
+    '/map/cdna/CCDS10020.1/100..300', 'map cdna'),
     { mappings => [
       {
         "assembly_name"=>"GRCh37","end"=>28081775,"seq_region_name"=>"15","gap"=>0,
@@ -160,8 +161,8 @@ my $basic_mapping_cds_including_original_region = {mappings => [
 
 #CDS mapping
 {
-  is_json_GET(
-    '/map/cds/CCDS10020.1/100..300',
+  cmp_deeply(json_GET( 
+    '/map/cds/CCDS10020.1/100..300', 'map cds'),
     { "mappings" => [
       {
         "assembly_name"=>"GRCh37","end"=>28081775,"seq_region_name"=>"15","gap"=>0,
@@ -178,8 +179,8 @@ my $basic_mapping_cds_including_original_region = {mappings => [
 
 #protein mapping
 {
-  is_json_GET(
-    '/map/translation/CCDS10020.1/100..300',
+  cmp_deeply(json_GET( 
+    '/map/translation/CCDS10020.1/100..300', 'map translation'),
     { "mappings" => [
       {
         "assembly_name"=>"GRCh37","end"=>28032093,"seq_region_name"=>"15","gap"=>0,

--- a/t/ontology.t
+++ b/t/ontology.t
@@ -25,6 +25,7 @@ BEGIN {
 }
 
 use Test::More;
+use Test::Deep;
 use Catalyst::Test ();
 use Bio::EnsEMBL::Test::MultiTestDB;
 
@@ -33,7 +34,7 @@ Catalyst::Test->import('EnsEMBL::REST');
 
 my $term = "SO:0001506";
 
-is_json_GET("ontology/descendants/$term?zero_distance=0",
+cmp_bag(json_GET("ontology/descendants/$term?zero_distance=0", 'ontology/descendants zero_distance off'),
    [
        {
            "ontology" => "SO",
@@ -56,7 +57,7 @@ is_json_GET("ontology/descendants/$term?zero_distance=0",
    ], 'Check functionality of zero-distance flag'
 );
 
-is_json_GET("ontology/descendants/$term?zero_distance=1",
+cmp_bag(json_GET("ontology/descendants/$term?zero_distance=1", 'ontology/descendants zero_distance on'),
    [
        {
            "accession" => "SO:0001506",

--- a/t/overlap.t
+++ b/t/overlap.t
@@ -25,6 +25,7 @@ BEGIN {
 }
 use Test::More;
 use Test::Differences;
+use Test::Deep;
 use Catalyst::Test ();
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Test::TestUtils;
@@ -74,7 +75,7 @@ my $base = '/overlap/region/homo_sapiens';
   is(scalar(@{$json}), 7, '7 features representing gene models');
   
   my ($gene) = grep { $_->{feature_type} eq 'gene' } @{$json};
-  eq_or_diff_data($gene, {
+  cmp_deeply($gene, {
     id => 'ENSG00000176515',
     gene_id => 'ENSG00000176515',
     biotype => 'protein_coding',
@@ -192,7 +193,7 @@ my $base = '/overlap/region/homo_sapiens';
   my $expected_count = 2;
   my $json = json_GET("$base/$region?feature=variation", 'Fetching variations at '.$region);
   is(scalar(@{$json}), $expected_count, 'Expected variations at '.$region);
-  eq_or_diff_data($json->[0],{
+  cmp_deeply($json->[0],{
     start => 1001893,
     assembly_name => 'GRCh37',
     clinical_significance => [], 
@@ -233,7 +234,7 @@ my $base = '/overlap/region/homo_sapiens';
   my $region = '6:1000000..1010000';
   my $json = json_GET("$base/$region?feature=repeat", 'Getting RepeatFeature JSON');
   is(22, scalar(@{$json}), 'Searching for 22 repeats');
-  eq_or_diff_data($json->[0], {
+  cmp_deeply($json->[0], {
     start => 1000732,
     assembly_name => 'GRCh37',
     end => 1000776,
@@ -247,7 +248,7 @@ my $base = '/overlap/region/homo_sapiens';
 #Simple feature testing
 {
   my $region = '6:1020000..1030000';
-  is_json_GET("$base/$region?feature=simple", [{
+  cmp_deeply(json_GET("$base/$region?feature=simple","fetch simple_feature"), [{
     start => 1026863,
     assembly_name => 'GRCh37',
     end => 1027454,
@@ -266,7 +267,7 @@ my $base = '/overlap/region/homo_sapiens';
 #Band information testing
 {
   my $region = '6:1020000..1030000';
-  is_json_GET("$base/$region?feature=band", [{
+  cmp_deeply(json_GET("$base/$region?feature=band", "fetch band"), [{
     start => 1026863,
     assembly_name => 'GRCh37',
     end => 1027454,
@@ -282,7 +283,7 @@ my $base = '/overlap/region/homo_sapiens';
 #Regulatory feature testing
 {
   my $region = '1:76429380..76430144';
-  is_json_GET("$base/$region?feature=regulatory", [{
+  cmp_deeply(json_GET("$base/$region?feature=regulatory", 'Get regulatory_feature'), [{
     id => 'ENSR00000105157',                   
     bound_end => 76430144,                     
     bound_start => 76429380,                   
@@ -299,7 +300,7 @@ my $base = '/overlap/region/homo_sapiens';
 #Motif feature testing
 {
   my $region = '1:23034888..23034896';
-  is_json_GET("$base/$region?feature=motif", [{
+  cmp_deeply(json_GET("$base/$region?feature=motif","Get motif_feature"), [{
     binding_matrix => 'MA0597.1', 
     end => 23034896,                         
     feature_type => 'motif',     
@@ -315,7 +316,7 @@ my $base = '/overlap/region/homo_sapiens';
 #Probe feature testing
 {
   my $region = '1:1020000..1030000';
-  is_json_GET("$base/$region?feature=array_probe", [{
+  cmp_deeply(json_GET("$base/$region?feature=array_probe","Get probe_feature"), [{
     end => 1020593,                          
     feature_type => 'array_probe', 
     microarray => 'HuEx-1_0-st-v2',          
@@ -350,7 +351,7 @@ my $base = '/overlap/region/homo_sapiens';
     sanger_project => 'bA550K21',
     well_name => 'Chr6tp-3D12',
   };
-  is_json_GET("$base/$region?feature=misc", [
+  cmp_deeply(json_GET("$base/$region?feature=misc","Get misc_feature"), [
   {
     start => 1072318,
     assembly_name => 'GRCh37',
@@ -368,7 +369,7 @@ my $base = '/overlap/region/homo_sapiens';
   $thirty_k_feature  
   ], 'Getting misc_feature as JSON with no limits');
   
-  is_json_GET("$base/$region?feature=misc;misc_set=cloneset_30k",
+  cmp_deeply(json_GET("$base/$region?feature=misc;misc_set=cloneset_30k","Get misc_feature from cloneset_30k"),
      [$thirty_k_feature], 'Getting misc_feature as JSON with misc_set limit of cloneset_30k');
 }
 

--- a/t/phenotype_annotation.t
+++ b/t/phenotype_annotation.t
@@ -26,10 +26,10 @@ BEGIN {
 
 use Test::More;
 use Test::Differences;
+use Test::Deep;
 use Catalyst::Test ();
 use Bio::EnsEMBL::Test::TestUtils;
 use Bio::EnsEMBL::Test::MultiTestDB;
-use Data::Dumper;
 
 my $dba = Bio::EnsEMBL::Test::MultiTestDB->new('homo_sapiens');
 my $multi = Bio::EnsEMBL::Test::MultiTestDB->new('multi');
@@ -66,21 +66,21 @@ my $expected_data2 = [];
 my $accession_query = 'accession/homo_sapiens/Orphanet:130';
 
 my $json1 = json_GET("$base/$accession_query", 'get by ontology accession');
-eq_or_diff($json1, $expected_data1, "Checking the get result from phenotype/accession");
+cmp_bag($json1, $expected_data1, "Checking the get result from phenotype/accession");
 
 
 ## get by term
 my $term_query = 'term/homo_sapiens/Brugada%20syndrome';
 
 my $json2 = json_GET("$base/$term_query", 'get by ontology term');
-eq_or_diff($json2, $expected_data1, "Checking the get result from phenotype/term");
+cmp_bag($json2, $expected_data1, "Checking the get result from phenotype/term");
 
 
 ## get by term & bad source
 my $term_source_query = 'term/homo_sapiens/Brugada%20syndrome?source=turnip';
 
 my $json3 = json_GET("$base/$term_source_query", 'get by ontology term & source');
-eq_or_diff($json3, $expected_data2, "Checking the get result from phenotype/term & source");
+cmp_bag($json3, $expected_data2, "Checking the get result from phenotype/term & source");
 
 
 ## get by term & good source
@@ -88,14 +88,14 @@ my $term_source_query2 = 'term/homo_sapiens/Brugada%20syndrome?source=DGVa';
 
 my $expected_data = [];
 my $json4 = json_GET("$base/$term_source_query2", 'get by ontology term & source');
-eq_or_diff($json4, $expected_data1, "Checking the get result from phenotype/term & source");
+cmp_bag($json4, $expected_data1, "Checking the get result from phenotype/term & source");
 
 
 ## get by accession inc children
 my $accession_child_query = 'accession/homo_sapiens/Orphanet:101934?include_children=1';
 
 my $json5 = json_GET("$base/$accession_child_query", 'get by ontology accession & child terms');
-eq_or_diff($json5, $expected_data1, "Checking the get result from phenotype/accession with child terms");
+cmp_bag($json5, $expected_data1, "Checking the get result from phenotype/accession with child terms");
 
 
 done_testing();

--- a/t/phenotype_gene.t
+++ b/t/phenotype_gene.t
@@ -27,6 +27,7 @@ BEGIN {
 use JSON;
 use Test::More;
 use Test::Differences;
+use Test::Deep;
 use Catalyst::Test();
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Test::TestUtils;
@@ -75,27 +76,27 @@ my $gene_name='FOXF2';
   my $expected_data = [
           {
             Gene => "ENSG00000137273",
-	    attributes => {
-	      external_reference => 'PMID:8626802'  
-	    },
-	    description => 'positive regulation of transcription from RNA polymerase II promoter',
-	    location => '6:1312675-1314992',
-	    source => 'GOA'
+            attributes => {
+              external_reference => 'PMID:8626802'  
             },
-	  {
-	    Gene => "ENSG00000137273",
-	    attributes => {
-	      external_reference => 'PMID:8626802'  
-	    },
-	    description => 'soft palate development',
-	    location => '6:1312675-1314992',
-	    source => 'GOA' 
+            description => 'positive regulation of transcription from RNA polymerase II promoter',
+            location => '6:1312675-1314992',
+            source => 'GOA'
+          },
+          {
+            Gene => "ENSG00000137273",
+            attributes => {
+              external_reference => 'PMID:8626802'  
+            },
+            description => 'soft palate development',
+            location => '6:1312675-1314992',
+            source => 'GOA' 
           }
         ];
 	
   my $json = json_GET("$base/$gene", 'Gene with 2 phenotype features associated from GOAs ');
   cmp_ok(scalar(@{$json}), "==", $expected, 'Gene with 2 phenotype associations found');
-  eq_or_diff($json, $expected_data, "Checking the result content from the phenotype/gene REST call");
+  cmp_bag($json, $expected_data, "Checking the result content from the phenotype/gene REST call");
 }
 
 #Get Gene phenotype features given gene name
@@ -105,27 +106,27 @@ my $gene_name='FOXF2';
   my $expected_data = [
           {
             Gene => "ENSG00000137273",
-	    attributes => {
-	      external_reference => 'PMID:8626802'  
-	    },
-	    description => 'positive regulation of transcription from RNA polymerase II promoter',
-	    location => '6:1312675-1314992',
-	    source => 'GOA'
+            attributes => {
+              external_reference => 'PMID:8626802'  
             },
-	  {
-	    Gene => "ENSG00000137273",
-	    attributes => {
-	      external_reference => 'PMID:8626802'  
-	    },
-	    description => 'soft palate development',
-	    location => '6:1312675-1314992',
-	    source => 'GOA' 
+            description => 'positive regulation of transcription from RNA polymerase II promoter',
+            location => '6:1312675-1314992',
+            source => 'GOA'
+          },
+          {
+            Gene => "ENSG00000137273",
+            attributes => {
+              external_reference => 'PMID:8626802'  
+            },
+            description => 'soft palate development',
+            location => '6:1312675-1314992',
+            source => 'GOA' 
           }
         ];
 	
   my $json = json_GET("$base/$gene_name", 'Gene with 2 phenotype features associated from GOAs ');
   cmp_ok(scalar(@{$json}),"==", $expected, 'Gene with 2 phenotype associations found');
-  eq_or_diff($json, $expected_data, "Checking the result content from the phenotype/gene REST call");
+  cmp_bag($json, $expected_data, "Checking the result content from the phenotype/gene REST call");
 }
 
 
@@ -135,16 +136,16 @@ my $gene_name='FOXF2';
 
   my $expected_data = [
            {
-	    Gene => 'ENSG00000137273',
+      Gene => 'ENSG00000137273',
             attributes => {                        
               external_reference => 'PMID:8626802'
             },                                                       
             description => 'positive regulation of transcription from RNA polymerase II promoter',
             location => '6:1312675-1314992',  
             source => 'GOA'                  
-       	  },  
+          },  
           {                                                                                
-	    Gene => 'ENSG00000137273',
+      Gene => 'ENSG00000137273',
             attributes => {                        
               external_reference => 'PMID:8626802'
             },                                                                       
@@ -152,21 +153,21 @@ my $gene_name='FOXF2';
             location => '6:1312675-1314992',                                                 
             source => 'GOA'                                                               
           },       
-	  {
+         {
             Variation => 'rs2299222',
-	    attributes => {
-	      associated_gene => 'YES1,FOXF2',
-	      external_reference => 'pubmed/17122850'
-	    },
-	    description => 'ACHONDROPLASIA',
-	    location => '7:86442404-86442404',
-	    source => 'dbSNP'
+            attributes => {
+            associated_gene => 'YES1,FOXF2',
+            external_reference => 'pubmed/17122850'
+          },
+            description => 'ACHONDROPLASIA',
+            location => '7:86442404-86442404',
+            source => 'dbSNP'
           }
         ];
-	
+
   my $json = json_GET("$base/$gene_name?include_associated=1", 'Gene with 1 phenotype feature associated with a variant');
   cmp_ok(scalar(@{$json}),"==", $expected, 'Gene with 1 phenotype association with variant found');
-  eq_or_diff($json, $expected_data, "Checking the result content from the phenotype/gene REST call");
+  cmp_bag($json, $expected_data, "Checking the result content from the phenotype/gene REST call");
 }
 
 
@@ -176,7 +177,7 @@ my $gene_name='FOXF2';
 
   my $expected_data = [
           {
-	    Gene => 'ENSG00000137273',
+            Gene => 'ENSG00000137273',
             attributes => {                        
               external_reference => 'PMID:8626802'
             },                                                       
@@ -185,7 +186,7 @@ my $gene_name='FOXF2';
             source => 'GOA'                  
        	  },  
           {                                                                                
-	    Gene => 'ENSG00000137273',
+            Gene => 'ENSG00000137273',
             attributes => {                        
               external_reference => 'PMID:8626802'
             },                                                                       
@@ -193,17 +194,17 @@ my $gene_name='FOXF2';
             location => '6:1312675-1314992',                                                 
             source => 'GOA'                                                               
           },
-	  {
-	    StructuralVariation => 'esv1234',
-	    description => 'COSMIC:tumour_site:skin',
-	    location => '6:1312670-1390070',
-	    source => 'DGVa'
-	  }
+          {
+            StructuralVariation => 'esv1234',
+            description => 'COSMIC:tumour_site:skin',
+            location => '6:1312670-1390070',
+            source => 'DGVa'
+          }
         ];
 	
   my $json = json_GET("$base/$gene_name?include_overlap=1", 'Gene with 3 phenotype feature overlap');
   cmp_ok(scalar(@{$json}), "==", $expected, 'Gene with 3 phenotype feature overlaps');
-  eq_or_diff($json, $expected_data, "Checking the result content from the phenotype/gene REST call");
+  cmp_bag($json, $expected_data, "Checking the result content from the phenotype/gene REST call");
 }
 
 done_testing();

--- a/t/phenotype_region.t
+++ b/t/phenotype_region.t
@@ -27,6 +27,7 @@ BEGIN {
 use JSON;
 use Test::More;
 use Test::Differences;
+use Test::Deep;
 use Catalyst::Test();
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Test::TestUtils;
@@ -73,7 +74,7 @@ my $var_region = '13:86442400:86442410';
 
   my $json = json_GET("$base/$var_region?feature_type=Variation", '1 Variation with phenotype feature associated from chr 13');
   is(scalar(@{$json}), $expected, 'Variation with phenotype association found in the region');
-  eq_or_diff($json, $expected_data, "Checking the result content from the phenotype/region REST call");
+  cmp_bag($json, $expected_data, "Checking the result content from the phenotype/region REST call");
 }
 
 # Get the light result version (only phenotypes)
@@ -95,7 +96,7 @@ my $var_region = '13:86442400:86442410';
 
   my $json = json_GET("$base/$var_region?feature_type=Variation;only_phenotypes=1", '1 Variation with phenotype feature associated from chr 13 - light results');
   is(scalar(@{$json}), $expected, 'Variation with phenotype association found in the region - light result');
-  eq_or_diff($json, $expected_data, "Checking the result content from the phenotype/region REST call - light result");
+  cmp_bag($json, $expected_data, "Checking the result content from the phenotype/region REST call - light result");
 }
 
 

--- a/t/taxonomy.t
+++ b/t/taxonomy.t
@@ -25,6 +25,7 @@ BEGIN {
 }
 
 use Test::More;
+use Test::Deep;
 use Catalyst::Test ();
 use Bio::EnsEMBL::Test::MultiTestDB;
 
@@ -40,14 +41,13 @@ $expected = {scientific_name => "Homo sapiens",
 };
 # Leaf => 1 is only true in test data.
 
-is_json_GET("/taxonomy/id/9606?content-type=application/json;simple=1", $expected, 'Check id endpoint with valid data');
+cmp_deeply(json_GET("/taxonomy/id/9606?content-type=application/json;simple=1",'taxonomy/id'), $expected, 'Check id endpoint with valid data');
 action_bad("/taxonomyid/-1", 'ID should not be found.');
 
-is_json_GET("/taxonomy/name/human?simple=1", [$expected], 'Test human lookup with name');
+cmp_deeply(json_GET("/taxonomy/name/human?simple=1",'taxonomy/name'), [$expected], 'Test human lookup with name');
 my $result = json_GET("/taxonomy/name/canis%?simple=1",'Select wolf');
-is($result->[0]->{'id'},'9612','Wolf found by wildcarded Canis');
-is($result->[1]->{'id'},'9615','Beagle found by wildcarded Canis');
-is($result->[2]->{'id'},'9611','Canis node found by wildcarded Canis');
+
+cmp_bag([ map { $_->{id} } @$result], ['9612','9615','9611'],'Wolf, Beagle and Canis found via wildcard on Canis');
 
 $result = json_GET("/taxonomy/name/canis familiaris?simple=1",'Select dog');
 is($result->[0]->{'id'},'9615','Dog called by name');
@@ -96,7 +96,7 @@ $expected = [{
 
 }];
 
-is_json_GET("/taxonomy/classification/2759?content-type=application/json", $expected, 'Test classification response for Eukaryotes');
+cmp_bag(json_GET("/taxonomy/classification/2759?content-type=application/json",'taxononmy/classification'), $expected, 'Test classification response for Eukaryotes');
 action_bad("/taxonomy/classification?A;content-type=application/json", 'Classification in bad data case');
 
 done_testing();

--- a/t/transcript_haplotypes.t
+++ b/t/transcript_haplotypes.t
@@ -26,6 +26,7 @@ BEGIN {
 
 use Test::More;
 use Test::Differences;
+use Test::Deep;
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Data::Dumper;
 use Bio::EnsEMBL::Test::TestUtils;
@@ -162,7 +163,7 @@ $expected_output = {
   'total_haplotype_count' => 4
 };
 
-eq_or_diff($json, $expected_output, "Example transcript");
+cmp_deeply($json, $expected_output, "Example transcript");
 
 # request sequence
 $th_get = '/transcript_haplotypes/homo_sapiens/ENST00000314040?sequence=1';
@@ -174,7 +175,7 @@ $expected_output = {
   '31c01f1c180d58287b3f950852d4673f' => 'MLSPLWLQISKRPRPEVSVSNVCFSSALPTSNPTSLTLKHHNIFVLRVALEIIQYSVHGGRNRKPLEVTSLAYSCPENWWQKQIGVQPPDVHASALSPKPCVSWSRPLSLLSSTILFWKTHDERADFSKLHS*'
 };
 
-eq_or_diff({map {$_->{hex} => $_->{seq}} @{$json->{protein_haplotypes}}}, $expected_output, "Example transcript with sequence");
+cmp_deeply({map {$_->{hex} => $_->{seq}} @{$json->{protein_haplotypes}}}, $expected_output, "Example transcript with sequence");
 
 # request aligned sequences
 $th_get = '/transcript_haplotypes/homo_sapiens/ENST00000314040?aligned_sequences=1';
@@ -195,7 +196,7 @@ $expected_output = {
   ]
 };
 
-eq_or_diff({map {$_->{hex} => $_->{aligned_sequences}} @{$json->{protein_haplotypes}}}, $expected_output, "Example transcript with aligned_sequences");
+cmp_deeply({map {$_->{hex} => $_->{aligned_sequences}} @{$json->{protein_haplotypes}}}, $expected_output, "Example transcript with aligned_sequences");
 
 
 # request samples
@@ -215,7 +216,7 @@ $expected_output = {
   }
 };
 
-eq_or_diff({map {$_->{hex} => $_->{samples}} @{$json->{cds_haplotypes}}}, $expected_output, "Example transcript with samples");
+cmp_deeply({map {$_->{hex} => $_->{samples}} @{$json->{cds_haplotypes}}}, $expected_output, "Example transcript with samples");
 
 
 done_testing();

--- a/t/variation.t
+++ b/t/variation.t
@@ -26,6 +26,7 @@ BEGIN {
 
 use Test::More;
 use Test::Differences;
+use Test::Deep;
 use Catalyst::Test ();
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Test::TestUtils;
@@ -42,13 +43,13 @@ my $base = '/variation/homo_sapiens';
   my $json = json_GET("$base/$id", 'Variation feature');
   #is(scalar(@$json), 1, '1 variation feature returned');
   my $expected_variation_1 = {source => 'Variants (including SNPs and indels) imported from dbSNP', name => $id, MAF => '0.123049', minor_allele => 'A', ambiguity => 'R', var_class => 'SNP', synonyms => [], evidence => ['Multiple_observations','1000Genomes'], ancestral_allele => 'G', most_severe_consequence => 'intron_variant', mappings => [{"assembly_name" => "GRCh37", "location"=>"18:23821095-23821095", "strand" => 1, "start" => 23821095, "end" => 23821095, "seq_region_name" => "18", "coord_system" => "chromosome","allele_string"=>"G/A"}]};
-  eq_or_diff($json, $expected_variation_1, "Checking the result from the variation endpoint");
+  cmp_deeply($json, $expected_variation_1, "Checking the result from the variation endpoint");
 
 # Include phenotype information
   my $expected_phenotype = { %{$expected_variation_1},
   "phenotypes" => [{"source" => "DGVa","variants" => undef, "ontology_accessions" => ["Orphanet:130"], "trait" => "BRUGADA SYNDROME", "genes" => undef}]};
   my $phen_json = json_GET("$base/$id?phenotypes=1", "Phenotype info");
-  eq_or_diff($phen_json, $expected_phenotype, "Returning phenotype information");
+  cmp_deeply($phen_json, $expected_phenotype, "Returning phenotype information");
 
 # Get additional genotype information
   $id = 'rs67521280';
@@ -56,13 +57,13 @@ my $base = '/variation/homo_sapiens';
   my $expected_genotype = { %{$expected_variation_2}, 
   genotypes => [{genotype => "GT|GT", gender => "Male", sample => "J. CRAIG VENTER", submission_id => 'ss95559393'}] };
   my $genotype_json = json_GET("$base/$id?genotypes=1", "Genotype info");
-  eq_or_diff($genotype_json, $expected_genotype, "Returning genotype information");
+  cmp_deeply($genotype_json, $expected_genotype, "Returning genotype information");
 
 # Include population allele frequency information
   my $expected_pops = { %{$expected_variation_2},
   populations => [{population => "HUMANGENOME_JCVI:J. Craig Venter",frequency => 1,allele => "GT",allele_count => 2, submission_id => 'ss95559393'}]};
   my $pops_json = json_GET("$base/$id?pops=1", "Population info");
-  eq_or_diff($pops_json, $expected_pops, "Returning population information");
+  cmp_deeply($pops_json, $expected_pops, "Returning population information");
 
 # Include population_genotype information ( data faked)
    my $expected_pop_genos = { %{$expected_variation_2},
@@ -76,7 +77,7 @@ my $base = '/variation/homo_sapiens';
  ]};
  
    my $pop_genos_json = json_GET("$base/$id?population_genotypes=1", "Population_genotype info");
-   eq_or_diff($pop_genos_json, $expected_pop_genos, "Returning population_genotype information");
+   cmp_deeply($pop_genos_json, $expected_pop_genos, "Returning population_genotype information");
 
 my $post_data = '{ "ids" : ["rs142276873","rs67521280"]}';
 my $expected_result = { rs142276873 => $expected_variation_1, rs67521280 => $expected_variation_2 };
@@ -137,7 +138,18 @@ my $publication_output =
   is(ref($variants_json), 'ARRAY', 'Array wanted from endpoint');
   
   # Check the variations
-  eq_or_diff($variants_json, $publication_output, "Checking PMID endpoint");
+  # Must be checked individually due to variable ordering in output. is_json doesn't ignore order, cmp_bag cannot handle arrays within hashes
+  is($variants_json->[0]->{source}, $publication_output->[0]->{source} ,'PMID source key');
+  is_deeply($variants_json->[0]->{mappings},$publication_output->[0]->{mappings},'PMID mappings key');
+  cmp_bag($variants_json->[0]->{synonyms},$publication_output->[0]->{synonyms},'PMID synonyms');
+  is($variants_json->[0]->{name}, $publication_output->[0]->{name} ,'PMID name key');
+  is($variants_json->[0]->{MAF},$publication_output->[0]->{MAF} ,'PMID MAF key'); # Interestingly these are not numerically equal under certain testing conditions...
+  is($variants_json->[0]->{ambiguity}, $publication_output->[0]->{ambiguity} ,'PMID ambiguity key');
+  is($variants_json->[0]->{var_class}, $publication_output->[0]->{var_class} ,'PMID source key');
+  ok(!$variants_json->[0]->{ancestral_allele},'PMID ancestral_allele key not set');
+  is($variants_json->[0]->{minor_allele}, $publication_output->[0]->{minor_allele} ,'PMID minor_allele key');
+  is($variants_json->[0]->{most_severe_consequence}, $publication_output->[0]->{most_severe_consequence} ,'PMID most_severe_consequence key');
+
  
   # Invalid species
   action_bad(
@@ -166,7 +178,16 @@ my $publication_output =
   is(ref($variants_json), 'ARRAY', 'Array wanted from endpoint');
   
   # Check the variations
-  eq_or_diff($variants_json, $publication_output, "Checking PMCID endpoint");
+  is($variants_json->[0]->{source}, $publication_output->[0]->{source} ,'PMID source key');
+  is_deeply($variants_json->[0]->{mappings},$publication_output->[0]->{mappings},'PMID mappings key');
+  cmp_bag($variants_json->[0]->{synonyms},$publication_output->[0]->{synonyms},'PMID synonyms');
+  is($variants_json->[0]->{name}, $publication_output->[0]->{name} ,'PMID name key');
+  is($variants_json->[0]->{MAF},$publication_output->[0]->{MAF} ,'PMID MAF key');
+  is($variants_json->[0]->{ambiguity}, $publication_output->[0]->{ambiguity} ,'PMID ambiguity key');
+  is($variants_json->[0]->{var_class}, $publication_output->[0]->{var_class} ,'PMID source key');
+  ok(!$variants_json->[0]->{ancestral_allele},'PMID ancestral_allele key not set');
+  is($variants_json->[0]->{minor_allele}, $publication_output->[0]->{minor_allele} ,'PMID minor_allele key');
+  is($variants_json->[0]->{most_severe_consequence}, $publication_output->[0]->{most_severe_consequence} ,'PMID most_severe_consequence key');
  
   # Invalid species
   action_bad(

--- a/t/vep.t
+++ b/t/vep.t
@@ -26,6 +26,7 @@ BEGIN {
 
 use Test::More;
 use Test::Differences;
+use Test::Deep;
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Test::TestUtils;
 use Catalyst::Test ();
@@ -117,7 +118,7 @@ my $vep_output =
 
 # Test vep/region
 my $json = json_GET($vep_get,'GET a VEP region');
-eq_or_diff($json, $vep_output, 'Example vep region get message');
+cmp_bag($json, $vep_output, 'Example vep region get message');
 
 
 # test with non-toplevel sequence (should transform to toplevel)
@@ -148,6 +149,7 @@ $json = json_GET($vep_get,'GET a VEP region on a non-toplevel sequence');
 my $vep_post = '/vep/homo_sapiens/region';
 my $vep_post_body = '{ "variants" : ["7 34381884 var1 C T . . .",
                                      "7 86442404 var2 T C . . ."]}';
+
 
 $vep_output =
 [{
@@ -272,7 +274,7 @@ $vep_output =
 }];
 
 $json = json_POST($vep_post,$vep_post_body,'POST a selection of regions to the VEP');
-eq_or_diff($json,$vep_output, "VEP region POST");
+cmp_bag($json,$vep_output, "VEP region POST");
 
 
 # test vep/id
@@ -321,7 +323,7 @@ $vep_output =
   }];
 
 $json = json_GET($vep_id_get,'GET consequences for Variation ID');
-eq_or_diff($json, $vep_output, 'VEP id GET');
+cmp_bag($json, $vep_output, 'VEP id GET');
 
 
 my $vep_id_post = '/vep/homo_sapiens/id';
@@ -406,7 +408,7 @@ $vep_output =
 
 
 $json = json_POST($vep_id_post,$vep_id_body,'VEP ID list POST');
-eq_or_diff($json, $vep_output, 'VEP id POST');
+cmp_bag($json, $vep_output, 'VEP id POST');
 
 
 # test vep/hgvs with a genomic coord
@@ -449,7 +451,7 @@ $vep_output = [{
 }];
 
 $json = json_GET($vep_hgvs_get,'GET consequences for genomic HGVS notation');
-eq_or_diff($json, $vep_output, 'VEP genomic HGVS GET');
+cmp_bag($json, $vep_output, 'VEP genomic HGVS GET');
 
 # test vep/hgvs with a transcript coord
 $vep_hgvs_get = '/vep/homo_sapiens/hgvs/ENST00000314040:c.311G>T?content-type=application/json';
@@ -509,7 +511,7 @@ $vep_output = [{
 }];
 
 $json = json_GET($vep_plugin_get,'GET consequences with test plugin');
-eq_or_diff($json, $vep_output, 'VEP plugin test');
+cmp_bag($json, $vep_output, 'VEP plugin test');
 
 # test using transcript_id
 my $vep_transcript_id_get = '/vep/homo_sapiens/region/7:86442404-86442404:1/C?content-type=application/json&transcript_id=ENST00000361669';
@@ -545,7 +547,7 @@ $vep_output = [
 ];                                               
 
 $json = json_GET($vep_transcript_id_get,'GET consequences with transcript_id');
-eq_or_diff($json, $vep_output, 'VEP transcript filter test');
+cmp_bag($json, $vep_output, 'VEP transcript filter test');
 
 # test using refseq cache
 my $vep_refseq_get = '/vep/homo_sapiens/region/7:34097707-34097707:1/C?content-type=application/json&refseq=1';

--- a/t/xrefs.t
+++ b/t/xrefs.t
@@ -25,6 +25,7 @@ BEGIN {
 }
 
 use Test::More;
+use Test::Deep;
 use Catalyst::Test ();
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Test::Differences;
@@ -71,7 +72,7 @@ my $UPI = 'UPI0000073BC4';
     version => '0',
   };
   my ($actual) = grep { $_->{primary_id} eq $go_id } @{$json};
-  eq_or_diff_data($actual, $expected, 'Checking GO Xrefs bring along their linkage types');
+  cmp_deeply($actual, $expected, 'Checking GO Xrefs bring along their linkage types');
 }
 
 # Check identity xrefs
@@ -92,7 +93,7 @@ my $UPI = 'UPI0000073BC4';
     xref_start => 1, xref_end => 132, xref_identity => 100,
   };
   my ($actual) = grep { $_->{primary_id} eq $external_id } @{$json};
-  eq_or_diff_data($actual, $expected, 'Checking identity Xrefs bring along their alignment data. Using '.$external_id); 
+  cmp_deeply($actual, $expected, 'Checking identity Xrefs bring along their alignment data. Using '.$external_id); 
 }
 
 #Name based xref lookup


### PR DESCRIPTION
Description
Whilst comparing the e! and EG family endpoints, Matthieu found a couple of minor issues in our documentation:

https://rest.ensembl.org/documentation/info/family_member_id : db_type, object_type and species are not used in this endpoint (they're only used in the member_symbol endpoint)
https://rest.ensembl.org/documentation/info/family : the documentation is missing the member_source option

Use case
https://rest.ensembl.org/documentation/info/family_member_id : db_type, object_type and species are not used in this endpoint (they're only used in the member_symbol endpoint)
https://rest.ensembl.org/documentation/info/family : the documentation is missing the member_source option

Benefits
Clarity

Possible Drawbacks
none

Testing
N/A

Yes.

N/A

Changelog
no