### PR TITLE
Biotype endpoints

### DIFF
--- a/ensembl_rest_testing.conf
+++ b/ensembl_rest_testing.conf
@@ -72,7 +72,8 @@ jsonp=1
     variation_id_two=tmp__
 
     biotype_group=coding
-    biotype_name=guide_RNA
+    biotype_name=CRISPR
+    biotype_ot=gene
 
   </replacements>
 </Model::Documentation>

--- a/ensembl_rest_testing.conf
+++ b/ensembl_rest_testing.conf
@@ -70,6 +70,10 @@ jsonp=1
     
     variation_id=tmp__
     variation_id_two=tmp__
+
+    biotype_group=coding
+    biotype_name=guide_RNA
+
   </replacements>
 </Model::Documentation>
 

--- a/lib/EnsEMBL/REST/Controller/Info.pm
+++ b/lib/EnsEMBL/REST/Controller/Info.pm
@@ -192,7 +192,7 @@ sub biotype_group : Path("biotypes/groups") CaptureArgs(2) ActionClass('REST') {
   };
 
   ## Return 404 for get requests with no return
-  if ( !$biotypes->[0] ) {
+  if ( ! scalar @{$biotypes} ) {
     my $ot_error = '';
     if ($object_type) { $ot_error = " and object_type $object_type" }
     $c->go( 'ReturnError', 'not_found', ["biotypes not found for group $group$ot_error"]);
@@ -220,7 +220,7 @@ sub biotype_name : Path("biotypes/name") CaptureArgs(2) ActionClass('REST') {
   };
 
   ## Return 404 for get requests with no return
-  if ( !$biotypes->[0] ) {
+  if ( ! scalar @{$biotypes} ) {
     my $ot_error = '';
     if ($object_type) { $ot_error = " and object_type $object_type" }
     $c->go( 'ReturnError', 'not_found', ["biotypes not found for name $name$ot_error"]);

--- a/lib/EnsEMBL/REST/Controller/Info.pm
+++ b/lib/EnsEMBL/REST/Controller/Info.pm
@@ -189,6 +189,9 @@ sub biotype_group : Path("biotypes/groups") Args(1) ActionClass('REST') {
     $c->go('ReturnError', 'custom', [qq{$_}]);
   };
 
+  ## Return 404 for get requests with no return
+  $c->go( 'ReturnError', 'not_found', ["biotypes not found for group $group"]) unless $biotypes->[0];
+
   $self->status_ok($c, entity => $biotypes);
   return;
 }
@@ -209,6 +212,9 @@ sub biotype_name : Path("biotypes/name") CaptureArgs(1) ActionClass('REST') {
     $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;
     $c->go('ReturnError', 'custom', [qq{$_}]);
   };
+
+  ## Return 404 for get requests with no return
+  $c->go( 'ReturnError', 'not_found', ["biotypes not found for name $name"]) unless $biotypes->[0];
 
   $self->status_ok($c, entity => $biotypes);
   return;

--- a/lib/EnsEMBL/REST/Controller/Info.pm
+++ b/lib/EnsEMBL/REST/Controller/Info.pm
@@ -179,7 +179,7 @@ sub biotype_group_GET { }
 sub biotype_group : Path("biotypes/groups") CaptureArgs(2) ActionClass('REST') {
   my ($self, $c, $group, $object_type) = @_;
 
-  $c->go('ReturnError', 'custom', ["Missing mandatory argument ':group' for endpoint info/biotypes/groups/:group/:object_type"]) unless $group;
+  $c->go('ReturnError', 'custom', ["Missing argument ':group' for endpoint info/biotypes/groups/:group/:object_type"]) unless $group;
 
   my $biotypes;
 
@@ -207,7 +207,7 @@ sub biotype_name_GET { }
 sub biotype_name : Path("biotypes/name") CaptureArgs(2) ActionClass('REST') {
   my ($self, $c, $name, $object_type) = @_;
 
-  $c->go('ReturnError', 'custom', ["Missing mandatory argument ':name' for endpoint info/biotypes/name/:name"]) unless $name;
+  $c->go('ReturnError', 'custom', ["Missing mandatory argument ':name' for endpoint info/biotypes/name/:name/:object_type"]) unless $name;
 
   my $biotypes;
 

--- a/lib/EnsEMBL/REST/Controller/Info.pm
+++ b/lib/EnsEMBL/REST/Controller/Info.pm
@@ -143,14 +143,11 @@ sub external_dbs_GET :Local :Args(1) {
   return
 }
 
-sub biotypes_GET { }
+sub biotypes :Local :ActionClass('REST') :Args(1) { }
 
-sub biotypes : Chained('/') PathPart("info/biotypes") Args(1) ActionClass('REST') {
+sub biotypes_GET :Local :Args(1) {
   my ($self, $c, $species) = @_;
   my $dba = $c->model('Registry')->get_DBAdaptor($species, 'core', 1);
-  if ( $species eq 'name') {
-    $c->go('ReturnError', 'custom', ["Missing argument ':name' for endpoint info/biotypes/name/:name"]);
-  }
   $c->go('ReturnError', 'custom', ["Could not fetch adaptor for species $species"]) unless $dba;
   my $obj_biotypes = EnsEMBL::REST::EnsemblModel::Biotype->get_Biotypes($c, $species);
   my @biotypes = map { $_->summary_as_hash() } @{$obj_biotypes};
@@ -160,7 +157,7 @@ sub biotypes : Chained('/') PathPart("info/biotypes") Args(1) ActionClass('REST'
 
 sub biotype_groups_GET { }
 
-sub biotype_groups : Chained('/') PathPart("info/biotypes/groups") Args(0) ActionClass('REST') {
+sub biotype_groups : Path("biotypes/groups") Args(0) ActionClass('REST') {
   my ($self, $c) = @_;
 
   my $groups;
@@ -177,10 +174,9 @@ sub biotype_groups : Chained('/') PathPart("info/biotypes/groups") Args(0) Actio
   return;
 }
 
-
 sub biotype_group_GET { }
 
-sub biotype_group : Chained('/') PathPart("info/biotypes/groups") Args(1) ActionClass('REST') {
+sub biotype_group : Path("biotypes/groups") Args(1) ActionClass('REST') {
   my ($self, $c, $group) = @_;
 
   my $biotypes;
@@ -199,8 +195,10 @@ sub biotype_group : Chained('/') PathPart("info/biotypes/groups") Args(1) Action
 
 sub biotype_name_GET { }
 
-sub biotype_name : Chained('/') PathPart("info/biotypes/name") Args(1) ActionClass('REST') {
+sub biotype_name : Path("biotypes/name") CaptureArgs(1) ActionClass('REST') {
   my ($self, $c, $name) = @_;
+
+  $c->go('ReturnError', 'custom', ["Missing argument ':name' for endpoint info/biotypes/name/:name"]) unless $name;
 
   my $biotypes;
 

--- a/lib/EnsEMBL/REST/Controller/Info.pm
+++ b/lib/EnsEMBL/REST/Controller/Info.pm
@@ -148,6 +148,9 @@ sub biotypes_GET { }
 sub biotypes : Chained('/') PathPart("info/biotypes") Args(1) ActionClass('REST') {
   my ($self, $c, $species) = @_;
   my $dba = $c->model('Registry')->get_DBAdaptor($species, 'core', 1);
+  if ( $species eq 'name') {
+    $c->go('ReturnError', 'custom', ["Missing argument ':name' for endpoint info/biotypes/name/:name"]);
+  }
   $c->go('ReturnError', 'custom', ["Could not fetch adaptor for species $species"]) unless $dba;
   my $obj_biotypes = EnsEMBL::REST::EnsemblModel::Biotype->get_Biotypes($c, $species);
   my @biotypes = map { $_->summary_as_hash() } @{$obj_biotypes};
@@ -191,16 +194,6 @@ sub biotype_group : Chained('/') PathPart("info/biotypes/groups") Args(1) Action
   };
 
   $self->status_ok($c, entity => $biotypes);
-  return;
-}
-
-sub biotype_names_GET { }
-
-sub biotype_names : Chained('/') PathPart("info/biotypes/name") Args(0) ActionClass('REST') {
-  my ($self, $c) = @_;
-
-  $c->go('ReturnError', 'custom', ["Missing argument ':name' for endpoint info/biotypes/name/:name"]);
-
   return;
 }
 

--- a/lib/EnsEMBL/REST/Model/Biotype.pm
+++ b/lib/EnsEMBL/REST/Model/Biotype.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute 
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
 Copyright [2016-2018] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -92,7 +92,7 @@ sub fetch_biotypes_by_group {
   $dbc->sql_helper->execute_no_return(-SQL => $sql, -CALLBACK => sub {
     my ($row) = @_;
 
-    my $biotype = { 
+    my $biotype = {
       'name'          => $row->[0],
       'biotype_group' => $row->[1],
       'object_type'   => $row->[2],
@@ -126,7 +126,7 @@ sub fetch_biotypes_by_name {
   $dbc->sql_helper->execute_no_return(-SQL => $sql, -CALLBACK => sub {
     my ($row) = @_;
 
-    my $biotype = { 
+    my $biotype = {
       'name'          => $row->[0],
       'biotype_group' => $row->[1],
       'object_type'   => $row->[2],

--- a/lib/EnsEMBL/REST/Model/Biotype.pm
+++ b/lib/EnsEMBL/REST/Model/Biotype.pm
@@ -24,9 +24,7 @@ use Try::Tiny;
 use Catalyst::Exception qw(throw);
 use Scalar::Util qw/weaken/;
 use List::MoreUtils qw(uniq);
-
 use Bio::EnsEMBL::Utils::Scalar qw/assert_ref/;
-
 
 extends 'Catalyst::Model';
 
@@ -43,7 +41,7 @@ sub build_per_context_instance {
 
 =head fetch_by_name_object_type
 
-Fetches Biotype object by name and object_pype
+Fetches Biotype object by name and object_type
 
 =cut
 
@@ -106,9 +104,6 @@ sub fetch_biotypes_by_group {
 
   return \@biotypes;
 }
-
-
-
 
 =head fetch_biotypes_by_name
 

--- a/lib/EnsEMBL/REST/Model/Biotype.pm
+++ b/lib/EnsEMBL/REST/Model/Biotype.pm
@@ -1,0 +1,142 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute 
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::REST::Model::Biotype;
+
+use Moose;
+use Try::Tiny;
+use Catalyst::Exception qw(throw);
+use Scalar::Util qw/weaken/;
+use List::MoreUtils qw(uniq);
+
+use Bio::EnsEMBL::Utils::Scalar qw/assert_ref/;
+
+
+extends 'Catalyst::Model';
+
+with 'Catalyst::Component::InstancePerContext';
+
+has 'context' => (is => 'ro', weak_ref => 1);
+
+
+sub build_per_context_instance {
+  my ($self, $c, @args) = @_;
+  weaken($c);
+  return $self->new({ context => $c, %$self, @args });
+}
+
+=head fetch_by_name_object_type
+
+Fetches Biotype object by name and object_pype
+
+=cut
+
+sub fetch_by_name_object_type {
+
+  my ($self, $name, $object_type) = @_;
+
+  my $biotype_adaptor = $self->context->model('Registry')->get_adaptor( 'Homo_sapiens', 'Core', 'Biotype' );
+  my $biotype = $biotype_adaptor->fetch_by_name_object_type( $name, $object_type );
+
+  return $biotype;
+}
+
+=head fetch_biotype_groups
+
+Retrieves list of biotype groups
+
+=cut
+
+sub fetch_biotype_groups {
+  my ($self) = @_;
+
+  my $dbc = $self->context->model('Registry')->get_adaptor( 'Homo_sapiens', 'Core', 'Biotype' )->db->dbc();
+
+  my $sql = "SELECT DISTINCT biotype_group FROM biotype WHERE biotype_group IS NOT NULL ORDER BY biotype_group";
+  my $biotypes = $dbc->sql_helper->execute_simple(-SQL => $sql);
+
+  return $biotypes;
+}
+
+=head fetch_biotypes_by_group
+
+Retrieves list of biotypes part of a provided biotype group
+
+=cut
+
+sub fetch_biotypes_by_group {
+  my ($self, $group) = @_;
+
+  my $dbc = $self->context->model('Registry')->get_adaptor( 'Homo_sapiens', 'Core', 'Biotype' )->db->dbc();
+
+  my $sql = "SELECT name, biotype_group, object_type, so_acc FROM biotype WHERE biotype_group = \"$group\" ORDER BY object_type, name";
+
+  my @biotypes;
+
+  $dbc->sql_helper->execute_no_return(-SQL => $sql, -CALLBACK => sub {
+    my ($row) = @_;
+
+    my $biotype = { 
+      'name'          => $row->[0],
+      'biotype_group' => $row->[1],
+      'object_type'   => $row->[2],
+      'so_acc'        => $row->[3]
+    };
+
+    push @biotypes, $biotype;
+  });
+
+  return \@biotypes;
+}
+
+
+
+
+=head fetch_biotypes_by_name
+
+Retrieves biotypes with the provided name
+
+=cut
+
+sub fetch_biotypes_by_name {
+  my ($self, $name) = @_;
+
+  my $dbc = $self->context->model('Registry')->get_adaptor( 'Homo_sapiens', 'Core', 'Biotype' )->db->dbc();
+
+  my $sql = "SELECT name, biotype_group, object_type, so_acc FROM biotype WHERE name = \"$name\" ORDER BY object_type, name";
+
+  my @biotypes;
+
+  $dbc->sql_helper->execute_no_return(-SQL => $sql, -CALLBACK => sub {
+    my ($row) = @_;
+
+    my $biotype = { 
+      'name'          => $row->[0],
+      'biotype_group' => $row->[1],
+      'object_type'   => $row->[2],
+      'so_acc'        => $row->[3]
+    };
+
+    push @biotypes, $biotype;
+  });
+
+  return \@biotypes;
+}
+
+1;

--- a/lib/EnsEMBL/REST/Model/Biotype.pm
+++ b/lib/EnsEMBL/REST/Model/Biotype.pm
@@ -81,11 +81,13 @@ Retrieves list of biotypes part of a provided biotype group
 =cut
 
 sub fetch_biotypes_by_group {
-  my ($self, $group) = @_;
+  my ($self, $group, $object_type) = @_;
 
   my $dbc = $self->context->model('Registry')->get_adaptor( 'Homo_sapiens', 'Core', 'Biotype' )->db->dbc();
 
-  my $sql = "SELECT name, biotype_group, object_type, so_acc FROM biotype WHERE biotype_group = \"$group\" ORDER BY object_type, name";
+  my $ot_filter = '';
+  if ( $object_type ) { $ot_filter = "AND object_type = \"$object_type\"" }
+  my $sql = "SELECT name, biotype_group, object_type, so_acc FROM biotype WHERE biotype_group = \"$group\" AND db_type LIKE '%core%' $ot_filter ORDER BY object_type, name";
 
   my @biotypes;
 
@@ -115,11 +117,13 @@ Retrieves biotypes with the provided name
 =cut
 
 sub fetch_biotypes_by_name {
-  my ($self, $name) = @_;
+  my ($self, $name, $object_type) = @_;
 
   my $dbc = $self->context->model('Registry')->get_adaptor( 'Homo_sapiens', 'Core', 'Biotype' )->db->dbc();
 
-  my $sql = "SELECT name, biotype_group, object_type, so_acc FROM biotype WHERE name = \"$name\" ORDER BY object_type, name";
+  my $ot_filter = '';
+  if ( $object_type ) { $ot_filter = "AND object_type = \"$object_type\"" }
+  my $sql = "SELECT name, biotype_group, object_type, so_acc FROM biotype WHERE name = \"$name\" AND db_type LIKE '%core%' $ot_filter ORDER BY object_type, name";
 
   my @biotypes;
 

--- a/root/documentation/info.conf
+++ b/root/documentation/info.conf
@@ -167,11 +167,12 @@
   </biotypes>
 
   <biotypes_groups>
-    description=List the functional classifications within a biotype group. Without argument the list of available biotype groups is returned.
-    endpoint="info/biotypes/groups/:group"
+    description=Without argument the list of available biotype groups is returned. With :group argument provided, list the properties of biotypes within that group. Object type (gene or transcript) can be provided for filtering.
+    endpoint="info/biotypes/groups/:group/:object_type"
     method=GET
     group=Information
     output=json
+    output=yaml
     <params>
       <group>
         type=String
@@ -179,26 +180,39 @@
         required=0
         example=__VAR(biotype_group)__
       </group>
+      <object_type>
+        type=String
+        description=Object type (gene or transcript)
+        required=0
+        example=__VAR(biotype_ot)__
+      </object_type>
     </params>
     <examples>
-      <one>
+      <a>
         path=/info/biotypes/groups/
         content=application/json
-      </one>
-      <two>
+      </a>
+      <b>
         path=/info/biotypes/groups/
         capture=__VAR(biotype_group)__
         content=application/json
-      </two>
+      </b>
+      <c>
+        path=/info/biotypes/groups/
+        capture=__VAR(biotype_group)__
+        capture=__VAR(biotype_ot)__
+        content=application/json
+      </c>
     </examples>
   </biotypes_groups>
 
   <biotypes_name>
-    description=List the biotypes for a given biotype name. Usually two exist for a particular name, based on the object_type (gene or transcript). 
-    endpoint="info/biotypes/name/:name"
+    description=List the properties of biotypes with a given name. Object type (gene or transcript) can be provided for filtering.
+    endpoint="info/biotypes/name/:name/:object_type"
     method=GET
     group=Information
     output=json
+    output=yaml
     <params>
       <name>
         type=String
@@ -206,13 +220,25 @@
         required=1
         example=__VAR(biotype_name)__
       </name>
+      <object_type>
+        type=String
+        description=Object type (gene or transcript)
+        required=0
+        example=__VAR(biotype_ot)__
+      </object_type>
     </params>
     <examples>
-      <one>
+      <a>
         path=/info/biotypes/name/
         capture=__VAR(biotype_name)__
         content=application/json
-      </one>
+      </a>
+      <b>
+        path=/info/biotypes/name/
+        capture=__VAR(biotype_name)__
+        capture=__VAR(biotype_ot)__
+        content=application/json
+      </b>
     </examples>
   </biotypes_name>
 
@@ -246,27 +272,27 @@
       </filter>
     </params>
     <examples>
-      <one>
+      <a>
         path=/info/external_dbs/
         capture=__VAR(species)__
         content=application/json
-      </one>
-      <two>
+      </a>
+      <b>
         path=/info/external_dbs/
         capture=__VAR(species)__
         <params>
           filter=GO%
         </params>
         content=application/json
-      </two>
-      <three>
+      </b>
+      <c>
         path=/info/external_dbs/
         capture=__VAR(species)__
         <params>
           feature=seq_region_synonym
         </params>
         content=application/json
-      </three>
+      </c>
     </examples>
   </external_dbs>
 
@@ -275,7 +301,6 @@
     endpoint="info/compara/methods"
     method=GET
     group=Information
-    output=json
     output=json
     output=yaml
     output=xml

--- a/root/documentation/info.conf
+++ b/root/documentation/info.conf
@@ -165,7 +165,57 @@
       </one>
     </examples>
   </biotypes>
-  
+
+  <biotypes_groups>
+    description=List the functional classifications within a biotype group. Without argument the list of available biotype groups is returned.
+    endpoint="info/biotypes/groups/:group"
+    method=GET
+    group=Information
+    output=json
+    <params>
+      <group>
+        type=String
+        description=Biotype group
+        required=0
+        example=__VAR(biotype_group)__
+      </group>
+    </params>
+    <examples>
+      <one>
+        path=/info/biotypes/groups/
+        content=application/json
+      </one>
+      <two>
+        path=/info/biotypes/groups/
+        capture=__VAR(biotype_group)__
+        content=application/json
+      </two>
+    </examples>
+  </biotypes_groups>
+
+  <biotypes_name>
+    description=List the biotypes for a given biotype name. Usually two exist for a particular name, based on the object_type (gene or transcript). 
+    endpoint="info/biotypes/name/:name"
+    method=GET
+    group=Information
+    output=json
+    <params>
+      <name>
+        type=String
+        description=Biotype name
+        required=1
+        example=__VAR(biotype_name)__
+      </name>
+    </params>
+    <examples>
+      <one>
+        path=/info/biotypes/name/
+        capture=__VAR(biotype_name)__
+        content=application/json
+      </one>
+    </examples>
+  </biotypes_name>
+
   <external_dbs>
     description=Lists all available external sources for a species.
     endpoint="info/external_dbs/:species"

--- a/t/info.t
+++ b/t/info.t
@@ -165,6 +165,7 @@ is_json_GET(
   is(ref($biotype), 'HASH', 'Biotypes represented by Hashes');
   my $expected = { name => 'IG_C_gene', biotype_group => 'coding', object_type => 'gene', so_acc => 'SO:0001217'};
   eq_or_diff_data($biotype, $expected, 'Checking internal contents of biotype hash as expected');
+  action_bad_regex('/info/biotypes/groups/fake_group', qr/biotypes not found for group/, 'No matches for provided group error');
 }
 
 # /info/biotypes/name/:name
@@ -177,6 +178,7 @@ is_json_GET(
   is(ref($biotype), 'HASH', 'Biotypes represented by Hashes');
   my $expected = { name => 'guide_RNA', biotype_group => 'snoncoding', object_type => 'gene', so_acc => 'SO:0001263'};
   eq_or_diff_data($biotype, $expected, 'Checking internal contents of biotype hash as expected');
+  action_bad_regex('/info/biotypes/name/fake_name', qr/biotypes not found for name/, 'No matches for provided name error');
 }
 
 #/info/compara/methods

--- a/t/info.t
+++ b/t/info.t
@@ -160,25 +160,29 @@ is_json_GET(
 {
   my $biotypes_json = json_GET('/info/biotypes/groups/coding', 'Get the list of coding biotypes');
   is(ref($biotypes_json), 'ARRAY', 'Array wanted from endpoint');
-  cmp_ok(scalar(@{$biotypes_json}), '==', 39, 'Ensuring we have the right number of biotypes of group coding');
+  cmp_ok(scalar(@{$biotypes_json}), '==', 33, 'Ensuring we have the right number of biotypes of group coding');
   my $biotype = shift @{$biotypes_json};
   is(ref($biotype), 'HASH', 'Biotypes represented by Hashes');
   my $expected = { name => 'IG_C_gene', biotype_group => 'coding', object_type => 'gene', so_acc => 'SO:0001217'};
   eq_or_diff_data($biotype, $expected, 'Checking internal contents of biotype hash as expected');
   action_bad_regex('/info/biotypes/groups/fake_group', qr/biotypes not found for group/, 'No matches for provided group error');
+  action_bad_regex('/info/biotypes/groups/coding/aaa', qr/biotypes not found for group coding and object_type/, 'No matches for provided object_type error');
 }
 
 # /info/biotypes/name/:name
 {
-  action_bad_regex('/info/biotypes/name', qr/Missing argument/, 'No argument provided means error message');
-  my $biotypes_json = json_GET('/info/biotypes/name/guide_RNA', 'Get guide_RNA biotypes');
+  action_bad_regex('/info/biotypes/name', qr/Missing mandatory argument/, 'No argument provided means error message');
+  my $biotypes_json = json_GET('/info/biotypes/name/CRISPR', 'Get CRISPR biotypes');
   is(ref($biotypes_json), 'ARRAY', 'Array wanted from endpoint');
-  cmp_ok(scalar(@{$biotypes_json}), '==', 2, 'Ensuring we have the right number of biotypes of name guide_RNA');
+  cmp_ok(scalar(@{$biotypes_json}), '==', 2, 'Ensuring we have the right number of biotypes of name CRISPR');
   my $biotype = shift @{$biotypes_json};
   is(ref($biotype), 'HASH', 'Biotypes represented by Hashes');
-  my $expected = { name => 'guide_RNA', biotype_group => 'snoncoding', object_type => 'gene', so_acc => 'SO:0001263'};
+  my $expected = { name => 'CRISPR', biotype_group => 'snoncoding', object_type => 'gene', so_acc => 'SO:0001263'};
   eq_or_diff_data($biotype, $expected, 'Checking internal contents of biotype hash as expected');
+  my $biotype_json = json_GET('/info/biotypes/name/CRISPR/gene', 'Get CRISPR gene biotype');
+  eq_or_diff_data(shift @{$biotype_json}, $expected, 'Checking internal contents of biotype hash as expected');
   action_bad_regex('/info/biotypes/name/fake_name', qr/biotypes not found for name/, 'No matches for provided name error');
+  action_bad_regex('/info/biotypes/name/CRISPR/fake_ot', qr/biotypes not found for name CRISPR and object_type/, 'No matches for provided object_type error');
 }
 
 #/info/compara/methods

--- a/t/info.t
+++ b/t/info.t
@@ -149,9 +149,11 @@ is_json_GET(
 
 # /info/biotypes/groups
 {
-  my $biotypes_json = json_GET('/info/biotypes/groups', 'Get the list biotype groups');
-  is(ref($biotypes_json), 'ARRAY', 'Array wanted from endpoint');
-  cmp_ok(scalar(@{$biotypes_json}), '==', 8, 'Ensuring we have the right number of biotype groups');
+  my $groups_json = json_GET('/info/biotypes/groups', 'Get the list biotype groups');
+  is(ref($groups_json), 'ARRAY', 'Array wanted from endpoint');
+  cmp_ok(scalar(@{$groups_json}), '==', 8, 'Ensuring we have the right number of biotype groups');
+  is(shift @{$groups_json}, 'coding', 'first group is coding');
+  is(pop @{$groups_json}, 'no_group', 'last group is no_group')
 }
 
 # /info/biotypes/groups/:group

--- a/t/info.t
+++ b/t/info.t
@@ -159,7 +159,7 @@ is_json_GET(
   my $biotypes_json = json_GET('/info/biotypes/groups/coding', 'Get the list of coding biotypes');
   is(ref($biotypes_json), 'ARRAY', 'Array wanted from endpoint');
   cmp_ok(scalar(@{$biotypes_json}), '==', 39, 'Ensuring we have the right number of biotypes of group coding');
-  my $biotype = shift $biotypes_json;
+  my $biotype = shift @{$biotypes_json};
   is(ref($biotype), 'HASH', 'Biotypes represented by Hashes');
   my $expected = { name => 'IG_C_gene', biotype_group => 'coding', object_type => 'gene', so_acc => 'SO:0001217'};
   eq_or_diff_data($biotype, $expected, 'Checking internal contents of biotype hash as expected');
@@ -171,7 +171,7 @@ is_json_GET(
   my $biotypes_json = json_GET('/info/biotypes/name/guide_RNA', 'Get guide_RNA biotypes');
   is(ref($biotypes_json), 'ARRAY', 'Array wanted from endpoint');
   cmp_ok(scalar(@{$biotypes_json}), '==', 2, 'Ensuring we have the right number of biotypes of name guide_RNA');
-  my $biotype = shift $biotypes_json;
+  my $biotype = shift @{$biotypes_json};
   is(ref($biotype), 'HASH', 'Biotypes represented by Hashes');
   my $expected = { name => 'guide_RNA', biotype_group => 'snoncoding', object_type => 'gene', so_acc => 'SO:0001263'};
   eq_or_diff_data($biotype, $expected, 'Checking internal contents of biotype hash as expected');

--- a/t/info.t
+++ b/t/info.t
@@ -147,6 +147,36 @@ is_json_GET(
   action_bad_regex('/info/biotypes/wibble', qr/Could not fetch adaptor for species .+/, 'Bogus species means error message');
 }
 
+# /info/biotypes/groups
+{
+  my $biotypes_json = json_GET('/info/biotypes/groups', 'Get the list biotype groups');
+  is(ref($biotypes_json), 'ARRAY', 'Array wanted from endpoint');
+  cmp_ok(scalar(@{$biotypes_json}), '==', 8, 'Ensuring we have the right number of biotype groups');
+}
+
+# /info/biotypes/groups/:group
+{
+  my $biotypes_json = json_GET('/info/biotypes/groups/coding', 'Get the list of coding biotypes');
+  is(ref($biotypes_json), 'ARRAY', 'Array wanted from endpoint');
+  cmp_ok(scalar(@{$biotypes_json}), '==', 39, 'Ensuring we have the right number of biotypes of group coding');
+  my $biotype = shift $biotypes_json;
+  is(ref($biotype), 'HASH', 'Biotypes represented by Hashes');
+  my $expected = { name => 'IG_C_gene', biotype_group => 'coding', object_type => 'gene', so_acc => 'SO:0001217'};
+  eq_or_diff_data($biotype, $expected, 'Checking internal contents of biotype hash as expected');
+}
+
+# /info/biotypes/name/:name
+{
+  action_bad_regex('/info/biotypes/name', qr/Missing argument/, 'No argument provided means error message');
+  my $biotypes_json = json_GET('/info/biotypes/name/guide_RNA', 'Get guide_RNA biotypes');
+  is(ref($biotypes_json), 'ARRAY', 'Array wanted from endpoint');
+  cmp_ok(scalar(@{$biotypes_json}), '==', 2, 'Ensuring we have the right number of biotypes of name guide_RNA');
+  my $biotype = shift $biotypes_json;
+  is(ref($biotype), 'HASH', 'Biotypes represented by Hashes');
+  my $expected = { name => 'guide_RNA', biotype_group => 'snoncoding', object_type => 'gene', so_acc => 'SO:0001263'};
+  eq_or_diff_data($biotype, $expected, 'Checking internal contents of biotype hash as expected');
+}
+
 #/info/compara/methods
 {
   my $methods_json = json_GET('/info/compara/methods', 'Get the compara methods hash');

--- a/t/test-genome-DBs/homo_sapiens/core/biotype.txt
+++ b/t/test-genome-DBs/homo_sapiens/core/biotype.txt
@@ -1,0 +1,203 @@
+1	IG_C_gene	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217
+2	IG_C_gene	transcript	core,otherfeatures,presite	NULL	NULL	coding	SO:0000478
+3	IG_D_gene	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217
+4	IG_D_gene	transcript	core,otherfeatures,presite	NULL	NULL	coding	SO:0000458
+5	IG_J_gene	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217
+6	IG_J_gene	transcript	core,otherfeatures,presite	NULL	NULL	coding	SO:0000470
+7	IG_J_pseudogene	gene	core,presite	67	NULL	pseudogene	SO:0000336
+8	IG_J_pseudogene	transcript	core,presite	NULL	NULL	pseudogene	SO:0000516
+9	IG_V_gene	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217
+10	IG_V_gene	transcript	core,otherfeatures,presite	NULL	NULL	coding	SO:0000466
+11	IG_V_pseudogene	gene	core,presite	67	NULL	pseudogene	SO:0000336
+12	IG_V_pseudogene	transcript	core,presite	NULL	NULL	pseudogene	SO:0000516
+13	IG_gene	gene	vega	NULL	NULL	coding	SO:0001217
+14	IG_gene	transcript	vega	NULL	NULL	coding	SO:3000000
+15	IG_pseudogene	gene	core,vega,presite	67	NULL	pseudogene	SO:0000336
+16	IG_pseudogene	transcript	core,vega,presite	NULL	NULL	pseudogene	SO:0000516
+17	LRG_gene	gene	core	NULL	NULL	LRG	NULL
+18	LRG_gene	transcript	core	NULL	NULL	LRG	NULL
+19	Mt_rRNA	gene	core,presite	73	NULL	snoncoding	SO:0001263
+20	Mt_rRNA	transcript	core,presite	NULL	NULL	snoncoding	SO:0000252
+21	Mt_tRNA	gene	core,presite	74	NULL	snoncoding	SO:0001263
+22	Mt_tRNA	transcript	core,presite	NULL	NULL	snoncoding	SO:0000253
+23	Mt_tRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
+24	Mt_tRNA_pseudogene	transcript	core	NULL	noncoding RNA pseudogene	pseudogene	SO:0000516
+25	RNA-Seq_gene	gene	otherfeatures	NULL	NULL	undefined	NULL
+26	RNA-Seq_gene	transcript	otherfeatures	NULL	NULL	undefined	NULL
+27	TEC	gene	core,vega,sangervega	0	NULL	undefined	NULL
+28	TEC	transcript	core,vega,sangervega	NULL	NULL	undefined	SO:0002139
+29	TR_gene	gene	vega	NULL	NULL	coding	SO:0001217
+30	TR_gene	transcript	core,vega	NULL	NULL	coding	SO:3000000
+31	TR_pseudogene	gene	vega	NULL	NULL	pseudogene	SO:0000336
+32	TR_pseudogene	transcript	vega	0	NULL	pseudogene	SO:0000516
+33	ambiguous_orf	transcript	core,vega	NULL	NULL	lnoncoding	SO:0001877
+35	cdna_update	gene	cdna	NULL	NULL	undefined	NULL
+36	cdna_update	transcript	cdna	NULL	NULL	undefined	NULL
+37	cdna	gene	otherfeatures	NULL	NULL	undefined	SO:0000756
+38	cdna	transcript	otherfeatures	NULL	NULL	undefined	SO:0000756
+39	disrupted_domain	transcript	core,vega	NULL	NULL	pseudogene	SO:0000516
+40	est	gene	otherfeatures	NULL	NULL	undefined	NULL
+41	est	transcript	otherfeatures	NULL	NULL	undefined	SO:0000345
+42	lincRNA	gene	core,vega,presite	190	NULL	lnoncoding	SO:0001263
+43	lincRNA	transcript	core,vega,presite	NULL	NULL	lnoncoding	SO:0001877
+44	miRNA	gene	core,otherfeatures,vega,presite	70	From RefSeq import.	snoncoding	SO:0001263
+45	miRNA	transcript	core,otherfeatures,presite	NULL	From RefSeq import.	snoncoding	SO:0000276
+46	miRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
+47	miRNA_pseudogene	transcript	core	NULL	noncoding RNA pseudogene	pseudogene	SO:0000516
+48	misc_RNA	gene	core,otherfeatures,presite	NULL	NULL	mnoncoding	SO:0001263
+49	misc_RNA	transcript	core,otherfeatures,presite	NULL	NULL	mnoncoding	SO:0000655
+50	misc_RNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
+51	misc_RNA_pseudogene	transcript	core	NULL	noncoding RNA pseudogene	pseudogene	SO:0000516
+52	ncRNA	gene	core,otherfeatures	99	NULL	snoncoding	SO:0001263
+53	ncRNA	transcript	core,otherfeatures	NULL	NULL	snoncoding	SO:0000655
+54	non_coding	gene	core,otherfeatures,rnaseq,vega,presite	353	NULL	lnoncoding	SO:0001263
+55	non_coding	transcript	core,otherfeatures,rnaseq,vega,presite	NULL	NULL	lnoncoding	SO:0001877
+56	nonsense_mediated_decay	transcript	core,vega,presite	NULL	NULL	coding	SO:0000234
+57	polymorphic	gene	vega	NULL	NULL	coding	SO:0001217
+58	polymorphic_pseudogene	gene	core,vega,presite	67	NULL	coding	SO:0001217
+59	polymorphic_pseudogene	transcript	core,vega,presite	NULL	NULL	coding	SO:0000234
+60	processed_pseudogene	gene	core,vega,presite	NULL	NULL	pseudogene	SO:0000336
+61	processed_pseudogene	transcript	core,vega,presite	NULL	NULL	pseudogene	SO:0000516
+62	processed_transcript	gene	core,vega,presite	79	NULL	lnoncoding	SO:0001263
+63	processed_transcript	transcript	core,vega,presite	NULL	NULL	lnoncoding	SO:0001877
+64	protein_coding	gene	core,otherfeatures,rnaseq,vega,presite	NULL	NULL	coding	SO:0001217
+65	protein_coding	transcript	core,otherfeatures,rnaseq,vega,presite	NULL	NULL	coding	SO:0000234
+66	pseudogene	gene	core,otherfeatures,vega,presite	67	NULL	pseudogene	SO:0000336
+67	pseudogene	transcript	core,otherfeatures,vega,presite	NULL	NULL	pseudogene	SO:0000516
+68	rRNA	gene	core,otherfeatures,vega,presite	NULL	NULL	snoncoding	SO:0001263
+69	rRNA	transcript	core,otherfeatures,vega,presite	NULL	NULL	snoncoding	SO:0000252
+70	rRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
+71	rRNA_pseudogene	transcript	core	NULL	noncoding RNA pseudogene	pseudogene	SO:0000516
+72	retained_intron	transcript	core,vega,presite	NULL	NULL	lnoncoding	SO:0001877
+75	scRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
+76	scRNA_pseudogene	transcript	core	NULL	noncoding RNA pseudogene	pseudogene	SO:0000516
+77	snRNA	gene	core,otherfeatures,vega,presite	68	From Havana manual annotation.	snoncoding	SO:0001263
+78	snRNA	transcript	core,otherfeatures,vega,presite	NULL	From Havana manual annotation.	snoncoding	SO:0000274
+79	snRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
+80	snRNA_pseudogene	transcript	core	NULL	noncoding RNA pseudogene	pseudogene	SO:0000516
+81	snlRNA	gene	core	78	NULL	snoncoding	SO:0001263
+82	snlRNA	transcript	core	NULL	NULL	snoncoding	SO:0000274
+83	snoRNA	gene	core,otherfeatures,vega,presite	69	small nucleolar RNA.	snoncoding	SO:0001263
+84	snoRNA	transcript	core,otherfeatures,vega,presite	NULL	small nucleolar RNA.	snoncoding	SO:0000275
+85	snoRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
+86	snoRNA_pseudogene	transcript	core	NULL	noncoding RNA pseudogene	pseudogene	SO:0000516
+87	tRNA	gene	core,otherfeatures,presite	76	NULL	snoncoding	SO:0001263
+88	tRNA	transcript	core,otherfeatures,presite	76	NULL	snoncoding	SO:0000253
+89	tRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
+90	tRNA_pseudogene	transcript	core	NULL	noncoding RNA pseudogene	pseudogene	SO:0000516
+91	transcribed_processed_pseudogene	gene	core,vega,presite	NULL	NULL	pseudogene	SO:0000336
+92	transcribed_processed_pseudogene	transcript	core,vega,presite	NULL	NULL	pseudogene	SO:0000516
+93	transcribed_unitary_pseudogene	gene	core,vega	NULL	NULL	pseudogene	SO:0000336
+94	transcribed_unprocessed_pseudogene	gene	core,vega,presite	NULL	NULL	pseudogene	SO:0000336
+95	transcribed_unprocessed_pseudogene	transcript	core,vega,presite	NULL	NULL	pseudogene	SO:0000516
+96	unitary_pseudogene	gene	core,vega,presite	NULL	NULL	pseudogene	SO:0000336
+97	unitary_pseudogene	transcript	core,vega,presite	NULL	NULL	pseudogene	SO:0000516
+98	unprocessed_pseudogene	gene	core,vega,presite	NULL	NULL	pseudogene	SO:0000336
+99	unprocessed_pseudogene	transcript	core,vega,presite	NULL	NULL	pseudogene	SO:0000516
+100	ccds_gene	gene	otherfeatures	NULL	Imported CCDS gene models	undefined	NULL
+101	protein_coding_in_progress	gene	vega	NULL	occurs where the ORF is lost when remapping to a different assembly and the gene is awaiting reannotation	undefined	NULL
+102	IG_Z_gene	gene	core,vega	100	NULL	coding	SO:0001217
+103	IG_M_gene	gene	core,vega	100	NULL	coding	SO:0001217
+104	ncRNA_host	transcript	core,vega	NULL	NULL	lnoncoding	NULL
+105	TR_V_pseudogene	gene	core,presite	67	NULL	pseudogene	SO:0000336
+106	TR_V_gene	gene	core,presite	100	NULL	coding	SO:0001217
+107	IG_C_pseudogene	gene	core,presite	67	NULL	pseudogene	SO:0000336
+108	TR_C_gene	gene	core,presite	100	NULL	coding	SO:0001217
+109	TR_J_gene	gene	core,presite	100	NULL	coding	SO:0001217
+110	TR_V_pseudogene	transcript	core,presite	NULL	NULL	pseudogene	SO:0000516
+111	TR_V_gene	transcript	core,presite	NULL	NULL	coding	SO:0000466
+112	IG_C_pseudogene	transcript	core,presite	NULL	NULL	pseudogene	SO:0000516
+113	TR_C_gene	transcript	core,presite	NULL	NULL	coding	SO:0000478
+114	TR_J_gene	transcript	core,presite	NULL	NULL	coding	SO:0000470
+115	protein_coding_in_progress	transcript	vega	NULL	occurs where the ORF is lost when remapping to a different assembly and the gene is awaiting reannotation	undefined	NULL
+116	IG_M_gene	transcript	core	NULL	NULL	coding	SO:3000000
+117	IG_Z_gene	transcript	core	NULL	NULL	coding	SO:3000000
+118	3prime_overlapping_ncRNA	transcript	core,vega,presite	NULL	NULL	lnoncoding	SO:0002120
+123	antisense_RNA	gene	otherfeatures	NULL	From RefSeq import	lnoncoding	SO:0001263
+124	antisense_RNA	transcript	otherfeatures	NULL	From RefSeq import	lnoncoding	SO:0001877
+125	scRNA	gene	core,otherfeatures,vega	NULL	From RefSeq import or Havana manual annotation.	snoncoding	SO:0001263
+126	scRNA	transcript	core,otherfeatures,vega	NULL	From RefSeq import or Havana manual annotation.	snoncoding	SO:0000013
+127	RNase_MRP_RNA	gene	core,otherfeatures,presite	NULL	From RefSeq import or Rfamscan	snoncoding	SO:0001263
+128	RNase_MRP_RNA	transcript	core,otherfeatures,presite	NULL	From RefSeq import or Rfamscan	snoncoding	SO:0000385
+129	RNase_P_RNA	gene	core,otherfeatures,presite	NULL	From RefSeq import or Rfamscan	snoncoding	SO:0001263
+130	RNase_P_RNA	transcript	core,otherfeatures,presite	NULL	From RefSeq import or Rfamscan	snoncoding	SO:0000386
+131	telomerase_RNA	gene	otherfeatures,presite	NULL	From RefSeq import or Rfamscan	snoncoding	SO:0001263
+132	telomerase_RNA	transcript	otherfeatures,presite	NULL	From RefSeq import or Rfamscan	snoncoding	SO:0000390
+133	sense_intronic	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877
+135	sense_overlapping	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877
+138	sense_intronic	gene	core,vega,presite	350	NULL	lnoncoding	SO:0001263
+139	ambiguous_orf	gene	core,vega	351	NULL	lnoncoding	SO:0001263
+140	retained_intron	gene	core,vega,presite	352	NULL	lnoncoding	SO:0001263
+142	3prime_overlapping_ncRNA	gene	core,vega,presite	NULL	NULL	lnoncoding	NULL
+143	ncRNA_host	gene	core,vega	NULL	NULL	lnoncoding	NULL
+144	sense_overlapping	gene	core,vega,presite	355	NULL	lnoncoding	SO:0001263
+146	TR_D_gene	transcript	core,presite	NULL	NULL	coding	SO:0000458
+147	TR_J_pseudogene	transcript	core,presite	NULL	NULL	pseudogene	SO:0000516
+148	TR_D_gene	gene	core,presite	100	NULL	coding	SO:0001217
+149	TR_J_pseudogene	gene	core,presite	67	NULL	pseudogene	SO:0000336
+150	ncbi_pseudogene	gene	otherfeatures	NULL	Imported annotation from RefSeq	pseudogene	SO:0000336
+151	ncbi_pseudogene	transcript	otherfeatures	NULL	Imported annotation from RefSeq	pseudogene	SO:0000516
+152	ncbigene	gene	otherfeatures	NULL	Imported annotation from RefSeq	undefined	NULL
+153	non_stop_decay	transcript	core,vega,presite	0	A new transcript biotype from Havana.	coding	SO:0000234
+154	pre_miRNA	transcript	core	0	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001244
+\nHence only required for EnsemblBacteria.e of tsnoncoding of ncSO:0001263that is only found in bacteria.
+156	tmRNA	transcript	core	0	One of the classes of ncRNA genes that is only found in bacteria. Hence only required for EnsemblBacteria.	snoncoding	SO:0000584
+157	SRP_RNA	gene	core,otherfeatures	NULL	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0001263
+158	SRP_RNA	transcript	core,otherfeatures	0	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0000590
+160	ribozyme	transcript	core,otherfeatures,presite	NULL	NULL	lnoncoding	SO:0001877
+163	ncRNA_pseudogene	gene	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000336
+164	ncRNA_pseudogene	transcript	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000516
+165	IG_LV_gene	gene	core	100	NULL	coding	SO:0001217
+166	IG_LV_gene	transcript	core	NULL	NULL	coding	SO:3000000
+167	translated_processed_pseudogene	gene	core,vega,presite	NULL	NULL	pseudogene	SO:0000336
+168	translated_processed_pseudogene	transcript	core,vega,presite	NULL	NULL	pseudogene	SO:0000516
+169	nontranslating_CDS	gene	core	NULL	An imported 'protein-coding' gene that does not translate due to one or more unannotated stop codons.	coding	SO:0001217
+170	nontranslating_CDS	transcript	core	NULL	An imported 'protein-coding' transcript that does not translate due to one or more unannotated stop codons.	coding	SO:0000234
+171	translated_unprocessed_pseudogene	gene	core,vega	NULL	NULL	pseudogene	SO:0000336
+172	translated_unprocessed_pseudogene	transcript	core,vega	NULL	NULL	pseudogene	SO:0000516
+173	mRNA	gene	otherfeatures	NULL	From RefSeq import	coding	SO:0001217
+174	mRNA	transcript	otherfeatures	NULL	From RefSeq import	coding	SO:0000234
+175	pre_miRNA	gene	core	NULL	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001263
+176	artifact	gene	vega	NULL	Should not see this biotype in core db	undefined	NULL
+177	artifact	transcript	vega	NULL	Should not see this biotype in core db	undefined	NULL
+178	lncRNA	gene	core,otherfeatures,vega,presite	190	NULL	lnoncoding	SO:0001263
+179	class_I_RNA	gene	core	NULL	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263
+180	class_I_RNA	transcript	core	NULL	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000990
+181	class_II_RNA	gene	core	NULL	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263
+182	class_II_RNA	transcript	core	NULL	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000989
+183	known_ncRNA	gene	core,otherfeatures,vega,sangervega	NULL	NULL	snoncoding	NULL
+184	known_ncRNA	transcript	core,otherfeatures,vega,sangervega	NULL	NULL	snoncoding	SO:0000655
+185	transcribed_unitary_pseudogene	transcript	core,vega	NULL	NULL	pseudogene	SO:0000516
+186	piRNA	gene	core	NULL	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001263
+187	piRNA	transcript	core	NULL	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001035
+188	IG_D_pseudogene	gene	core,presite	67	NULL	pseudogene	SO:0000336
+189	macro_lncRNA	gene	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001263
+191	vaultRNA	gene	core,otherfeatures,vega	388	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0001263
+192	scaRNA	gene	core,otherfeatures,presite	440	NULL	snoncoding	SO:0001263
+193	scaRNA	transcript	core,otherfeatures,presite	NULL	NULL	snoncoding	SO:0000013
+194	sRNA	transcript	core,otherfeatures,presite	NULL	NULL	snoncoding	SO:0000274
+195	sRNA	gene	core,otherfeatures,presite	441	NULL	snoncoding	SO:0001263
+196	CRISPR	gene	core,otherfeatures,presite	442	NULL	snoncoding	SO:0001263
+197	CRISPR	transcript	core,otherfeatures,presite	NULL	NULL	snoncoding	SO:0001459
+198	antitoxin	transcript	core,otherfeatures,presite	NULL	NULL	lnoncoding	SO:0001877
+199	antitoxin	gene	core,otherfeatures,presite	443	NULL	lnoncoding	SO:0001263
+200	ribozyme	gene	core,otherfeatures,presite	359	NULL	lnoncoding	SO:0001263
+202	vaultRNA	transcript	core,otherfeatures,vega	388	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0002040
+203	macro_lncRNA	transcript	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001877
+204	IG_D_pseudogene	transcript	core,presite	67	NULL	pseudogene	SO:0000516
+205	guide_RNA	gene	otherfeatures	NULL	From RefSeq import	snoncoding	SO:0001263
+206	guide_RNA	transcript	otherfeatures	NULL	From RefSeq import	snoncoding	SO:0000602
+207	Y_RNA	gene	otherfeatures	NULL	From RefSeq import	snoncoding	SO:0001263
+208	Y_RNA	transcript	otherfeatures	NULL	From RefSeq import	snoncoding	SO:0000405
+209	transposable_element	transcript	core	NULL	NULL	no_group	SO:0000101
+210	transposable_element	gene	core	NULL	NULL	no_group	SO:0000111
+211	bidirectional_promoter_lncRNA	transcript	core,vega,presite	NULL	NULL	lnoncoding	NULL
+212	bidirectional_promoter_lncRNA	gene	core,vega,presite	NULL	NULL	lnoncoding	SO:0002185
+215	unknown_likely_coding	gene	core	NULL	Biotype introduced by UCSC in the mouse strains, for genes/transcripts that were not in the mouse reference but are likely to be new protein coding models.	coding	NULL
+216	unknown_likely_coding	transcript	core	NULL	Biotype introduced by UCSC in the mouse strains, for genes/transcripts that were not in the mouse reference but are likely to be new protein coding models.	coding	NULL
+217	other	gene	otherfeatures	NULL	NULL	undefined	NULL
+218	lncRNA	transcript	core,otherfeatures,vega,presite	NULL	NULL	lnoncoding	SO:0001877
+219	aligned_transcript	gene	otherfeatures	NULL	Capture Long Seq (CLS) on human and mouse	undefined	NULL
+220	aligned_transcript	transcript	otherfeatures	NULL	Capture Long Seq (CLS) on human and mouse	undefined	NULL
+221	antisense	gene	core,presite	NULL	NULL	lnoncoding	SO:0001263
+222	antisense	transcript	core,presite	NULL	NULL	lnoncoding	SO:0001877

--- a/t/test-genome-DBs/homo_sapiens/funcgen/epigenome.txt
+++ b/t/test-genome-DBs/homo_sapiens/funcgen/epigenome.txt
@@ -1,1 +1,1 @@
-1	Lung	Lung	REMC Epigenome (Class2) for Lung	Lung	female	\N	\N	\N
+1	Lung	Lung	REMC Epigenome (Class2) for Lung	Lung	female

--- a/t/test-genome-DBs/homo_sapiens/funcgen/meta.txt
+++ b/t/test-genome-DBs/homo_sapiens/funcgen/meta.txt
@@ -1,5 +1,5 @@
 1	1	schema_type	funcgen
-2	\N	schema_version	92
+2	\N	schema_version	93
 3	\N	patch	patch_88_89_a.sql|schema_version
 4	\N	patch	patch_88_89_b.sql|Created probe_seq table
 5	\N	patch	patch_88_89_c.sql|created probe_feature_transcript table
@@ -119,3 +119,18 @@
 691	\N	patch	patch_90_91_zh.sql|Add new columns to read_file_experimental_configuration table
 692	\N	patch	patch_90_91_zi.sql|Create probe_id index on probe_transcript table
 693	\N	patch	patch_91_92_a.sql|schema_version
+694	\N	patch	patch_91_92_b.sql|Drop column paired_with from table read_file
+695	\N	patch	patch_91_92_c.sql|Create underlying_structure table
+696	\N	patch	patch_92_93_a.sql|schema_version
+697	\N	patch	patch_92_93_b.sql|obsolete
+698	\N	patch	patch_92_93_c.sql|obsolete
+699	\N	patch	patch_92_93_d.sql|Create table for chance quality check
+700	\N	patch	patch_92_93_e.sql|Peak_calling table changes
+701	\N	patch	patch_92_93_f.sql|Updates to alignment table
+702	\N	patch	patch_92_93_g.sql|New table idr
+703	\N	patch	patch_92_93_h.sql|execution_plan table
+704	\N	patch	patch_92_93_i.sql|fastqc table
+705	\N	patch	patch_92_93_j.sql|phantom peak table
+706	\N	patch	patch_92_93_k.sql|frip table
+707	\N	patch	patch_92_93_l.sql|epigenome columns
+708	\N	patch	patch_92_93_m.sql|Remove constraints


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

Added some biotype info endpoints. Namely info/biotypes/groups and info/biotypes/name
Existing info/biotypes remains unchanged.

### Use case

info/biotypes/groups provides the list of available groups.
info/biotypes/groups/:group/:object_type provides the list of biotypes within that group.
info/biotypes/name/:name/:object_type provides the list of biotypes with that name.

### Benefits

Finding biotype data to be used elsewhere.

### Possible Drawbacks

None expected.

### Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

Pass, of course.

_Have you run the entire test suite and no regression was detected?_

Yes.

### Changelog

[info/biotypes/]
- Added new route [info/biotypes/groups] to retrieve list of available biotype groups.
- Added new route [info/biotypes/groups/:group/:object_type] to retrieve list the properties of biotypes within provided group (and object_type).
- Added new route [info/biotypes/name/:name/:object_type] to retrieve list the properties of biotypes with provided name (and object_type).
