### PR TITLE
For population allele frequencies only return allele count if available

### DIFF
--- a/lib/EnsEMBL/REST/Model/Variation.pm
+++ b/lib/EnsEMBL/REST/Model/Variation.pm
@@ -330,7 +330,7 @@ sub pops_as_hash {
   my $population;
   $population->{frequency} = 0 + $allele->frequency(); # Add 0 to treat it as numeric (to avoid quoting)
   $population->{population} = $allele->population->name();
-  $population->{allele_count} = 0 + $allele->count(); # Add 0 to treat it as numeric (to avoid quoting)
+  $population->{allele_count} = 0 + $allele->count() if defined $allele->count(); # Add 0 to treat it as numeric (to avoid quoting)
   $population->{allele} = $allele->allele();
   $population->{submission_id} = $allele->subsnp() if $allele->subsnp();
 

--- a/lib/EnsEMBL/REST/Model/Variation.pm
+++ b/lib/EnsEMBL/REST/Model/Variation.pm
@@ -330,7 +330,9 @@ sub pops_as_hash {
   my $population;
   $population->{frequency} = 0 + $allele->frequency(); # Add 0 to treat it as numeric (to avoid quoting)
   $population->{population} = $allele->population->name();
-  $population->{allele_count} = 0 + $allele->count() if defined $allele->count(); # Add 0 to treat it as numeric (to avoid quoting)
+  if (defined $allele->count()) {
+    $population->{allele_count} = 0 + $allele->count(); # Add 0 to treat it as numeric (to avoid quoting)
+  }
   $population->{allele} = $allele->allele();
   $population->{submission_id} = $allele->subsnp() if $allele->subsnp();
 

--- a/t/variation.t
+++ b/t/variation.t
@@ -105,6 +105,47 @@ my $expected_result = { rs142276873 => $expected_variation_1, rs67521280 => $exp
 
 is_json_POST($base,$post_data,$expected_result,"Try to POST list of variations");
 
+# Test population allele frequency with no allele_count
+  $id = 'COSM946275';
+  my $expected_pops_nc = {
+    'source' => 'http://cancer.sanger.ac.uk/cancergenome/projects/cosmic/',
+    'mappings' => [
+      {
+        'location' => '13:25744274-25744274',
+        'assembly_name' => 'GRCh37',
+        'end' => 25744274,
+        'seq_region_name' => '13',
+        'strand' => 1,
+        'coord_system' => 'chromosome',
+        'allele_string' => 'C/T',
+        'start' => 25744274
+     }
+    ],
+    'name' => 'COSM946275',
+    'MAF' => undef,
+    'ambiguity' => 'Y',
+    'populations' => [
+      {
+        'frequency' => '0.923077',
+        'population' => 'COSMIC:gene:FAM123A_ENST00000515384:tumour_site:endometrium',
+        'allele' => 'C',
+      },
+      {
+        'frequency' => '0.0769231',
+        'population' => 'COSMIC:gene:FAM123A_ENST00000515384:tumour_site:endometrium',
+        'allele' => 'T',
+     }
+    ],
+    'var_class' => 'somatic SNV',
+    'synonyms' => [],
+    'evidence' => [],
+    'ancestral_allele' => undef,
+    'most_severe_consequence' => 'missense_variant',
+    'minor_allele' => undef
+   };
+  $pops_json = json_GET("$base/$id?pops=1", "Population info");
+  cmp_deeply($pops_json, $expected_pops_nc, "Returning population information - no allele_count");
+
 # In test database the variant data for the publication PMID:22779046 PMC:3392070
 # is set to $publication_output
 my $publication_output = 

--- a/t/variation.t
+++ b/t/variation.t
@@ -144,7 +144,9 @@ is_json_POST($base,$post_data,$expected_result,"Try to POST list of variations")
     'minor_allele' => undef
    };
   $pops_json = json_GET("$base/$id?pops=1", "Population info");
-  cmp_deeply($pops_json, $expected_pops_nc, "Returning population information - no allele_count");
+  cmp_deeply($pops_json->{'populations'},
+             bag(@{$expected_pops_nc->{'populations'}}),
+             "Returning population information - no allele_count");
 
 # In test database the variant data for the publication PMID:22779046 PMC:3392070
 # is set to $publication_output


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

For population allele frequencies only return the allele count if available

### Use case

Currenty if there is allele_frequency but no allele_count the end_point returns the allele_count as 0.
This is incorrect.  The allele_count key is no longer returned.


### Benefits

The allele_count is not reported if not available.


### Possible Drawbacks

Users may have looked for the 'allele_count' key


### Testing

A test has been added for a population allele frequency with no allele_count

The test passes


_Have you run the entire test suite and no regression was detected?_
Yes

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

/variation/:species/:id?pops=1,  for population allele frequencies with no allele count property is not returned.
 
