### PR TITLE
ENSCORESW-3015: replace multi with vertebrates for compara usage

### DIFF
--- a/lib/EnsEMBL/REST/Controller/GenomicAlignment.pm
+++ b/lib/EnsEMBL/REST/Controller/GenomicAlignment.pm
@@ -25,7 +25,7 @@ require EnsEMBL::REST;
 
 BEGIN { extends 'Catalyst::Controller::REST'; }
 
-has 'default_compara' => ( is => 'ro', isa => 'Str', default => 'multi' );
+has 'default_compara' => ( is => 'ro', isa => 'Str', default => 'vertebrates' );
 has 'compara_base_dir_location' => ( is => 'ro', isa => 'Str' );
 has 'max_slice_length' => ( isa => 'Num', is => 'ro', default => 1e6);
 

--- a/lib/EnsEMBL/REST/Controller/Homology.pm
+++ b/lib/EnsEMBL/REST/Controller/Homology.pm
@@ -43,7 +43,7 @@ my $CONTENT_TYPE_REGEX = qr/(?^:(?:text\/(?:javascript|xml)|application\/json))/
 my $FORMAT_LOOKUP = { full => 1, condensed => 1 };
 my $TYPE_TO_COMPARA_TYPE = { orthologues => 'ENSEMBL_ORTHOLOGUES', paralogues => 'ENSEMBL_PARALOGUES', projections => 'ENSEMBL_PROJECTIONS', all => ''};
 
