### PR TITLE
[/genetree] Updated the documentation of the prune_* options

### DIFF
--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -542,13 +542,13 @@
       </nh_format>
       <prune_species>
         type=String
-        description=Prune the tree by species. Supports all species aliases
+        description=Prune the tree by species. Supports all species aliases. Will return a tree with only the species given
         example=__VAR(species_common)__
         example=__VAR(target_species)__
       </prune_species>
       <prune_taxon>
         type=Integer
-        description=Prune the tree by taxon
+        description=Prune the tree by taxon. Will return a tree with only the taxons given
         example=__VAR(taxon)__
         example=__VAR(target_taxon)__
       </prune_taxon>
@@ -645,13 +645,13 @@
       </nh_format>
       <prune_species>
         type=String
-        description=Prune the tree by species. Supports all species aliases
+        description=Prune the tree by species. Supports all species aliases. Will return a tree with only the species given
         example=__VAR(species_common)__
         example=__VAR(target_species)__
       </prune_species>
       <prune_taxon>
         type=Integer
-        description=Prune the tree by taxon
+        description=Prune the tree by taxon. Will return a tree with only the taxons given
         example=__VAR(taxon)__
         example=__VAR(target_taxon)__
       </prune_taxon>


### PR DESCRIPTION
### Requirements

### Description

Updated the documentation of the prune_* options in two gene-tree endpoints (the first one already had the complete description)

### Use case

Someone wants to get a smaller tree by removing the species they don't care about. They think "is there an option to prune the tree ?". They go to the documentation and :confetti_ball: there it is

### Benefits

People know what the options are doing.

### Possible Drawbacks

More text to read. Some people may have preferred the function implemented the other way.

### Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

No

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

No
