### PR TITLE
Add new privacy policy link for archive 89 site

### DIFF
--- a/root/wrapper.tt
+++ b/root/wrapper.tt
@@ -60,6 +60,7 @@ limitations under the License.
                         <li><a href="http://github.com/Ensembl/ensembl-rest/wiki/Change-log">Change Log</a></li>
                         <li><a href="[% service_parent_url %]/info/about/index.html">About the Ensembl Project</a></li>
                         <li><a href="[% service_parent_url %]/info/about/contact/">Contact Ensembl</a></li>
+                        <li><a target="_blank" href="https://www.ebi.ac.uk/data-protection/ensembl/privacy-notice">Privacy Notice</a></li>
                     </ul>
             </div><!-- container-->
         </div><!-- navbar-inner-->


### PR DESCRIPTION
### Description

New GDPR privacy policy link for archive 89 site.

### Benefits

Users can access the updated privacy policy.

### Possible Drawbacks

We may lose users if they don't accept the privacy policy.

### Testing

Tested successfully in sandbox.
