### PR TITLE
update info/variation/population REST endpoint to retrieve individuals

### DIFF
--- a/lib/EnsEMBL/REST/Controller/Info.pm
+++ b/lib/EnsEMBL/REST/Controller/Info.pm
@@ -299,6 +299,23 @@ sub populations: Chained('/') PathPart('info/variation/populations') Args(1) Act
   return;
 }
 
+sub population_name_GET: {}
+
+sub population_name: Chained('/') PathPart('info/variation/populations') Args(2) ActionClass('REST') {
+  my ($self, $c, $species, $pop_name) = @_;
+  $c->stash(species => $species) if defined $species;
+  $c->stash(population_name => $pop_name) if defined $pop_name;
+  my $populations;
+  try {
+    $populations = $c->model('Variation')->fetch_population_infos($c->request->param('filter'));
+  } catch {
+    $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;
+    $c->go('ReturnError', 'custom', [qq{$_}]);
+  };
+  $self->status_ok($c, entity => $populations);
+  return;
+}
+
 sub consequence_types: Path('variation/consequence_types') Args(0) ActionClass('REST') { }
 
 sub consequence_types_GET {

--- a/lib/EnsEMBL/REST/Controller/Info.pm
+++ b/lib/EnsEMBL/REST/Controller/Info.pm
@@ -303,11 +303,11 @@ sub population_name_GET: {}
 
 sub population_name: Chained('/') PathPart('info/variation/populations') Args(2) ActionClass('REST') {
   my ($self, $c, $species, $pop_name) = @_;
-  $c->stash(species => $species) if defined $species;
-  $c->stash(population_name => $pop_name) if defined $pop_name;
+  $c->stash(species => $species);
+  $c->stash(population_name => $pop_name);
   my $populations;
   try {
-    $populations = $c->model('Variation')->fetch_population_infos($c->request->param('filter'));
+    $populations = $c->model('Variation')->fetch_population_infos();
   } catch {
     $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;
     $c->go('ReturnError', 'custom', [qq{$_}]);

--- a/lib/EnsEMBL/REST/Model/Variation.pm
+++ b/lib/EnsEMBL/REST/Model/Variation.pm
@@ -423,7 +423,9 @@ sub fetch_population_infos {
   
   my $populations;
   if (defined $population_name){
-    push @$populations, $pa->fetch_by_name($population_name);
+    my $population = $pa->fetch_by_name($population_name);
+    unless (defined $population ) {Catalyst::Exception->throw("Population '$population_name' not found.");}
+    push @$populations, $population;
   } else {
     if (defined $filter) {
       if ($filter eq 'LD') {

--- a/lib/EnsEMBL/REST/Model/Variation.pm
+++ b/lib/EnsEMBL/REST/Model/Variation.pm
@@ -420,7 +420,9 @@ sub fetch_population_infos {
   my $population_name = $c->stash->{population_name} if defined $c->stash->{population_name};
 
   my $pa = $c->model('Registry')->get_adaptor($species, 'Variation', 'Population');
-  
+  if (!$pa) {
+    Catalyst::Exception->throw("Species $species does not have population data.");
+  }
   my $populations;
   if (defined $population_name){
     my $population = $pa->fetch_by_name($population_name);

--- a/root/documentation/info.conf
+++ b/root/documentation/info.conf
@@ -432,7 +432,7 @@
   </variation_populations> 
 
   <variation_population_name>
-    description=List population and all its individuals for a species
+    description=List all individuals for a population from a species
     endpoint="info/variation/populations/:species:/:population_name"
     method=GET
     group=Information

--- a/root/documentation/info.conf
+++ b/root/documentation/info.conf
@@ -431,6 +431,37 @@
     </examples>
   </variation_populations> 
 
+  <variation_population_name>
+    description=List population and all its individuals for a species
+    endpoint="info/variation/populations/:species:/:population_name"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <params>
+      <species>
+        type=String
+        description=Species name/alias
+        required=1
+        example=__VAR(species_common)__
+      </species>
+      <population_name>
+        type=String
+        description=Population name
+        required=1
+        example=__VAR(population_name)__
+      </population_name>
+    </params>
+    <examples>
+      <a>
+        path=/info/variation/populations/
+        capture=__VAR(species_common)__
+        capture=__VAR(population_name)__
+        content=application/json
+      </a>
+    </examples>
+  </variation_population_name>
+
   <variation_consequence_types>
     description=Lists all variant consequence types.
     endpoint="info/variation/consequence_types"

--- a/t/info.t
+++ b/t/info.t
@@ -274,6 +274,19 @@ is_json_GET(
   cmp_bag(json_GET('/info/variation/populations/homo_sapiens?filter=LD',"LD variants"), $expected, 'Checking filtering for LD population works');
 }
 
+#/info/variation/populations/:species:/:population_name
+{
+  my $population_name = "1000GENOMES:phase_1_ASW";
+  my $json = json_GET("/info/variation/populations/homo_sapiens/1000GENOMES:phase_1_ASW", 'GET specific population for given species in variation database');
+  cmp_ok(scalar(@{$json}), '==', 1, 'Test that one population was returned');
+  cmp_ok($json->[0]->{name}, 'eq', $population_name, 'Test that correct population was returned');
+  cmp_ok($json->[0]->{size}, '==', 61, 'Test correct population size');
+  cmp_ok(scalar(@{$json->[0]->{individuals}}), '==', 61, 'Test that correct number of individuals was returned');
+  cmp_ok($json->[0]->{individuals}->[0]->{name}, 'eq', '1000GENOMES:phase_1:NA19625', 'Test first individual name');
+  cmp_ok($json->[0]->{individuals}->[0]->{gender}, 'eq', 'Female', 'Test first individual gender');
+
+}
+
 #/info/variation/consequence_types
 {
   # Check correct data structure returned

--- a/t/info.t
+++ b/t/info.t
@@ -292,6 +292,19 @@ is_json_GET(
   action_bad($bad_get, "Population badPopulationName not found.");
 }
 
+#/info/variation/populations/:species:/:population_name - bad_species
+{
+  my $bad_get = "/info/variation/populations/bad_species/1000GENOMES:phase_1_ASW";
+  action_bad($bad_get, 'bad_species is not a valid species name');
+}
+
+#/info/variation/populations/:species:/:population_name - species with no population data
+{
+  my $chicken = Bio::EnsEMBL::Test::MultiTestDB->new("gallus_gallus");
+  my $bad_get = "/info/variation/populations/gallus_gallus/1000GENOMES:phase_1_ASW";
+  action_bad($bad_get, 'Species gallus_gallus does not have population data');
+}
+
 #/info/variation/consequence_types
 {
   # Check correct data structure returned

--- a/t/info.t
+++ b/t/info.t
@@ -284,7 +284,12 @@ is_json_GET(
   cmp_ok(scalar(@{$json->[0]->{individuals}}), '==', 61, 'Test that correct number of individuals was returned');
   cmp_ok($json->[0]->{individuals}->[0]->{name}, 'eq', '1000GENOMES:phase_1:NA19625', 'Test first individual name');
   cmp_ok($json->[0]->{individuals}->[0]->{gender}, 'eq', 'Female', 'Test first individual gender');
+}
 
+#/info/variation/populations/:species:/:population_name - bad name
+{
+  my $bad_get = "/info/variation/populations/homo_sapiens/badPopulationName";
+  action_bad($bad_get, "Population badPopulationName not found.");
 }
 
 #/info/variation/consequence_types


### PR DESCRIPTION
### Description

The variation/population REST endpoint retrieves population names, descriptions and sample counts. Individuals/Population are also of interest. This update allows the retrieval of individual names and any genders for a given population name. 

### Use case

We have had requests for the ability to retrieve lists of individuals by population to help in analysis of genotype data. This functionality was only available in the perl API.

GET info/variation/populations/:species/:population_name

### Benefits

The update allows retrieval of all individuals for a population from a species.

### Possible Drawbacks

None.

### Testing

Yes. The corresponding tests have been updated.

_If so, do the tests pass/fail?_

Tests pass.

_Have you run the entire test suite and no regression was detected?_

Yes.

### Changelog

[/info/variation/population] Added the ability to retrieve all individuals for a population from a species.
