### PR TITLE
The Compara API doesn't print :0 on the root node any more

### DIFF
--- a/t/gene_tree.t
+++ b/t/gene_tree.t
@@ -459,7 +459,7 @@ $nh = nh_GET(
     'Gene-tree (ncRNA) by ID',
 );
 
-my $restricted_RF01299_nh_simple = '(ENSORLT00000026615:0.0716974,ENSPFOT00000021580:0.0877229):0;';
+my $restricted_RF01299_nh_simple = '(ENSORLT00000026615:0.0716974,ENSPFOT00000021580:0.0877229);';
 is($nh, $restricted_RF01299_nh_simple, 'Got the correct newick');
 
 

--- a/t/genomic_alignment.t
+++ b/t/genomic_alignment.t
@@ -489,12 +489,12 @@ sub get_data {
     my $data;
 
     $data->{short_EPO} =  {description=>'','end'=>106040100,'seq'=>'TGAACAAA--------GAAATGTCTTATCCCACAGAGAGTACAGACATTATAGAGTTAT','seq_region'=>2,'species'=>'taeniopygia_guttata','start'=>106040050,'strand'=>1};
-    $data->{short_EPO_tree} = '(taeniopygia_guttata_2_106040050_106040100[+]:0.1715,(gallus_gallus_2_100370256_100370312[+]:0.0414,meleagris_gallopavo_3_49885207_49885257[+]:0.0414)Ggal-Mgal[2]:0.1242)Ggal-Mgal-Tgut[3]:0;';
+    $data->{short_EPO_tree} = '(taeniopygia_guttata_2_106040050_106040100[+]:0.1715,(gallus_gallus_2_100370256_100370312[+]:0.0414,meleagris_gallopavo_3_49885207_49885257[+]:0.0414)Ggal-Mgal[2]:0.1242)Ggal-Mgal-Tgut[3];';
 
     $data->{short_EPO_tree_no_branch_lengths} = '(taeniopygia_guttata_2_106040050_106040100[+],(gallus_gallus_2_100370256_100370312[+],meleagris_gallopavo_3_49885207_49885257[+]));';
 
-    push @{$data->{large_EPO_tree}}, '(taeniopygia_guttata_2_106040050_106040400[+]:0.1715,(gallus_gallus_2_100370256_100370612[+]:0.0414,meleagris_gallopavo_3_49885207_49885557[+]:0.0414)Ggal-Mgal[2]:0.1242)Ggal-Mgal-Tgut[3]:0;';
-    push @{$data->{large_EPO_tree}}, '(taeniopygia_guttata_2_106040401_106041500[+]:0.1715,meleagris_gallopavo_3_49885558_49886610[+]:0.1656)Mgal-Tgut[2]:0;';
+    push @{$data->{large_EPO_tree}}, '(taeniopygia_guttata_2_106040050_106040400[+]:0.1715,(gallus_gallus_2_100370256_100370612[+]:0.0414,meleagris_gallopavo_3_49885207_49885557[+]:0.0414)Ggal-Mgal[2]:0.1242)Ggal-Mgal-Tgut[3];';
+    push @{$data->{large_EPO_tree}}, '(taeniopygia_guttata_2_106040401_106041500[+]:0.1715,meleagris_gallopavo_3_49885558_49886610[+]:0.1656)Mgal-Tgut[2];';
 
     $data->{short_EPO_no_gaps} =  {description=>'','end'=>106040100,'seq'=>'TGAACAAAGAAATGTCTTATCCCACAGAGAGTACAGACATTATAGAGTTAT','seq_region'=>2,'species'=>'taeniopygia_guttata','start'=>106040050,'strand'=>1};
     $data->{short_EPO_soft} =  {description=>'','end'=>106040550,'seq'=>'TAGTGG-TGAttttttggttttttGCCTGCTGGCCCTCCTTCTTTGTACTCA','seq_region'=>2,'species'=>'taeniopygia_guttata','start'=>106040500,'strand'=>1};


### PR DESCRIPTION
### Description

The Compara API has been fixed not to print distances for the root node of trees any more. This commit fixes the tests of this repo.

### Use case

cf Description

### Benefits

cf Description

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie tincidunt quam, id dapibus mauris consequat eu. Phasellus in neque quis purus laoreet malesuada in sit amet tellus.

### Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

Pass, of course.

_Have you run the entire test suite and no regression was detected?_

Yes.

### Changelog

No functionality change