### PR TITLE
Feature/fixratelimit

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -65,3 +65,4 @@ test_requires 'Test::Deep';
 test_requires 'HTTP::Request::Common';
 test_requires 'Plack::Test';
 test_requires 'Net::CIDR::Lite';
+test_requires 'Test::Time::HiRes';

--- a/lib/Plack/Middleware/EnsThrottle.pm
+++ b/lib/Plack/Middleware/EnsThrottle.pm
@@ -167,7 +167,6 @@ sub call {
       #If we are throttled then we have to prepare the throttle response
       if($remaining_requests == 0) {
         $res = [429, ['Content-Type', 'text/plain'], [$self->message() || $MESSAGE]];
-        $remaining_requests = 0;
         $retry_after = 1;
       }
       else {
@@ -295,6 +294,7 @@ sub _whitelisted_hdr {
     return grep { $_ eq $hdr_value } @{$values};
 }
 
+# Try to get the IP of the real client, and not any intervening load balancer or proxy
 sub _client_id_helper {
   my ( $self, $env ) = @_;
   return $env->{REMOTE_USER} ||

--- a/lib/Plack/Middleware/EnsThrottle/Second.pm
+++ b/lib/Plack/Middleware/EnsThrottle/Second.pm
@@ -25,12 +25,13 @@ use parent 'Plack::Middleware::EnsThrottle';
 
 sub key {
   my ($self, $env) = @_;
-  return sprintf('%s_%d', $self->_client_id($env),CORE::time());
+  my ($seconds,$microseconds) = Time::HiRes::time();
+  return sprintf('%s_%d', $self->_client_id($env),$seconds);
 }
  
 sub reset_time {
   my ($self) = @_;
-  my ($seconds, $microseconds) = Time::HiRes::gettimeofday;
+  my ($seconds, $microseconds) = Time::HiRes::time;
   #Current millis from microseconds
   my $millis = $microseconds/1000;
   #The time remaining in seconds before we will allow more requests

--- a/t/ratelimit.t
+++ b/t/ratelimit.t
@@ -148,6 +148,7 @@ sleep_until_next_second();
 
       note 'And pause then try with the wrong token value';
       sleep(1);
+      sleep_until_next_second();
       $res = $cb->(GET '/');
       is($res->code(), 200, 'Checking for a 200');
       $res = $cb->(GET '/', 'Token' => 'imnocool');
@@ -155,6 +156,7 @@ sleep_until_next_second();
 
       note 'And pause then try with the wrong token header';
       sleep(1);
+      sleep_until_next_second();
       $res = $cb->(GET '/');
       is($res->code(), 200, 'Checking for a 200');
       $res = $cb->(GET '/', 'Ttoken' => 'imacool');

--- a/t/ratelimit.t
+++ b/t/ratelimit.t
@@ -60,6 +60,9 @@ note 'Custom messages';
 assert_basic_rate_limit('EnsThrottle::Second', 1, 'second', 'You have done too much!');
 
 note 'Trying different remote ip headers';
+# These are the product of different load balancers. Since the load balancer is the source
+# of the request, it must report the real client ID in a header. These are three of those
+# headers
 sleep_until_next_second();
 $remote_ip_header = 'HTTP_X_CLUSTER_CLIENT_IP';
 assert_basic_rate_limit('EnsThrottle::Second', 1, 'second', 'Using HTTP_X_CLUSTER_CLIENT_IP as header');

--- a/t/ratelimit.t
+++ b/t/ratelimit.t
@@ -285,7 +285,7 @@ sub sleep_until_next_second {
   my $time = Time::HiRes::time();
   my $ceil = ceil($time);
   my $diff = $ceil-$time;
-  if($diff < 0.3) {
+  if($diff < 0.5) {
     note "Sleeping for ${diff} fractions of a second to avoid time related test failures";
     Time::HiRes::sleep($diff);
   }

--- a/t/ratelimit.t
+++ b/t/ratelimit.t
@@ -275,7 +275,7 @@ sleep_until_next_second();
 
       #Now inspect the numbers in the storage engine. We should not have negative numbers
       my ($value) = values %{$minute_backend->{hash}};
-      cmp_ok($value, '==', $max_requests, 'Checking that the backing hash maxs out at '.$max_requests);
+      cmp_ok($value, '==', $max_requests, 'Checking that the backing hash maxes out at '.$max_requests);
     };
 }
 
@@ -285,13 +285,13 @@ sub sleep_until_next_second {
   my $time = Time::HiRes::time();
   my $ceil = ceil($time);
   my $diff = $ceil-$time;
-  if($diff < 0.5) {
+  # if($diff < 0.5) {
     note "Sleeping for ${diff} fractions of a second to avoid time related test failures";
     Time::HiRes::sleep($diff);
-  }
-  else {
-    note "Carrying on. We are $diff fraction of a second away from the second. Should be ok";
-  }
+  # }
+  # else {
+    # note "Carrying on. We are $diff fraction of a second away from the second. Should be ok";
+  # }
   return;
 }
 
@@ -303,6 +303,7 @@ sub sleep_until_next_minute {
   my $diff = 60 - $seconds;
   if($diff < 4) {
     note "Sleeping for $diff seconds to avoid time related test failure";
+    sleep($diff);
   }
   else {
     note "Carrying on. We are $diff seconds away from the minute. Should be ok";


### PR DESCRIPTION
### Description

The rate limiter has been intermittently failing on Travis for some time now. There is clearly a problem with time on a heavily virtualised platform.

### Use case
If we make the rate limiter test less dependent on time, it should be less fragile in CI environments

### Benefits
Travis failures should be real problems, and not just the rate limiter. ratelimit.t should finish sooner as it has no significant sleep calls to wait for.

### Possible Drawbacks
May not have fixed the rate limiter for all time. There are still some parts which rely on a time component.

### Testing
No changes outside of ratelimit.t

Travis tests have passed 3 times

### Changelog

No user-facing changes