### PR TITLE
ENSCORESW-2814

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -181,6 +181,10 @@ jsonp=1
     genomic_alignment_species2=gallus_gallus
     genomic_alignment_pw_region=2:106041430-106041480:1
 
+    biotype_group=coding
+    biotype_name=CRISPR
+    biotype_ot=gene
+
     info_division=ensembl
   </replacements>
 </Model::Documentation>


### PR DESCRIPTION
### Description

Some replacement variables were not set.

### Use case

An error would appear when visiting http://rest.ensembl.org/documentation/info/biotypes_groups 
stating the missing variables.

### Benefits

The error should go away

### Possible Drawbacks

none I can see

### Testing

no


### Changelog

no