### PR TITLE
No alignment available after filtering by "display_species"

### DIFF
--- a/lib/EnsEMBL/REST/Model/GenomicAlignment.pm
+++ b/lib/EnsEMBL/REST/Model/GenomicAlignment.pm
@@ -123,7 +123,7 @@ sub get_alignment {
     #Must have new object here because of potential tree pruning (calls minimize_tree)
     $this_genomic_align_tree->repeatmask($mask);
     my $new_tree = $this_genomic_align_tree->prune($display_species);
-    push @$new_genomic_align_trees, $new_tree;
+    push @$new_genomic_align_trees, $new_tree if $new_tree;
   }
   
   return  $new_genomic_align_trees;

--- a/t/genomic_alignment.t
+++ b/t/genomic_alignment.t
@@ -77,6 +77,12 @@ my $data = get_data();
   action_bad_regex("/alignment/region/$species/$region?method=EPO;species_set=gallus_gallus;species_set=wibble", qr/wibble/, "Using unsupported species_set causes an exception");
 }
 
+# No alignment on this region
+{
+  my $region = '2:40000-41500';
+  action_bad("/alignment/$species/$region?method=EPO;species_set_group=birds", "no alignment available for this region");
+}
+
 #Small region EPO slice, tree, deprecated, json
 #curl 'http://127.0.0.1:3000/alignment/slice/region/taeniopygia_guttata/2:106040050-106040100:1?method=EPO;species_set_group=birds' -H 'Content-type:application/json'
 {

--- a/t/genomic_alignment.t
+++ b/t/genomic_alignment.t
@@ -270,6 +270,8 @@ my $data = get_data();
 
   is(scalar(@{$json->[0]{alignments}}), $num_alignments, "number of EPO alignments, restricted set");
   eq_or_diff_data($json->[0]{alignments}[0], $data->{short_EPO}, "First EPO alignment, restricted set");
+
+  action_bad("/alignment/$species/$region?method=EPO;species_set_group=birds;display_species_set=human", "no alignment available for this region");
 }
 
 #EPO, restricted species, phyloxml


### PR DESCRIPTION
### Description

When an alignment block doesn't match the required `$display_species`, the Compara API returns undef. This causes the REST to fail over undefined values.

### Use case

http://rest.ensembl.org/alignment/region/taeniopygia_guttata/2:106040000-106040050:1?content-type=application/json;species_set_group=amniotes;method=PECAN;display_species_set=cat;display_species_set=sheep;display_species_set=mus_musculus_casteij

### Benefits

The alignment block will now be discarded. If all blocks are discarded, the REST API will show the usual error message (as JSON) e.g. http://rest.ensembl.org/alignment/region/mus_musculus/1:50-52:1?species_set_group=murinae;content-type=application/json;method=CACTUS_HAL

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

### Testing

_Have you added/modified unit tests to test the changes?_

Yes

_If so, do the tests pass/fail?_

Yes

_Have you run the entire test suite and no regression was detected?_

Yes

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

No
