### PR TITLE
Remove CSN plugin support

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -113,11 +113,6 @@
         description=Retrieves a conservation score from the Ensembl Compara databases for variant positions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Conservation.pm">plugin details</a>)
         default=0
       </Conservation>
-      <CSN>
-        type=Boolean
-        description=Reports Clinical Sequencing Nomenclature (CSN) for variants (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CSN.pm">plugin details</a>)
-        default=0
-      </CSN>
       <dbNSFP>
         type=String
         description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://drive.google.com/file/d/0B60wROKy6OqcSFNBbWVjNWl5UjQ/view?usp=sharing">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
@@ -286,11 +281,6 @@
         description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
         default=0
       </Blosum62>
-      <CSN>
-        type=Boolean
-        description=Reports Clinical Sequencing Nomenclature (CSN) for variants (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CSN.pm">plugin details</a>)
-        default=0
-      </CSN>
       <dbNSFP>
         type=String
         description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://drive.google.com/file/d/0B60wROKy6OqcSFNBbWVjNWl5UjQ/view?usp=sharing">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
@@ -446,11 +436,6 @@
         description=Retrieves a conservation score from the Ensembl Compara databases for variant positions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Conservation.pm">plugin details</a>)
         default=0
       </Conservation>
-      <CSN>
-        type=Boolean
-        description=Reports Clinical Sequencing Nomenclature (CSN) for variants (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CSN.pm">plugin details</a>)
-        default=0
-      </CSN>
       <dbNSFP>
         type=String
         description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://drive.google.com/file/d/0B60wROKy6OqcSFNBbWVjNWl5UjQ/view?usp=sharing">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
@@ -601,11 +586,6 @@
         description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
         default=0
       </Blosum62>
-      <CSN>
-        type=Boolean
-        description=Reports Clinical Sequencing Nomenclature (CSN) for variants (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CSN.pm">plugin details</a>)
-        default=0
-      </CSN>
       <dbNSFP>
         type=String
         description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://drive.google.com/file/d/0B60wROKy6OqcSFNBbWVjNWl5UjQ/view?usp=sharing">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
@@ -762,11 +742,6 @@
         description=Retrieves a conservation score from the Ensembl Compara databases for variant positions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Conservation.pm">plugin details</a>)
         default=0
       </Conservation>
-      <CSN>
-        type=Boolean
-        description=Reports Clinical Sequencing Nomenclature (CSN) for variants (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CSN.pm">plugin details</a>)
-        default=0
-      </CSN>
       <dbNSFP>
         type=String
         description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://drive.google.com/file/d/0B60wROKy6OqcSFNBbWVjNWl5UjQ/view?usp=sharing">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
@@ -924,11 +899,6 @@
         description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
         default=0
       </Blosum62>
-      <CSN>
-        type=Boolean
-        description=Reports Clinical Sequencing Nomenclature (CSN) for variants (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CSN.pm">plugin details</a>)
-        default=0
-      </CSN>
       <dbNSFP>
         type=String
         description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://drive.google.com/file/d/0B60wROKy6OqcSFNBbWVjNWl5UjQ/view?usp=sharing">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

_Using one or more sentences, describe in detail the proposed changes._

### Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

### Benefits

Remove CSN plugin option from VEP plugin as no longer needed and has also been removed from web

### Possible Drawbacks

User will miss option

### Testing

_Have you added/modified unit tests to test the changes?_
No tests added. Info page was checked visually
_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
No change to code. Test run.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians
[/vep/:species] CSN option removed