### PR TITLE
Added format types to POST endpoints

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -22,6 +22,7 @@ use Moose;
 use namespace::autoclean;
 use Data::Dumper;
 use Bio::EnsEMBL::VEP::Runner;
+use Bio::EnsEMBL::Utils::IO qw/slurp/;
 
 use Try::Tiny;
 
@@ -31,6 +32,52 @@ EnsEMBL::REST->turn_on_config_serialisers(__PACKAGE__);
 BEGIN { 
   extends 'Catalyst::Controller::REST';
 }
+
+# This list describes user overridable variables for this endpoint. It protects other more fundamental variables
+has valid_user_params => ( 
+  is => 'ro', 
+  isa => 'HashRef', 
+  traits => ['Hash'], 
+  handles => { valid_user_param => 'exists' },
+  default => sub { return {
+    map {$_ => 1} (qw/
+    gencode_basic
+    refseq
+    merged
+    all_refseq
+
+    failed
+    variant_class
+    minimal
+
+    everything
+    appris
+    canonical
+    ccds
+    domains
+    hgvs
+    numbers
+    protein
+    tsl
+    uniprot
+    xref_refseq
+    phyloP
+    transcript_id
+    phastCons
+    distance
+    ambiguity
+
+    pick
+    pick_allele
+    per_gene
+    pick_allele_gene
+    flag_pick
+    flag_pick_allele
+    flag_pick_allele_gene
+    pick_order
+  /)}
+  }
+);
 
 with 'EnsEMBL::REST::Role::PostLimiter';
 
