### PR TITLE
Adds HGVSp example to documentation

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -173,6 +173,7 @@ jsonp=1
     vep_hgvs=AGT:c.803T>C
     vep_hgvs_two=9:g.22125504G>C
     vep_hgvs_three=ENST00000003084:c.1431_1433delTTC
+    vep_hgvs_four=ENSP00000401091.1:p.Tyr124Cys
 
     genomic_alignment_species=taeniopygia_guttata
     genomic_alignment_region=2:106040000-106040050:1

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -801,6 +801,13 @@
        capture=__VAR(vep_hgvs_three)__
        content=application/json
      </three>
+     <four>
+       path=/vep/
+       capture=__VAR(species_common)__
+       capture=hgvs
+       capture=__VAR(vep_hgvs_four)__
+       content=application/json
+     </four>
    </examples>
   </vep_hgvs_get>
 


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

Added a 4th example for HGVSp to the vep_hgvs_get endpoint

### Use case

As requested by Ben on 13th November - A user would like an HGVSp example added

### Benefits

More examples

### Possible Drawbacks

### Testing

None

### Changelog