### PR TITLE
[ENSCORESW-2749] Add a hashing algorithm and user-derived salt to rate limiter

### DIFF
--- a/lib/Plack/Middleware/EnsThrottle.pm
+++ b/lib/Plack/Middleware/EnsThrottle.pm
@@ -110,13 +110,14 @@ use Net::CIDR::Lite;
 use Readonly;
 use Plack::Middleware::EnsThrottle::SimpleBackend;
 use Plack::Request;
+use Digest::MD5 qw/md5_hex/;
 
 Readonly::Scalar my $CLIENT_ID_PREFIX => 'throttle';
 Readonly::Scalar my $MESSAGE => 'Too many requests';
 Readonly::Scalar my $RETRY_AFTER_ADDITION => 0;
 
 # Implement the following in subclasses (stubbed as yada-yada)
-# - period - time overwhich we calculate the limit (seconds)
+# - period - time over which we calculate the limit (seconds)
 # - key - the key to use in our backend storage layer to store current number of requests
 # - reset_time - time until we will accept a new request
 
@@ -297,16 +298,23 @@ sub _whitelisted_hdr {
 
 sub _client_id_helper {
   my ( $self, $env ) = @_;
+
   return $env->{REMOTE_USER} ||
-      $env->{HTTP_X_CLUSTER_CLIENT_IP} ||
-      $env->{REMOTE_ADDR};
+    $env->{HTTP_X_CLUSTER_CLIENT_IP} ||
+    $env->{REMOTE_ADDR};
 }
 
+# This is only called in subclasses - Second, Minute, Hour.
+# Add the user agent to salt the IP in unpredictable fashion, then anonymise via md5sum.
+# This is to improve our GDPR compliance in regard to storing user IP addresses in the memcached.
 sub _client_id {
   my ($self, $env) = @_;
   my $id = $self->_client_id_helper($env);
+  
   my $prefix = $self->client_id_prefix() || $CLIENT_ID_PREFIX;
-  return $prefix.'_'.$id;
+  my $user_agent = '';
+  $user_agent = $env->{HTTP_USER_AGENT} if exists $env->{HTTP_USER_AGENT};
+  return $prefix.'_'.md5_hex($user_agent.$id);
 }
 
 sub _populate_cidr {
@@ -324,7 +332,7 @@ sub _populate_array {
     my ($self, $input) = @_;
 
     if($input) {
-	$input = (ref($input) eq 'ARRAY') ? $input : [$input];
+      $input = (ref($input) eq 'ARRAY') ? $input : [$input];
     }
     return $input;
 }

--- a/t/ratelimit.t
+++ b/t/ratelimit.t
@@ -41,6 +41,11 @@ my $default_remote_user_sub = sub {
   };
 };
 
+# Verify that anonymisation works on key for memcached:
+my $anonymised_IP = Plack::Middleware::EnsThrottle::Second->_client_id({ REMOTE_USER => '127.0.0.1', HTTP_USER_AGENT => 'Curl'});
+is($anonymised_IP, 'throttle_eb4189c32cd43041d6602cafc025a909', 'Given the same user IP and user agent, we should always get the same hashed result');
+
+
 # First check if we build the object it'll die without key attributes
 throws_ok { Plack::Middleware::EnsThrottle::Second->new()->prepare_app() } 
   qr/Cannot continue.+max_requests/, 'No max_requests given caught';


### PR DESCRIPTION
### Description

Anonymise the IP addresses used to rate-limit REST API users. A user-agent derived salt is added to the IP address and MD5 is used to encode it. 

### Use case

Production use of ensembl-rest requires a transient database record of user activity above what is collected at the institution load balancer.

### Benefits

This is a good faith effort to mitigate our obligations w.r.t. GDPR compliance. User IP storage is transient and never in plain text form. We would need to expend great effort to extract the IP addresses from the rate limiter.

### Possible Drawbacks

A per-request cost to encode the user's IP. Very unlikely hash collision, where two users end up sharing the same rate limit.

### Testing

A simple cross-check is added that tests the encoded IP address is a hash and not an IP.

### Changelog

This change should be invisible to users.