### PR TITLE
Fix broken URL pointing to the Ensembl Variation documentation

### DIFF
--- a/root/documentation/overlap.conf
+++ b/root/documentation/overlap.conf
@@ -52,7 +52,7 @@
       </so_term>
       <variant_set>
         type=String
-        description= Short name of a set to restrict the variants found. (<a target="_blank" href="http://www.ensembl.org/info/genome/variation/data_description.html\#variation_sets">See list of short set names</a>) 
+        description= Short name of a set to restrict the variants found. (<a target="_blank" href="//www.ensembl.org/info/genome/variation/species/sets.html">See list of short set names</a>) 
         example=ClinVar
       </variant_set>
       <misc_set>


### PR DESCRIPTION
### Description

Fix old URL pointing to the Ensembl Variation documentation

### Benefits

Link is pointing to an actual page on the Ensembl Live Website