### PR TITLE
Bump version to 8.0, e94 - for real this time

### DIFF
--- a/lib/EnsEMBL/REST.pm
+++ b/lib/EnsEMBL/REST.pm
@@ -64,7 +64,7 @@ use Catalyst qw/
 /;
 
 
-our $VERSION = '7.0';
+our $VERSION = '8.0';
 
 # Configure the application.
 #


### PR DESCRIPTION
Turns out the commit which was supposed to bump the version, did not. Given there will have been breaking changes between e93 and e94, we'd better make sure the server version number does get updated before the release day.