### PR TITLE
Change default division to be 'EnsemblVertebrates'

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -181,7 +181,7 @@ jsonp=1
     genomic_alignment_species2=gallus_gallus
     genomic_alignment_pw_region=2:106041430-106041480:1
 
-    info_division=ensembl
+    info_division=EnsemblVertebrates
   </replacements>
 </Model::Documentation>
 

--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -310,7 +310,7 @@ sub get_species {
   my ($self, $division, $strain_collection, $hide_strain_info) = @_;
   my $info = $self->_species_info();
   #have to force numerification again. It got lost ... somewhere
-  #filter by division (e.g.: ensembl)
+  #filter by division (e.g.: EnsemblVertebrates)
   return [ grep { $_ > 0 } map {$_->{release} += 0; $_} grep { lc($_->{division}) eq lc($division) } @{$info}] if $division;
 
   #filter by strain_collection (e.g.: mouse)
@@ -369,7 +369,7 @@ sub _build_species_info {
         if(!$dba->is_multispecies() && $species !~ /Ancestral/) {
           my $csa = $dba->get_CoordSystemAdaptor();
           $release_lookup{$species} = $schema_version;
-          $division_lookup{$species} = $mc->get_division() || 'Ensembl';
+          $division_lookup{$species} = $mc->get_division() || 'EnsemblVertebrates';
           $common_lookup{$species} = $mc->get_common_name();
           $taxon_lookup{$species} = $mc->get_taxonomy_id();
           $display_lookup{$species} = $mc->get_display_name();
@@ -498,7 +498,7 @@ sub get_compara_name_for_species {
     my $mc = $self->get_adaptor($species, 'core', 'metacontainer');
     my $compara_group = 'multi';
     my $division = $mc->single_value_by_key('species.division');
-    if($division and $division ne 'Ensembl') {
+    if($division and $division ne 'EnsemblVertebrates') {
       $division =~ s/^Ensembl//;
       $compara_group = lc($division);
     }

--- a/t/info.t
+++ b/t/info.t
@@ -75,22 +75,22 @@ is_json_GET(
     return $info_species;
   };
 
-  my $expected = {species => [ { division => 'Ensembl', name => 'homo_sapiens', 'accession' => 'GCA_000001405.9', common_name => 'human', display_name => 'Human', taxon_id => '9606', groups => ['core', 'funcgen', 'variation'], aliases => [], release => $core_schema_version, assembly => 'GRCh37', strain => 'test_strain', strain_collection => 'human'} ]};
-  my $expected_hide_strain_info = {species => [ { division => 'Ensembl', name => 'homo_sapiens', 'accession' => 'GCA_000001405.9', common_name => 'human', display_name => 'Human', taxon_id => '9606', groups => ['core', 'funcgen', 'variation'], aliases => [], release => $core_schema_version, assembly => 'GRCh37'} ]};
+  my $expected = {species => [ { division => 'EnsemblVertebrates', name => 'homo_sapiens', 'accession' => 'GCA_000001405.9', common_name => 'human', display_name => 'Human', taxon_id => '9606', groups => ['core', 'funcgen', 'variation'], aliases => [], release => $core_schema_version, assembly => 'GRCh37', strain => 'test_strain', strain_collection => 'human'} ]};
+  my $expected_hide_strain_info = {species => [ { division => 'EnsemblVertebrates', name => 'homo_sapiens', 'accession' => 'GCA_000001405.9', common_name => 'human', display_name => 'Human', taxon_id => '9606', groups => ['core', 'funcgen', 'variation'], aliases => [], release => $core_schema_version, assembly => 'GRCh37'} ]};
   my $expected_empty_list = {species => [ ]};
 
   eq_or_diff_data(
     $get_species->('/info/species', 'Checking only DBA available is the test DBA'), $expected, 
     "/info/species | Checking only DBA available is the test DBA");
   eq_or_diff_data(
-    $get_species->('/info/species?division=Ensembl', q{Output is same as /info/species if specified 'Ensembl' division}), $expected, 
-    "/info/species?division=Ensembl | Output is same as /info/species if specified 'Ensembl' division");
+    $get_species->('/info/species?division=EnsemblVertebrates', q{Output is same as /info/species if specified 'EnsemblVertebrates' division}), $expected, 
+    "/info/species?division=EnsemblVertebrates | Output is same as /info/species if specified 'Ensembl' division");
   eq_or_diff_data(
-    $get_species->('/info/species?division=ensembl', q{Output is same as /info/species if specified 'ensembl' division}), $expected, 
-    "/info/species?division=ensembl | Output is same as /info/species if specified 'ensembl' division");
+    $get_species->('/info/species?division=ensemblvertebrates', q{Output is same as /info/species if specified 'ensemblvertebrates' division}), $expected, 
+    "/info/species?division=ensemblvertebrates | Output is same as /info/species if specified 'ensembl' division");
   eq_or_diff_data(
-    $get_species->('/info/species?division=EnsEMBL', q{Output is same as /info/species if specified 'EnsEMBL' division}), $expected, 
-    "/info/species?division=EnsEMBL | Output is same as /info/species if specified 'EnsEMBL' division");
+    $get_species->('/info/species?division=EnsEMBLvertebrates', q{Output is same as /info/species if specified 'EnsEMBLvertebrates' division}), $expected, 
+    "/info/species?division=EnsEMBLvertebrates | Output is same as /info/species if specified 'EnsEMBL' division");
   eq_or_diff_data(
     $get_species->('/info/species?hide_strain_info=1', q{Output do not have strain and strain_collection info}), $expected_hide_strain_info,
     "/info/species?hide_strain_info=1 | Output do not have strain and strain_collection info");


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

Default division changed from 'ensembl' to 'EnsemblVertebrates' in line with Ensembl 95 changes to species.division meta value in the core dbs.

### Use case

In e95 species.divsion changed from ensembl -> EnsemblVertebrates
Hardcoded occurrences in the REST code need to change respectively. 

### Benefits

e95 compatibility

### Possible Drawbacks

No back-compatibility.
REST users may not be expecting this change?

### Testing

_Have you added/modified unit tests to test the changes?_

Yes

_If so, do the tests pass/fail?_

The subtests I changed are passing  - other subtests are failing (as they were before my change)

_Have you run the entire test suite and no regression was detected?_

I ran the whole test suite but lots of tests fail with or without my changes.

### Changelog

Default division changed from 'ensembl' to 'EnsemblVertebrates' in line with Ensembl 95 database changes.
