### PR TITLE
resolve funcgen test db schema inconsistencies

### DIFF
--- a/t/test-genome-DBs/homo_sapiens/funcgen/meta.txt
+++ b/t/test-genome-DBs/homo_sapiens/funcgen/meta.txt
@@ -178,4 +178,5 @@
 750	\N	patch	patch_95_96_b.sql|changed data type for regulatory build statistics
 751	\N	patch	patch_95_96_c.sql|make unique probe_id column from probe table
 752	\N	patch	patch_95_96_d.sql|add ReadFile to the enum of the ensembl_object_type
-753	\N	patch	patch_95_96_e.sql|
+753	\N	patch	patch_95_96_e.sql|Add description and release_version columns to regulatory_build table
+754	\N	patch	patch_95_96_f.sql|Modify binding_matrix_table

--- a/t/test-genome-DBs/homo_sapiens/funcgen/table.sql
+++ b/t/test-genome-DBs/homo_sapiens/funcgen/table.sql
@@ -687,7 +687,7 @@ CREATE TABLE `regulatory_build` (
   `regulatory_build_id` int(4) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(45) NOT NULL,
   `release_version` int(11) DEFAULT NULL,
-  `description` text,
+  `description` text DEFAULT NULL,
   `version` varchar(50) DEFAULT NULL,
   `initial_release_date` varchar(50) DEFAULT NULL,
   `last_annotation_update` varchar(50) DEFAULT NULL,


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

_Using one or more sentences, describe in detail the proposed changes._

This PR should resolve schema inconsistencies of the funcgen test database. It replaces https://github.com/Ensembl/ensembl-rest/pull/327

### Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

### Benefits

_If applicable, describe the advantages the changes will have._

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

### Testing

_Have you added/modified unit tests to test the changes?_
No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians
