### PR TITLE
E94 backports

### DIFF
--- a/lib/EnsEMBL/REST/Controller/Sequence.pm
+++ b/lib/EnsEMBL/REST/Controller/Sequence.pm
@@ -306,6 +306,12 @@ sub _process_feature {
   }
   # Anything else (like exon)
   else {
+    # Special case, it doesn't make sense to try and fetch coding sequence from an exon,
+    # we have no idea which transcript the exon is associated with. So throw an error.
+    if($object->isa('Bio::EnsEMBL::Exon') && (($type eq 'cds') || ($type eq 'protein'))) {
+      $c->go('ReturnError', 'custom', ["The type $type can not be use when retrieving an Exon"]);
+    }
+
     $slice = $object->feature_Slice();
   }
   

--- a/t/sequences.t
+++ b/t/sequences.t
@@ -232,6 +232,40 @@ Catalyst::Test->import('EnsEMBL::REST');
   );
 }
 
+# DNA via Exon id in FASTA
+{
+  my $id = 'ENSE00001271861';
+  my $url = "/sequence/id/${id}";
+  my $fasta = fasta_GET($url, 'Getting ENSE00001271861 in FASTA');
+  my $expected = <<'FASTA';
+>ENSE00001271861.1 chromosome:GRCh37:6:1080164:1080229:1
+CCTCAAATAAGAGCCACAAACGTGGAAGATATATCCAAAGGAACCAAATTAAAGGACTGG
+AGAAAG
+FASTA
+  is($fasta, $expected, 'ENSE00001271861 FASTA formatting');
+
+}
+
+# CDS via Exon id in FASTA; bad
+{
+  my $id = 'ENSE00001271861';
+  action_bad_regex(
+    '/sequence/id/'.$id.'?type=cds',
+    qr/can not be use when retrieving an Exon/,
+    'Attempting to get CDS on an Exon, that doesn\'t make sense'
+  );
+}
+
+# protein via Exon id in FASTA; bad
+{
+  my $id = 'ENSE00001271861';
+  action_bad_regex(
+    '/sequence/id/'.$id.'?type=protein',
+    qr/can not be use when retrieving an Exon/,
+    'Attempting to get protein on an Exon, that doesn\'t make sense'
+  );
+}
+
 # DNA Region; bad
 {
   my $region = '6:1..30001';


### PR DESCRIPTION
1. Cherry-pick the ENSCORESW2842 fix from master. That was apparently supposed to be done by Mag bug she hasn't managed to take care of it before her holiday.

2. Update the docs pointer to have the above + implementation of the BindingMatrix endpoint (which got cherry-picked earlier) listed in the e94 change log.
