### PR TITLE
Removed index from table.sql so patch_95_96_f.sql can be applied.

### DIFF
--- a/t/test-genome-DBs/homo_sapiens/funcgen/table.sql
+++ b/t/test-genome-DBs/homo_sapiens/funcgen/table.sql
@@ -144,8 +144,7 @@ CREATE TABLE `binding_matrix` (
   `source` varchar(20) NOT NULL,
   `stable_id` varchar(128) NOT NULL,
   PRIMARY KEY (`binding_matrix_id`),
-  UNIQUE KEY `name_idx` (`name`),
-  UNIQUE KEY `stable_id_idx` (`stable_id`)
+  UNIQUE KEY `name_idx` (`name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=215 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `binding_matrix_frequencies` (


### PR DESCRIPTION
### Description

[patch_95_96_f.sql](https://github.com/Ensembl/ensembl-funcgen/blob/master/sql/patch_95_96_f.sql) tries to create an index that already exists in the table.sql. 

This PR removes the index from the table.sql so the patch can be applied without errors.

### Changelog

No endpoints are changed.