### PR TITLE
If a user tries to request a cds or protein type in the sequence endp…

### DIFF
--- a/lib/EnsEMBL/REST/Controller/Sequence.pm
+++ b/lib/EnsEMBL/REST/Controller/Sequence.pm
@@ -306,6 +306,12 @@ sub _process_feature {
   }
   # Anything else (like exon)
   else {
+    # Special case, it doesn't make sense to try and fetch coding sequence from an exon,
+    # we have no idea which transcript the exon is associated with. So throw an error.
+    if($object->isa('Bio::EnsEMBL::Exon') && (($type eq 'cds') || ($type eq 'protein'))) {
+      $c->go('ReturnError', 'custom', ["The type $type can not be use when retrieving an Exon"]);
+    }
+
     $slice = $object->feature_Slice();
   }
   

--- a/t/sequences.t
+++ b/t/sequences.t
@@ -232,6 +232,40 @@ Catalyst::Test->import('EnsEMBL::REST');
   );
 }
 
+# DNA via Exon id in FASTA
+{
+  my $id = 'ENSE00001271861';
+  my $url = "/sequence/id/${id}";
+  my $fasta = fasta_GET($url, 'Getting ENSE00001271861 in FASTA');
+  my $expected = <<'FASTA';
+>ENSE00001271861.1 chromosome:GRCh37:6:1080164:1080229:1
+CCTCAAATAAGAGCCACAAACGTGGAAGATATATCCAAAGGAACCAAATTAAAGGACTGG
+AGAAAG
+FASTA
+  is($fasta, $expected, 'ENSE00001271861 FASTA formatting');
+
+}
+
+# CDS via Exon id in FASTA; bad
+{
+  my $id = 'ENSE00001271861';
+  action_bad_regex(
+    '/sequence/id/'.$id.'?type=cds',
+    qr/can not be use when retrieving an Exon/,
+    'Attempting to get CDS on an Exon, that doesn\'t make sense'
+  );
+}
+
+# protein via Exon id in FASTA; bad
+{
+  my $id = 'ENSE00001271861';
+  action_bad_regex(
+    '/sequence/id/'.$id.'?type=protein',
+    qr/can not be use when retrieving an Exon/,
+    'Attempting to get protein on an Exon, that doesn\'t make sense'
+  );
+}
+
 # DNA Region; bad
 {
   my $region = '6:1..30001';


### PR DESCRIPTION
…oint using an exon id, that should be an error. We don't know what transcript to associate with that exon.

We don't need to create an entire top level elsif for Bio::EnsEMBL::Exon, that would cause duplication of the default behaviour code for all other 'type' arguments. If in the future the logic becomes more complex, then yes Exons can get their on entry in the Gene, Transcript, etc top level if/else statements. But this is a very specific corner case.

### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

If a user tries to request a cds or protein type in the sequence endpoint using an exon id, that should be an error. We don't know what transcript to associate with that exon. So... throw an error.

### Use case

A user does type=protein or type=cds on the sequence endpoint with an exon id, that's lunacy. Lunacy, I tell you!

### Benefits

Users won't think they're getting exons with the UTR trimmed, when they're not.

### Possible Drawbacks

Break legacy code that doesn't take it in to account.

### Testing

Added tests for this situation, plus a successful exon retrieval test which never existed.

_If so, do the tests pass/fail?_

Pass

### Changelog

[/sequence/id] Retrieving sequence using an exon id and types protein or cds now return an error, this combination of parameters is not valid.
