### PR TITLE
Cherry-picked commits from e95

### DIFF
--- a/lib/EnsEMBL/REST/Controller/GenomicAlignment.pm
+++ b/lib/EnsEMBL/REST/Controller/GenomicAlignment.pm
@@ -52,6 +52,7 @@ sub get_adaptors :Private {
     my $species = $c->stash()->{species};
     my $compara_dba = $c->model('Registry')->get_best_compara_DBAdaptor($species, $c->request()->param('compara'), $self->default_compara());
 
+    my $ma = $compara_dba->get_MethodAdaptor();
     my $mlssa = $compara_dba->get_MethodLinkSpeciesSetAdaptor();
     my $gdba = $compara_dba->get_GenomeDBAdaptor();
     my $asa = $compara_dba->get_AlignSliceAdaptor();
@@ -62,6 +63,7 @@ sub get_adaptors :Private {
     
     $c->stash(
       compara_dba => $compara_dba,
+      method_adaptor => $ma,
       method_link_species_set_adaptor => $mlssa,
       genome_db_adaptor => $gdba,
       align_slice_adaptor => $asa,

--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -734,7 +734,7 @@
 	example=mus_musculus
       </species_set>
       <method>
-        type=Enum(EPO, EPO_LOW_COVERAGE, PECAN, LASTZ_NET, BLASTZ_NET, TRANSLATED_BLAT_NET, CACTUS_HAL)
+        type=Enum(EPO, EPO_LOW_COVERAGE, PECAN, LASTZ_NET, BLASTZ_NET, TRANSLATED_BLAT_NET, CACTUS_HAL, CACTUS_HAL_PW)
 	description=The alignment method
 	default=EPO
 	example=PECAN

--- a/t/genomic_alignment.t
+++ b/t/genomic_alignment.t
@@ -54,6 +54,11 @@ my $data = get_data();
   action_bad_regex("/alignment/block/region/$species/$region?method=wibble", qr/The method 'wibble' is not understood by this service/, "Using unsupported method causes an exception");
 }
 
+#Wrong method
+{
+  action_bad_regex("/alignment/block/region/$species/$region?method=SYNTENY", qr/The method 'SYNTENY' is not used for genome alignments/, "Using non-alignment method causes an exception");
+}
+
 #Wrong masking
 {
   action_bad_regex("/alignment/block/region/$species/$region?mask=wibble", qr/wibble/, "Using unsupported masking type causes an exception");

--- a/t/genomic_alignment.t
+++ b/t/genomic_alignment.t
@@ -77,6 +77,12 @@ my $data = get_data();
   action_bad_regex("/alignment/region/$species/$region?method=EPO;species_set=gallus_gallus;species_set=wibble", qr/wibble/, "Using unsupported species_set causes an exception");
 }
 
+# No alignment on this region
+{
+  my $region = '2:40000-41500';
+  action_bad("/alignment/$species/$region?method=EPO;species_set_group=birds", "no alignment available for this region");
+}
+
 #Small region EPO slice, tree, deprecated, json
 #curl 'http://127.0.0.1:3000/alignment/slice/region/taeniopygia_guttata/2:106040050-106040100:1?method=EPO;species_set_group=birds' -H 'Content-type:application/json'
 {


### PR DESCRIPTION
### Description

Those commits have already been reviewed and accepted on the release/95 branch, see #312 and #313. This PR is to copy them to master

For all the other sections of this template, see the original PRs for more details. There is
1. a fix to handle undefined values when filtering whole-genome alignments
2. a change to allow the real list of whole-genome alignments methods available in the database, rather than an hard-coded list

### Testing

_Have you added/modified unit tests to test the changes?_

yes

_If so, do the tests pass/fail?_

yes
