### PR TITLE
Variant Recoder REST updated to accept SPDI format

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -173,6 +173,7 @@ jsonp=1
     vep_hgvs=AGT:c.803T>C
     vep_hgvs_two=9:g.22125504G>C
     vep_hgvs_three=ENST00000003084:c.1431_1433delTTC
+    vep_spdi=NC_000023.11:284252:C:G
     vep_hgvs_four=ENSP00000401091.1:p.Tyr124Cys
 
     genomic_alignment_species=taeniopygia_guttata

--- a/root/documentation/variation.conf
+++ b/root/documentation/variation.conf
@@ -151,7 +151,7 @@
   </variation_post>
   
   <variant_recoder>
-    description=Translate a variant identifier or HGVS notation to all possible variant IDs and HGVS
+    description=Translate a variant identifier, HGVS notation or genomic SPDI notation to all possible variant IDs, HGVS and genomic SPDI
     endpoint=variant_recoder/:species/:id
     method=GET
     group=Variation
@@ -161,9 +161,10 @@
     <params>
       <id>
         type=String
-        description=Variant ID or HGVS notation
+        description=Variant ID, HGVS notation or genomic SPDI notation
         example=__VAR(variation_id)__
         example=__VAR(vep_hgvs)__
+        example=__VAR(vep_spdi)__
         required=1
       </id>
       <species>
@@ -175,8 +176,8 @@
       </species>
       <fields>
         type=String
-        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein)
-        default=id,hgvsg,hgvsc,hgvsp
+        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic)
+        default=id,hgvsg,hgvsc,hgvsp,spdi
       </fields>
     </params>
 
@@ -197,7 +198,7 @@
   </variant_recoder>
   
   <variant_recoder_post>
-    description=Translate a list of variant identifiers or HGVS notations to all possible variant IDs and HGVS
+    description=Translate a list of variant identifiers, HGVS notations or genomic SPDI notations to all possible variant IDs, HGVS and genomic SPDI
     endpoint=variant_recoder/:species
     method=POST
     group=Variation
@@ -214,8 +215,8 @@
       </species>
       <fields>
         type=String
-        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein)
-        default=id,hgvsg,hgvsc,hgvsp
+        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic)
+        default=id,hgvsg,hgvsc,hgvsp,spdi
       </fields>
     </params>
 

--- a/t/variation.t
+++ b/t/variation.t
@@ -297,6 +297,9 @@ my $exp = [
     ],
     'hgvsg' => [
       'X:g.200920C>G'
+    ],
+    'spdi' => [
+      'X:200919:C:G'
     ]
   }
 ];
@@ -305,6 +308,7 @@ for my $input(qw(
   rs200625439
   ENST00000381657.2:c.66C>G
   X:g.200920C>G
+  X:200919:C:G
 )) {
   $exp->[0]->{input} = $input;
   is_deeply(
@@ -326,7 +330,7 @@ my $expf = dclone($exp);
 delete($expf->[0]->{$_}) for qw(hgvsc hgvsp);
 $expf->[0]->{input} = 'rs200625439';
 is_deeply(
-  json_GET("$base/rs200625439?fields=hgvsg,id", "variant_recoder - restrict fields"),
+  json_GET("$base/rs200625439?fields=hgvsg,id,spdi", "variant_recoder - restrict fields"),
   $expf,
   'variant_recoder - GET - restrict fields'
 );
@@ -362,6 +366,9 @@ my $exp2 = [
     ],
     'hgvsg' => [
       'X:g.208208C>T'
+    ],
+    'spdi' => [
+      'X:208207:C:T'
     ]
   }
 ];
@@ -379,7 +386,7 @@ delete($expf2->[0]->{$_}) for qw(hgvsc hgvsp);
 
 is_json_POST(
   $base,
-  '{"ids" : ["rs200625439", "rs142663151"], "fields": "hgvsg,id"}',
+  '{"ids" : ["rs200625439", "rs142663151"], "fields": "hgvsg,id,spdi"}',
   [$expf->[0], $expf2->[0]],
   'variant_recoder - POST - restrict fields'
 );


### PR DESCRIPTION
### Description

Update Variant Recoder to accept SPDI format as input and output. 

### Use case

Allow the users to use SPDI notation. 

### Benefits

Users can input SPDI format and get the corresponding variant identifier, HGVS and SPDI notation. 

### Possible Drawbacks

None

### Testing

Added some tests and all passed. 

### Changelog

[variant_recoder/] Also retrieve a SPDI for a given variant identifier, HGVS or SPDI notation.  
