### PR TITLE
remove use of private method

### DIFF
--- a/lib/EnsEMBL/REST/Model/Phenotype.pm
+++ b/lib/EnsEMBL/REST/Model/Phenotype.pm
@@ -221,7 +221,6 @@ sub fetch_features_by_gene {
   unless (defined $gene_ad ) {Catalyst::Exception->throw("Species $species not found.");}
 
   my $phenfeat_ad = $c->model('Registry')->get_adaptor($species,'variation', 'phenotypefeature');
-  $phenfeat_ad->_include_ontology(1);
   my $slice_ad = $c->model('Registry')->get_adaptor($species, "core", "slice");
 
   my $include_assoc = $c->request->parameters->{include_associated};
@@ -270,7 +269,6 @@ sub fetch_features_by_gene {
       push @phenotype_features, $record;
     }
   }
-  $phenfeat_ad->_include_ontology(0);
   return \@phenotype_features;
 }
 


### PR DESCRIPTION
### Description

Removing the private method call to reflect the bug fix in the dependent repository.

### Use case

The endpoint functionality stays the same.

### Benefits

The result of the endpoint will contain ontology accessions without the need of calling a private method.

### Possible Drawbacks

None.

### Testing

_Have you added/modified unit tests to test the changes?_

No change in the tests was needed.

_If so, do the tests pass/fail?_

Tests pass.

_Have you run the entire test suite and no regression was detected?_

Yes.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

The endpoint functionality is not changed.