@@ -83,7 +130,6 @@ sub get_region_GET {
 sub get_region_POST {
   my ( $self, $c ) = @_;
   my $post_data = $c->req->data;
-
   # $c->log->debug(Dumper $post_data);
   # $c->log->debug(Dumper $config->{'Controller::VEP'});
   # handle user config
@@ -256,6 +302,7 @@ sub get_id_POST {
   unless (exists $post_data->{ids}) {
     $c->go( 'ReturnError', 'custom', [ ' Cannot find "ids" key in your POST. Please check the format of your message against the documentation' ] );
   }
+$config->{format} = 'id';
   my @ids = @{$post_data->{ids}};
   $self->assert_post_size($c,\@ids);
   $self->_give_POST_to_VEP($c,\@ids,$config);
@@ -270,6 +317,7 @@ sub get_hgvs_POST {
   unless (exists $post_data->{hgvs_notations}) {
     $c->go( 'ReturnError', 'custom', [ ' Cannot find "hgvs_notations" key in your POST. Please check the format of your message against the documentation' ] );
   }
+  $config->{format} = 'hgvs';
   my @hgvs = @{$post_data->{hgvs_notations}};
   $self->assert_post_size($c,\@hgvs);
   $self->_give_POST_to_VEP($c,\@hgvs,$config);
@@ -278,44 +326,6 @@ sub get_hgvs_POST {
 sub _include_user_params {
   my ($self,$c,$user_config) = @_;
 
-  # This list stops users altering more crucial variables.
-  my %valid_keys = map {$_ => 1} (qw/
-    gencode_basic
-    refseq
-    merged
-    all_refseq
-
-    failed
-    variant_class
-    minimal
-
-    everything
-    appris
-    canonical
-    ccds
-    domains
-    hgvs
-    numbers
-    protein
-    tsl
-    uniprot
-    xref_refseq
-    phyloP
-    transcript_id
-    phastCons
-    distance
-    ambiguity
-
-    pick
-    pick_allele
-    per_gene
-    pick_allele_gene
-    flag_pick
-    flag_pick_allele
-    flag_pick_allele_gene
-    pick_order
-  /);
-  
   my %vep_params = %{ $c->config->{'Controller::VEP'} };
 
   # stash species
@@ -339,7 +349,7 @@ sub _include_user_params {
   map { $tmp_vep_params{$_} = $user_config->{$_}} keys %{$user_config};
 
   # only copy allowed keys to %vep_params as we don't want users to be able to meddle
-  $vep_params{$_} = $tmp_vep_params{$_} for grep { $valid_keys{$_} } keys %tmp_vep_params;
+  $vep_params{$_} = $tmp_vep_params{$_} for grep { $self->valid_user_param($_) } keys %tmp_vep_params;
   
   # we currently only have cache for human
   if ($c->stash->{species} ne 'homo_sapiens') {
@@ -381,11 +391,9 @@ sub _configure_plugins {
   my $plugin_config_file = $vep_config->{plugin_config};
   return [] unless $plugin_config_file && -e $plugin_config_file;
 
-  open IN, $plugin_config_file or return [];
-  my @content = <IN>;
-  close IN;
-  
-  my $VEP_PLUGIN_CONFIG = eval join('', @content);
+  my $content = [];
+  $content = slurp($plugin_config_file);
+  my $VEP_PLUGIN_CONFIG = eval $content;
   $c->log->warn("Could not eval VEP plugin config file: $@\n") if $@;
 
   # iterate over all defined plugins

--- a/t/vep.t
+++ b/t/vep.t
@@ -26,6 +26,7 @@ BEGIN {
 
 use Test::More;
 use Test::Differences;
+use Test::Deep;
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Test::TestUtils;
 use Catalyst::Test ();
@@ -117,7 +118,7 @@ my $vep_output =
 
 # Test vep/region
 my $json = json_GET($vep_get,'GET a VEP region');
-eq_or_diff($json, $vep_output, 'Example vep region get message');
+cmp_bag($json, $vep_output, 'Example vep region get message');
 
 
 # test with non-toplevel sequence (should transform to toplevel)
@@ -148,6 +149,7 @@ $json = json_GET($vep_get,'GET a VEP region on a non-toplevel sequence');
 my $vep_post = '/vep/homo_sapiens/region';
 my $vep_post_body = '{ "variants" : ["7 34381884 var1 C T . . .",
                                      "7 86442404 var2 T C . . ."]}';
+
 
 $vep_output =
 [{
@@ -272,7 +274,16 @@ $vep_output =
 }];
 
 $json = json_POST($vep_post,$vep_post_body,'POST a selection of regions to the VEP');
-eq_or_diff($json,$vep_output, "VEP region POST");
+
+cmp_bag($json,$vep_output, "VEP region POST");
+
+$vep_post = '/vep/homo_sapiens/id';
+my $vep_post_body_invalid = '{ "ids" : ["invalid_id", "rs186950277", "rs17081232" ]}';
+$json = json_POST($vep_post,$vep_post_body_invalid,'POST a selection of IDs to VEP');
+
+$vep_post = '/vep/homo_sapiens/hgvs';
+$vep_post_body_invalid = '{ "hgvs_notations" : ["invalid_hgvs", "ENST00000314040:c.311G>T"] }';
+$json = json_POST($vep_post,$vep_post_body_invalid,'POST a selection of HGVS variants to VEP');
 
 
 # test vep/id
@@ -321,7 +332,7 @@ $vep_output =
   }];
 
 $json = json_GET($vep_id_get,'GET consequences for Variation ID');
-eq_or_diff($json, $vep_output, 'VEP id GET');
+cmp_bag($json, $vep_output, 'VEP id GET');
 
 
 my $vep_id_post = '/vep/homo_sapiens/id';
@@ -406,7 +417,7 @@ $vep_output =
 
 
 $json = json_POST($vep_id_post,$vep_id_body,'VEP ID list POST');
-eq_or_diff($json, $vep_output, 'VEP id POST');
+cmp_bag($json, $vep_output, 'VEP id POST');
 
 
 # test vep/hgvs with a genomic coord
@@ -449,7 +460,7 @@ $vep_output = [{
 }];
 
 $json = json_GET($vep_hgvs_get,'GET consequences for genomic HGVS notation');
-eq_or_diff($json, $vep_output, 'VEP genomic HGVS GET');
+cmp_bag($json, $vep_output, 'VEP genomic HGVS GET');
 
 # test vep/hgvs with a transcript coord
 $vep_hgvs_get = '/vep/homo_sapiens/hgvs/ENST00000314040:c.311G>T?content-type=application/json';
@@ -509,7 +520,7 @@ $vep_output = [{
 }];
 
 $json = json_GET($vep_plugin_get,'GET consequences with test plugin');
-eq_or_diff($json, $vep_output, 'VEP plugin test');
+cmp_bag($json, $vep_output, 'VEP plugin test');
 
 # test using transcript_id
 my $vep_transcript_id_get = '/vep/homo_sapiens/region/7:86442404-86442404:1/C?content-type=application/json&transcript_id=ENST00000361669';
@@ -545,7 +556,7 @@ $vep_output = [
 ];                                               
 
 $json = json_GET($vep_transcript_id_get,'GET consequences with transcript_id');
-eq_or_diff($json, $vep_output, 'VEP transcript filter test');
+cmp_bag($json, $vep_output, 'VEP transcript filter test');
 
 # test using refseq cache
 my $vep_refseq_get = '/vep/homo_sapiens/region/7:34097707-34097707:1/C?content-type=application/json&refseq=1';

--- a/t/vep.t
+++ b/t/vep.t
@@ -27,6 +27,7 @@ BEGIN {
 use Test::More;
 use Test::Differences;
 use Test::Deep;
+use Test::Exception;
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Test::TestUtils;
 use Catalyst::Test ();
@@ -274,16 +275,17 @@ $vep_output =
 }];
 
 $json = json_POST($vep_post,$vep_post_body,'POST a selection of regions to the VEP');
-
 cmp_bag($json,$vep_output, "VEP region POST");
 
+#Ensure that providing an invalid ID is correctly handled by the ID endpoint
 $vep_post = '/vep/homo_sapiens/id';
 my $vep_post_body_invalid = '{ "ids" : ["invalid_id", "rs186950277", "rs17081232" ]}';
-$json = json_POST($vep_post,$vep_post_body_invalid,'POST a selection of IDs to VEP');
+lives_ok{$json = json_POST($vep_post,$vep_post_body_invalid,'POST a selection of IDs to VEP')} 'ensuring invalid ID is handled';
 
+#Ensure that providing invalid hgvs is correctly handled by the HGVS endpoint
 $vep_post = '/vep/homo_sapiens/hgvs';
 $vep_post_body_invalid = '{ "hgvs_notations" : ["invalid_hgvs", "ENST00000314040:c.311G>T"] }';
-$json = json_POST($vep_post,$vep_post_body_invalid,'POST a selection of HGVS variants to VEP');
+lives_ok{$json = json_POST($vep_post,$vep_post_body_invalid,'POST a selection of HGVS variants to VEP')} 'ensuring invalid HGVS is handled';
 
 
 # test vep/id


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

_One or more sentences describing in detail the proposed changes._

For the POST endpoints for hgvs and id vep input, specify the format type
### Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

When an array of data is submitted using a POST endpoint, VEP tries to guess which format the data is in, causing potential mistakes

### Benefits

_If applicable, describe the advantages the changes will have._

Faulty input data as the first array value of a POST request will no longer crash

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._


### Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

Pass, of course.

_Have you run the entire test suite and no regression was detected?_

Yes.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._
