### PR TITLE
Missing commit from e95

### DIFF
--- a/lib/EnsEMBL/REST/Model/GenomicAlignment.pm
+++ b/lib/EnsEMBL/REST/Model/GenomicAlignment.pm
@@ -125,7 +125,7 @@ sub get_alignment {
     #Must have new object here because of potential tree pruning (calls minimize_tree)
     $this_genomic_align_tree->repeatmask($mask);
     my $new_tree = $this_genomic_align_tree->prune($display_species);
-    push @$new_genomic_align_trees, $new_tree;
+    push @$new_genomic_align_trees, $new_tree if $new_tree;
   }
   
   return  $new_genomic_align_trees;

--- a/t/genomic_alignment.t
+++ b/t/genomic_alignment.t
@@ -281,6 +281,8 @@ my $data = get_data();
 
   is(scalar(@{$json->[0]{alignments}}), $num_alignments, "number of EPO alignments, restricted set");
   eq_or_diff_data($json->[0]{alignments}[0], $data->{short_EPO}, "First EPO alignment, restricted set");
+
+  action_bad("/alignment/$species/$region?method=EPO;species_set_group=birds;display_species_set=human", "no alignment available for this region");
 }
 
 #EPO, restricted species, phyloxml


### PR DESCRIPTION
### Description

I forgot to include this commit in #321 :disappointed:
The commit itself has already been reviewed and accepted on the release/95 branch (#312). This PR is to copy it to master before the e96 branch is created.

The change is a fix to handle undefined values when filtering whole-genome alignments

### Testing

_Have you added/modified unit tests to test the changes?_

yes

_If so, do the tests pass/fail?_

yes
