### PR TITLE
export phenotype ontology accessions

### DIFF
--- a/lib/EnsEMBL/REST/Model/Phenotype.pm
+++ b/lib/EnsEMBL/REST/Model/Phenotype.pm
@@ -221,6 +221,7 @@ sub fetch_features_by_gene {
   unless (defined $gene_ad ) {Catalyst::Exception->throw("Species $species not found.");}
 
   my $phenfeat_ad = $c->model('Registry')->get_adaptor($species,'variation', 'phenotypefeature');
+  $phenfeat_ad->_include_ontology(1);
   my $slice_ad = $c->model('Registry')->get_adaptor($species, "core", "slice");
 
   my $include_assoc = $c->request->parameters->{include_associated};
@@ -269,6 +270,7 @@ sub fetch_features_by_gene {
       push @phenotype_features, $record;
     }
   }
+  $phenfeat_ad->_include_ontology(0);
   return \@phenotype_features;
 }
 

--- a/t/lookup.t
+++ b/t/lookup.t
@@ -67,7 +67,7 @@ my $phenotype_response = {
 	object_type => 'Gene', db_type => 'core', species => 'homo_sapiens', id => $id_with_phenotype, version => 3,
 	phenotypes => [
     {genes => undef,source => 'GOA',study => 'PMID:8626802',trait => 'positive regulation of transcription from RNA polymerase II promoter', variants => undef},
-    {genes => undef,source => 'GOA',study => 'PMID:8626802',trait => 'soft palate development',variants => undef}
+    {genes => undef,source => 'GOA',study => 'PMID:8626802',trait => 'soft palate development', ontology_accessions => [ 'GO:0060023'], variants => undef}
    ],};
 cmp_deeply(json_GET("/lookup/id/$id_with_phenotype?phenotypes=1;format=condensed",'lookup a gene with phenotypes'), $phenotype_response, 'Get of a known gene ID with phenotypes option will return phenotypes as well');
 

--- a/t/phenotype_gene.t
+++ b/t/phenotype_gene.t
@@ -90,6 +90,7 @@ my $gene_name='FOXF2';
             },
             description => 'soft palate development',
             location => '6:1312675-1314992',
+            ontology_accessions => [ 'GO:0060023'],
             source => 'GOA' 
           }
         ];
@@ -120,6 +121,7 @@ my $gene_name='FOXF2';
             },
             description => 'soft palate development',
             location => '6:1312675-1314992',
+            ontology_accessions => [ 'GO:0060023'],
             source => 'GOA' 
           }
         ];
@@ -151,10 +153,12 @@ my $gene_name='FOXF2';
             },                                                                       
             description => 'soft palate development',                                       
             location => '6:1312675-1314992',                                                 
+            ontology_accessions => [ 'GO:0060023'],
             source => 'GOA'                                                               
           },       
          {
             Variation => 'rs2299222',
+            ontology_accessions => ['Orphanet:15'],
             attributes => {
             associated_gene => 'YES1,FOXF2',
             external_reference => 'pubmed/17122850'
@@ -192,6 +196,7 @@ my $gene_name='FOXF2';
             },                                                                       
             description => 'soft palate development',                                       
             location => '6:1312675-1314992',                                                 
+            ontology_accessions => [ 'GO:0060023'],
             source => 'GOA'                                                               
           },
           {

--- a/t/test-genome-DBs/homo_sapiens/variation/phenotype_ontology_accession.txt
+++ b/t/test-genome-DBs/homo_sapiens/variation/phenotype_ontology_accession.txt
@@ -1,1 +1,3 @@
+1	Orphanet:15	438	is
 3	Orphanet:130	438	is
+58138	GO:0060023	438	is


### PR DESCRIPTION
### Description

The phenotype REST endpoint retrieves the existing phenotypes but currently does not report the associated ontology accession terms. This is now being updated.

### Use case

The endpoint functionality stays the same.

### Benefits

The result of the endpoint will now also contain ontology accessions.

### Possible Drawbacks

None.

### Testing

_Have you added/modified unit tests to test the changes?_

Yes. The corresponding tests have been updated.

_If so, do the tests pass/fail?_

Tests pass.

_Have you run the entire test suite and no regression was detected?_

Yes.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

The endpoint functions as before, just the output is enriched with accession terms if they are present.