### PR TITLE
Only try to create log/PID dirs if the server is starting.

### DIFF
--- a/bin/production/server_control.pl
+++ b/bin/production/server_control.pl
@@ -37,8 +37,10 @@ my $init_config= $ENV{ENSEMBL_INIT_CONFIG} || '~/.bashrc';
 my $log_root   = $ENV{ENSEMBL_LOG_ROOT} || "$root_dir/logs";
 my $pid_root   = dirname($pid_file);
 
-ensure_dir_exists($pid_root, 0755, 'PID root');
-ensure_dir_exists($log_root, 0755, 'log root');
+if ($ARGV[0] =~ /^(start|restart|foreground)$/) {
+  ensure_dir_exists($pid_root, 0755, 'PID root');
+  ensure_dir_exists($log_root, 0755, 'log root');
+}
 
 Daemon::Control->new(
   {


### PR DESCRIPTION
### Description

Only try to create log/PID dirs if the server is starting.
The server control script may be used for other purposes than starting the server, 

### Use case

e.g. the REST installer uses the server control script to generate an init script, at which time we should not create these dirs.

### Benefits

The installer works properly

### Possible Drawbacks

none

### Testing

Tested in my sandbox

### Changelog

Server log/PID dirs now only created on server start operations