-has default_compara => ( is => 'ro', isa => 'Str', default => 'multi' );
+has default_compara => ( is => 'ro', isa => 'Str', default => 'vertebrates' );
 
 sub get_adaptors :Private {
   my ($self, $c) = @_;

--- a/lib/EnsEMBL/REST/Model/Lookup.pm
+++ b/lib/EnsEMBL/REST/Model/Lookup.pm
@@ -211,7 +211,7 @@ sub find_compara_methods {
   my $c = $self->context();
   #default is "multi"
   my $compara = $c->request->parameters->{compara} || $c->config->{'Controller::Compara'}->{default_compara} || 'multi';
-  if ($compara eq 'vertebrates') { $compara = 'multi'; }
+  if (lc($compara) eq 'vertebrates') { $compara = 'multi'; }
   my $reg = $c->model('Registry');
   my $compara_dba = $reg->get_DBAdaptor($compara, "compara");
   my $methods;
@@ -231,7 +231,7 @@ sub find_compara_species_sets {
   my $c = $self->context();
   #default is "multi"
   my $compara = $c->request->parameters->{compara} || $c->config->{'Controller::Compara'}->{default_compara} || 'multi';
-  if ($compara eq 'vertebrates') { $compara = 'multi'; }
+  if (lc($compara) eq 'vertebrates') { $compara = 'multi'; }
   my $reg = $c->model('Registry');
   my $compara_dba = $reg->get_DBAdaptor($compara, "compara");
 

--- a/lib/EnsEMBL/REST/Model/Lookup.pm
+++ b/lib/EnsEMBL/REST/Model/Lookup.pm
@@ -211,7 +211,9 @@ sub find_compara_methods {
   my $c = $self->context();
   #default is "multi"
   my $compara = $c->request->parameters->{compara} || $c->config->{'Controller::Compara'}->{default_compara} || 'multi';
-  if (lc($compara) eq 'vertebrates') { $compara = 'multi'; }
+  if (lc($compara) eq 'vertebrates') {
+    $compara = 'multi';
+  }
   my $reg = $c->model('Registry');
   my $compara_dba = $reg->get_DBAdaptor($compara, "compara");
   my $methods;
@@ -231,7 +233,9 @@ sub find_compara_species_sets {
   my $c = $self->context();
   #default is "multi"
   my $compara = $c->request->parameters->{compara} || $c->config->{'Controller::Compara'}->{default_compara} || 'multi';
-  if (lc($compara) eq 'vertebrates') { $compara = 'multi'; }
+  if (lc($compara) eq 'vertebrates') {
+    $compara = 'multi';
+  }
   my $reg = $c->model('Registry');
   my $compara_dba = $reg->get_DBAdaptor($compara, "compara");
 

--- a/lib/EnsEMBL/REST/Model/Lookup.pm
+++ b/lib/EnsEMBL/REST/Model/Lookup.pm
@@ -211,6 +211,7 @@ sub find_compara_methods {
   my $c = $self->context();
   #default is "multi"
   my $compara = $c->request->parameters->{compara} || $c->config->{'Controller::Compara'}->{default_compara} || 'multi';
+  if ($compara eq 'vertebrates') { $compara = 'multi'; }
   my $reg = $c->model('Registry');
   my $compara_dba = $reg->get_DBAdaptor($compara, "compara");
   my $methods;
@@ -230,6 +231,7 @@ sub find_compara_species_sets {
   my $c = $self->context();
   #default is "multi"
   my $compara = $c->request->parameters->{compara} || $c->config->{'Controller::Compara'}->{default_compara} || 'multi';
+  if ($compara eq 'vertebrates') { $compara = 'multi'; }
   my $reg = $c->model('Registry');
   my $compara_dba = $reg->get_DBAdaptor($compara, "compara");
 

--- a/lib/EnsEMBL/REST/Model/Overlap.pm
+++ b/lib/EnsEMBL/REST/Model/Overlap.pm
@@ -372,7 +372,7 @@ sub constrained {
   my $c = $self->context();
   my $species_set = $c->request->parameters->{species_set} || 'mammals';
   my $compara_name = $c->model('Registry')->get_compara_name_for_species($c->stash()->{species});
-  if ($compara_name eq 'vertebrates') { $compara_name = 'multi'; }
+  if (lc($compara_name) eq 'vertebrates') { $compara_name = 'multi'; }
   my $mlssa = $c->model('Registry')->get_adaptor($compara_name, 'compara', 'MethodLinkSpeciesSet');
   Catalyst::Exception->throw("No adaptor found for compara Multi and adaptor MethodLinkSpeciesSet") if ! $mlssa;
   my $method_list = $mlssa->fetch_by_method_link_type_species_set_name('GERP_CONSTRAINED_ELEMENT', $species_set);

--- a/lib/EnsEMBL/REST/Model/Overlap.pm
+++ b/lib/EnsEMBL/REST/Model/Overlap.pm
@@ -372,6 +372,7 @@ sub constrained {
   my $c = $self->context();
   my $species_set = $c->request->parameters->{species_set} || 'mammals';
   my $compara_name = $c->model('Registry')->get_compara_name_for_species($c->stash()->{species});
+  if ($compara_name eq 'vertebrates') { $compara_name = 'multi'; }
   my $mlssa = $c->model('Registry')->get_adaptor($compara_name, 'compara', 'MethodLinkSpeciesSet');
   Catalyst::Exception->throw("No adaptor found for compara Multi and adaptor MethodLinkSpeciesSet") if ! $mlssa;
   my $method_list = $mlssa->fetch_by_method_link_type_species_set_name('GERP_CONSTRAINED_ELEMENT', $species_set);

--- a/lib/EnsEMBL/REST/Model/Overlap.pm
+++ b/lib/EnsEMBL/REST/Model/Overlap.pm
@@ -372,7 +372,9 @@ sub constrained {
   my $c = $self->context();
   my $species_set = $c->request->parameters->{species_set} || 'mammals';
   my $compara_name = $c->model('Registry')->get_compara_name_for_species($c->stash()->{species});
-  if (lc($compara_name) eq 'vertebrates') { $compara_name = 'multi'; }
+  if (lc($compara_name) eq 'vertebrates') {
+    $compara_name = 'multi';
+  }
   my $mlssa = $c->model('Registry')->get_adaptor($compara_name, 'compara', 'MethodLinkSpeciesSet');
   Catalyst::Exception->throw("No adaptor found for compara Multi and adaptor MethodLinkSpeciesSet") if ! $mlssa;
   my $method_list = $mlssa->fetch_by_method_link_type_species_set_name('GERP_CONSTRAINED_ELEMENT', $species_set);

--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -279,6 +279,7 @@ sub get_best_compara_DBAdaptor {
   my $compara_name = $request_compara_name || ($species ? $self->get_compara_name_for_species($species) : undef);
   my $dba;
   if ( $compara_name ) {
+    if ($compara_name eq 'vertebrates') { $compara_name = 'multi'; }
     $dba = $self->get_DBAdaptor($compara_name, 'compara', 'no alias check');
     if ( !$dba ) {
       throw "Cannot find a suitable compara database for the species $species. Try specifying a compara parameter";
@@ -489,6 +490,7 @@ sub get_comparas {
   foreach my $dba (@{$dbadaptors}) {
     my $name = $dba->species();
     my $mc = $self->get_adaptor($name, 'compara', 'metacontainer');
+    if ($name eq 'multi') { $name = 'vertebrates'; }
     my $info = {
       name => $name,
       release => $mc->get_schema_version(),
@@ -503,9 +505,9 @@ sub get_compara_name_for_species {
   my ($self, $species) = @_;
   if(! exists $self->compara_cache()->{$species}) {
     my $mc = $self->get_adaptor($species, 'core', 'metacontainer');
-    my $compara_group = 'multi';
+    my $compara_group = 'vertebrates';
     my $division = $mc->single_value_by_key('species.division');
-    if($division and $division ne 'EnsemblVertebrates') {
+    if($division) {
       $division =~ s/^Ensembl//;
       $compara_group = lc($division);
     }

--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -279,7 +279,9 @@ sub get_best_compara_DBAdaptor {
   my $compara_name = $request_compara_name || ($species ? $self->get_compara_name_for_species($species) : undef);
   my $dba;
   if ( $compara_name ) {
-    if (lc($compara_name) eq 'vertebrates') { $compara_name = 'multi'; }
+    if (lc($compara_name) eq 'vertebrates') {
+      $compara_name = 'multi';
+    }
     $dba = $self->get_DBAdaptor($compara_name, 'compara', 'no alias check');
     if ( !$dba ) {
       throw "Cannot find a suitable compara database for the species $species. Try specifying a compara parameter";
@@ -490,7 +492,9 @@ sub get_comparas {
   foreach my $dba (@{$dbadaptors}) {
     my $name = $dba->species();
     my $mc = $self->get_adaptor($name, 'compara', 'metacontainer');
-    if (lc($name) eq 'multi') { $name = 'vertebrates'; }
+    if (lc($name) eq 'multi') {
+      $name = 'vertebrates';
+    }
     my $info = {
       name => $name,
       release => $mc->get_schema_version(),

--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -279,7 +279,7 @@ sub get_best_compara_DBAdaptor {
   my $compara_name = $request_compara_name || ($species ? $self->get_compara_name_for_species($species) : undef);
   my $dba;
   if ( $compara_name ) {
-    if ($compara_name eq 'vertebrates') { $compara_name = 'multi'; }
+    if (lc($compara_name) eq 'vertebrates') { $compara_name = 'multi'; }
     $dba = $self->get_DBAdaptor($compara_name, 'compara', 'no alias check');
     if ( !$dba ) {
       throw "Cannot find a suitable compara database for the species $species. Try specifying a compara parameter";
@@ -490,7 +490,7 @@ sub get_comparas {
   foreach my $dba (@{$dbadaptors}) {
     my $name = $dba->species();
     my $mc = $self->get_adaptor($name, 'compara', 'metacontainer');
-    if ($name eq 'multi') { $name = 'vertebrates'; }
+    if (lc($name) eq 'multi') { $name = 'vertebrates'; }
     my $info = {
       name => $name,
       release => $mc->get_schema_version(),

--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -23,9 +23,9 @@
       </symbol>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
-        default=multi (if using Ensembl)
-        example=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=vertebrates
       </compara>
       <external_db>
         type=String
@@ -136,9 +136,9 @@
       </id>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
-        default=multi (if using Ensembl)
-        example=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=vertebrates
       </compara>
       <format>
         type=Enum(full, condensed)
@@ -243,9 +243,9 @@
       </id>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
-        default=multi (if using Ensembl)
-        example=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=vertebrates
       </compara>
       <aligned>
         type=Boolean
@@ -286,9 +286,9 @@
       </id>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
-        default=multi (if using Ensembl)
-        example=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=vertebrates
       </compara>
       <aligned>
         type=Boolean
@@ -336,9 +336,9 @@
       </species>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
-        default=multi (if using Ensembl)
-        example=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=vertebrates
       </compara>
       <aligned>
         type=Boolean
@@ -401,9 +401,9 @@
       </id>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
-        default=multi (if using Ensembl)
-        example=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=vertebrates
       </compara>
       <aligned>
         type=Boolean
@@ -516,9 +516,9 @@
       </object_type>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
-        default=multi (if using Ensembl)
-        example=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=vertebrates
       </compara>
       <aligned>
         type=Boolean
@@ -619,9 +619,9 @@
       </object_type>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
-        default=multi (if using Ensembl)
-        example=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=vertebrates
       </compara>
       <aligned>
         type=Boolean
@@ -707,9 +707,9 @@
       </species>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
-        default=multi (if using Ensembl)
-        example=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=vertebrates
       </compara>
       <aligned>
         type=Boolean
@@ -800,9 +800,9 @@
       </id>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
-        default=multi (if using Ensembl)
-        example=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=vertebrates
       </compara>
       <nh_format>
         type=String
@@ -859,9 +859,9 @@
       </object_type>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
-        default=multi (if using Ensembl)
-        example=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=vertebrates
       </compara>
       <nh_format>
         description=The format of a NH (New Hampshire) request. Available only with the default setting to allow us to return the cafe tree with Taxa names appended with number of members and the p_value. example : homo_sapiens_3_0.123 where 3 is the number of members and 0.123 is the p value
@@ -925,9 +925,9 @@
       </object_type>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas can exist on a server if you are accessing Ensembl Genomes data
-        default=multi (if using Ensembl)
-        example=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=vertebrates
       </compara>
       <nh_format>
         description=The format of a NH (New Hampshire) request. Available only with the default setting to allow us to return the cafe tree with Taxa names appended with number of members and the p_value. example : homo_sapiens_3_0.123 where 3 is the number of members and 0.123 is the p value

--- a/root/documentation/info.conf
+++ b/root/documentation/info.conf
@@ -307,8 +307,8 @@
     <params>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas may exist on a server when accessing Ensembl Genomes data.
-        default=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
         example=__VAR(compara)__
       </compara>
       <class>
@@ -342,8 +342,8 @@
       </method>
       <compara>
         type=String
-        description=Name of the compara database to use. Multiple comparas may exist on a server when accessing Ensembl Genomes data.
-        default=multi
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
         example=__VAR(compara)__
       </compara>  
      </params>

--- a/t/info.t
+++ b/t/info.t
@@ -51,7 +51,7 @@ $compara_schema_version *= 1;
 
 # info/comparas
 is_json_GET(
-  '/info/comparas', { comparas => [ { name => 'multi', release => $compara_schema_version} ] }, "Comparas returns 1 DB"
+  '/info/comparas', { comparas => [ { name => 'vertebrates', release => $compara_schema_version} ] }, "Comparas returns 1 DB"
 );
 
 # info/data

--- a/t/test-genome-DBs/ancestral_sequences/core/meta.txt
+++ b/t/test-genome-DBs/ancestral_sequences/core/meta.txt
@@ -54,3 +54,4 @@
 853	\N	patch	patch_94_95_b.sql|vertebrate_division_rename
 854	\N	patch	patch_94_95_c.sql|ox_key_update
 855	\N	patch	patch_95_96_a.sql|schema_version
+856	1	species.division	EnsemblVertebrates

--- a/t/test-genome-DBs/gallus_gallus/core/meta.txt
+++ b/t/test-genome-DBs/gallus_gallus/core/meta.txt
@@ -171,3 +171,4 @@
 422	\N	patch	patch_94_95_b.sql|vertebrate_division_rename
 423	\N	patch	patch_94_95_c.sql|ox_key_update
 424	\N	patch	patch_95_96_a.sql|schema_version
+425	1	species.division	EnsemblVertebrates

--- a/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -242,3 +242,4 @@
 1856	\N	patch	patch_94_95_b.sql|vertebrate_division_rename
 1857	\N	patch	patch_94_95_c.sql|ox_key_update
 1858	\N	patch	patch_95_96_a.sql|schema_version
+1859	1	species.division	EnsemblVertebrates

--- a/t/test-genome-DBs/meleagris_gallopavo/core/meta.txt
+++ b/t/test-genome-DBs/meleagris_gallopavo/core/meta.txt
@@ -195,3 +195,4 @@
 1073	\N	patch	patch_94_95_b.sql|vertebrate_division_rename
 1074	\N	patch	patch_94_95_c.sql|ox_key_update
 1075	\N	patch	patch_95_96_a.sql|schema_version
+1076	1	species.division	EnsemblVertebrates

--- a/t/test-genome-DBs/taeniopygia_guttata/core/meta.txt
+++ b/t/test-genome-DBs/taeniopygia_guttata/core/meta.txt
@@ -239,3 +239,4 @@
 1295	\N	patch	patch_94_95_b.sql|vertebrate_division_rename
 1296	\N	patch	patch_94_95_c.sql|ox_key_update
 1297	\N	patch	patch_95_96_a.sql|schema_version
+1298	1	species.division	EnsemblVertebrates


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

_Using one or more sentences, describe in detail the proposed changes._
The default compara is set to 'vertebrates' instead of 'multi. Under the hood, 'multi' is still allowed for backwards compatibility.

### Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
For 96, we will have a single REST server providing access to all Ensembl divisions. For consistency across divisions, we do not want to have a 'multi' compara database that refers to vertebrates, when all other comparas are identified by their divisions (eg Plants, Fungi...)
This change allows us to present all divisions equally to our users while ensuring existing functionality remains unchanged.
In particular, the default compara is set to 'vertebrates'. That way, users who did not have to specify a compara database until now because only one was available (which is the case for anyone using vertebrates until release 95) will not have to change any of their queries.

### Benefits

_If applicable, describe the advantages the changes will have._
When querying the /info/comparas endpoint, users will get an meaningful list of compara databases available based on their division name.
This will also match the output of the /info/divisions endpoint.
Any other functionality will remain unchanged.

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
'multi' can still be used as an equivalent of 'vertebrates', exposing some of our internal workings

### Testing

_Have you added/modified unit tests to test the changes?_
Yes

_If so, do the tests pass/fail?_
Yes

_Have you run the entire test suite and no regression was detected?_
Yes

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._
No change of functionality

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians
