### PR TITLE
Release/92

### DIFF
--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -257,6 +257,11 @@
         description=The type of sequence to bring back. Setting it to none results in no sequence being returned. Note: dependant on the setting for "aligned", If aligned=1, this will override sequence=none
         default=protein
       </sequence>
+      <member_source>
+        type=Enum(all, ensembl, uniprot)
+        description=The source of the family members that you want returned
+        default=all
+      </member_source>
       <db_type>
         type=String
         description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
@@ -295,17 +300,6 @@
         example=__VAR(compara_gene_stable_id)__
         required=1
       </id>
-      <db_type>
-        type=String
-        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
-        example=core
-      </db_type>
-      <object_type>
-        type=String
-        description=Filter by feature type
-        example=gene
-        example=transcript
-      </object_type>
       <compara>
         type=String
         description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data

--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -459,10 +459,6 @@
         example=__VAR(taxon)__
         example=__VAR(target_taxon)__
       </prune_taxon>
-      <subtree>
-        type=Integer
-        description=Prune the tree by subtree. The subtree id is the long numbers found in the location id. ex: "location":"1:168452256-168452332". subtree = 168452332 or subtree = 168452256
-       </subtree>
       <clusterset_id>
         type=String
         description=Name of the gene-tree resource being queried. Common values are "default" for the standard multi-clade trees (which exclude all non-reference strains) and "murinae" for the trees spanning all mouse strains. By default, the most inclusive analysis will be selected

--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -262,22 +262,6 @@
         description=The source of the family members that you want returned
         default=all
       </member_source>
-      <db_type>
-        type=String
-        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
-        example=core
-      </db_type>
-      <object_type>
-        type=String
-        description=Filter by feature type
-        example=gene
-        example=transcript
-      </object_type>
-      <member_source>
-        type=Enum(all, ensembl, uniprot)
-        description=The source of the family members that you want returned
-        default=all
-      </member_source>
     </params>
     <examples>
       <json>
@@ -350,24 +334,6 @@
         example=__VAR(species_common)__
         required=1
       </species>
-      <db_type>
-        type=String
-        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
-        default=core
-        example=core
-        example=otherfeatures
-      </db_type>
-      <external_db>
-        type=String
-        description=Filter by external database
-        example=__VAR(gene_symbol_db)__
-      </external_db>
-      <object_type>
-        type=String
-        description=Filter by feature type
-        example=gene
-        example=transcript
-      </object_type>
       <compara>
         type=String
         description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
@@ -389,6 +355,24 @@
         description=The source of the family members that you want returned
         default=all
       </member_source>
+      <db_type>
+        type=String
+        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
+        default=core
+        example=core
+        example=otherfeatures
+      </db_type>
+      <external_db>
+        type=String
+        description=Filter by external database
+        example=__VAR(gene_symbol_db)__
+      </external_db>
+      <object_type>
+        type=String
+        description=Filter by feature type
+        example=gene
+        example=transcript
+      </object_type>
     </params>
     <examples>
       <json>

--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -254,9 +254,25 @@
       </aligned>
       <sequence>
         type=Enum(none, cdna, protein)
-        description=The type of sequence to bring back. Setting it to none results in no sequence being returned
+        description=The type of sequence to bring back. Setting it to none results in no sequence being returned. note: dependant on the aligned option. if aligned option is set to 1, this is able to override the sequence=none option. sequence=cdna returns an error unless the uniprot members are filtered out by setting member_source=ensembl
         default=protein
       </sequence>
+      <db_type>
+        type=String
+        description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
+        example=core
+      </db_type>
+      <object_type>
+        type=String
+        description=Filter by feature type
+        example=gene
+        example=transcript
+      </object_type>
+      <member_source>
+        type=Enum(all, ensembl, uniprot)
+        description=The source of the family members that you want returned
+        default=all
+      </member_source>
     </params>
     <examples>
       <json>
@@ -279,12 +295,6 @@
         example=__VAR(compara_gene_stable_id)__
         required=1
       </id>
-      <species>
-        type=String
-        description=Species name/alias
-        example=__VAR(species)__
-        example=__VAR(species_common)__
-      </species>
       <db_type>
         type=String
         description=Restrict the search to a database other than the default. Useful if you need to use a DB other than core
@@ -439,16 +449,20 @@
       </nh_format>
       <prune_species>
         type=String
-        description=Prune the tree by species. Supports all species aliases
+        description=Prune the tree by species. Supports all species aliases. Will return a tree with only the species given
         example=__VAR(species_common)__
         example=__VAR(target_species)__
       </prune_species>
       <prune_taxon>
         type=Integer
-        description=Prune the tree by taxon
+        description=Prune the tree by taxon. Will return a tree	with only the taxons given
         example=__VAR(taxon)__
         example=__VAR(target_taxon)__
       </prune_taxon>
+      <subtree>
+        type=Integer
+        description=Prune the tree by subtree. The subtree id is the long numbers found in the location id. ex: "location":"1:168452256-168452332". subtree = 168452332 or subtree = 168452256
+       </subtree>
       <clusterset_id>
         type=String
         description=Name of the gene-tree resource being queried. Common values are "default" for the standard multi-clade trees (which exclude all non-reference strains) and "murinae" for the trees spanning all mouse strains. By default, the most inclusive analysis will be selected

--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -249,12 +249,12 @@
       </compara>
       <aligned>
         type=Boolean
-        description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
+        description=Return the aligned string if true. Otherwise, return the original sequence (no insertions). Note: If aligned=1, this will override sequence=none
         default=1
       </aligned>
       <sequence>
         type=Enum(none, cdna, protein)
-        description=The type of sequence to bring back. Setting it to none results in no sequence being returned. note: dependant on the aligned option. if aligned option is set to 1, this is able to override the sequence=none option. sequence=cdna returns an error unless the uniprot members are filtered out by setting member_source=ensembl
+        description=The type of sequence to bring back. Setting it to none results in no sequence being returned. Note: dependant on the setting for "aligned", If aligned=1, this will override sequence=none
         default=protein
       </sequence>
       <db_type>
@@ -314,12 +314,12 @@
       </compara>
       <aligned>
         type=Boolean
-        description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
+        description=Return the aligned string if true. Otherwise, return the original sequence (no insertions). Note: If aligned=1, this will override sequence=none
         default=1
       </aligned>
       <sequence>
         type=Enum(none, cdna, protein)
-        description=The type of sequence to bring back. Setting it to none results in no sequence being returned
+        description=The type of sequence to bring back. Setting it to none results in no sequence being returned. Note: dependant on the setting for "aligned", If aligned=1, this will override sequence=none
         default=protein
       </sequence>
       <member_source>
@@ -382,12 +382,12 @@
       </compara>
       <aligned>
         type=Boolean
-        description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
+        description=Return the aligned string if true. Otherwise, return the original sequence (no insertions). Note: If aligned=1, this will override sequence=none
         default=1
       </aligned>
       <sequence>
         type=Enum(none, cdna, protein)
-        description=The type of sequence to bring back. Setting it to none results in no sequence being returned
+        description=The type of sequence to bring back. Setting it to none results in no sequence being returned. Note: dependant on the setting for "aligned", If aligned=1, this will override sequence=none
         default=protein
       </sequence>
       <member_source>
@@ -455,7 +455,7 @@
       </prune_species>
       <prune_taxon>
         type=Integer
-        description=Prune the tree by taxon. Will return a tree	with only the taxons given
+        description=Prune the tree by taxon. Will return a tree with only the taxons given
         example=__VAR(taxon)__
         example=__VAR(target_taxon)__
       </prune_taxon>


### PR DESCRIPTION
Description
Whilst comparing the e! and EG family endpoints, Matthieu found a couple of minor issues in our documentation:

https://rest.ensembl.org/documentation/info/family_member_id : db_type, object_type and species are not used in this endpoint (they're only used in the member_symbol endpoint)
https://rest.ensembl.org/documentation/info/family : the documentation is missing the member_source option

Use case
https://rest.ensembl.org/documentation/info/family_member_id : db_type, object_type and species are not used in this endpoint (they're only used in the member_symbol endpoint)
https://rest.ensembl.org/documentation/info/family : the documentation is missing the member_source option

Benefits
Clarity

Possible Drawbacks
none

Testing
N/A

Yes.

N/A

Changelog
no