### PR TITLE
Feature/fix strain info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
     - cd ../../
 
 install:
+    - export PERL5LIB=$PERL5LIB:$PWD/bioperl-live
     - cpanm -v --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .
     - cpanm -v --installdeps --with-recommends --notest .
     - cpanm -n Devel::Cover::Report::Coveralls

--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -219,27 +219,36 @@ sub get_species {
   my ($self, $division, $strain_collection, $hide_strain_info) = @_;
   my $info = $self->_species_info();
   #have to force numerification again. It got lost ... somewhere
-  #filter by division (e.g.: EnsemblVertebrates)
-  return [ grep { $_ > 0 } map {$_->{release} += 0; $_} grep { lc($_->{division}) eq lc($division) } @{$info}] if $division;
-
-  #filter by strain_collection (e.g.: mouse)
-  return [ grep { $_ > 0 } map {$_->{release} += 0; $_} grep { lc($_->{strain_collection}) eq lc($strain_collection) } @{$info}] if $strain_collection;
-
   #flag to show or hide strain info
-  if($hide_strain_info > 0){
+  if( $hide_strain_info > 0 ){
     my @hidden_keys = qw(strain strain_collection);
     my $new_info_list = [];
-    foreach my $inf(@{$info}){
-    my $new_info_hash = {};
-      foreach my $key(keys %$inf){
+    foreach my $inf ( @{$info} ) {
+      my $new_info_hash = {};
+      foreach my $key (keys %$inf){
         $new_info_hash->{$key} = $inf->{$key} unless grep {$_ eq $key} @hidden_keys;
       }
-    push (@$new_info_list, $new_info_hash);
+      push @$new_info_list, $new_info_hash;
     }
-    return $new_info_list;
+    $info = $new_info_list;
   }
-
-  return [ grep { $_ > 0 } map {$_->{release} += 0; $_} @{$info} ];
+  
+  my $filter;
+  my @subset = @{$info};
+  #filter by division (e.g.: EnsemblVertebrates, the default setting for info/species)
+  if ($division) {
+    @subset = grep { lc $_->{division} eq lc $division } @subset;
+  }
+  # This assumes one might specify strain collection AND division, but that may not be an issue
+  if ($strain_collection) {
+    @subset = grep { lc $_->{strain_collection} eq lc $strain_collection } @subset;
+  }
+  
+  return [
+    grep { $_ > 0 }
+    map { $_->{release} += 0; $_ }
+    @subset
+  ];
 }
 
 sub _build_species_info {

--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -233,7 +233,6 @@ sub get_species {
     $info = $new_info_list;
   }
   
-  my $filter;
   my @subset = @{$info};
   #filter by division (e.g.: EnsemblVertebrates, the default setting for info/species)
   if ($division) {

--- a/t/info.t
+++ b/t/info.t
@@ -119,17 +119,17 @@ is_json_GET(
   eq_or_diff_data(
     $get_species->('/info/species?division=EnsemblVertebrates', q{Output is same as /info/species if specified 'EnsemblVertebrates' division}),
     $expected, 
-    "/info/species?division=EnsemblVertebrates | Output is same as /info/species if specified 'Ensembl' division"
+    "/info/species?division=EnsemblVertebrates | Output is same as /info/species if specified 'EnsemblVertebrates' division"
   );
   eq_or_diff_data(
     $get_species->('/info/species?division=ensemblvertebrates', q{Output is same as /info/species if specified 'ensemblvertebrates' division}),
     $expected, 
-    "/info/species?division=ensemblvertebrates | Output is same as /info/species if specified 'ensembl' division"
+    "/info/species?division=ensemblvertebrates | Output is same as /info/species if specified 'ensemblvertebrates' division"
   );
   eq_or_diff_data(
     $get_species->('/info/species?division=EnsEMBLvertebrates', q{Output is same as /info/species if specified 'EnsEMBLvertebrates' division}),
     $expected, 
-    "/info/species?division=EnsEMBLvertebrates | Output is same as /info/species if specified 'EnsEMBL' division"
+    "/info/species?division=EnsEMBLvertebrates | Output is same as /info/species if specified 'EnsEMBLvertebrates' division"
   );
   eq_or_diff_data(
     $get_species->('/info/species?hide_strain_info=1', q{Output does not have strain and strain_collection info}),

--- a/t/info.t
+++ b/t/info.t
@@ -75,33 +75,79 @@ is_json_GET(
     return $info_species;
   };
 
-  my $expected = {species => [ { division => 'EnsemblVertebrates', name => 'homo_sapiens', 'accession' => 'GCA_000001405.9', common_name => 'human', display_name => 'Human', taxon_id => '9606', groups => ['core', 'funcgen', 'variation'], aliases => [], release => $core_schema_version, assembly => 'GRCh37', strain => 'test_strain', strain_collection => 'human'} ]};
-  my $expected_hide_strain_info = {species => [ { division => 'EnsemblVertebrates', name => 'homo_sapiens', 'accession' => 'GCA_000001405.9', common_name => 'human', display_name => 'Human', taxon_id => '9606', groups => ['core', 'funcgen', 'variation'], aliases => [], release => $core_schema_version, assembly => 'GRCh37'} ]};
+  my $expected = {
+    species => [
+      {
+        division => 'EnsemblVertebrates',
+        name => 'homo_sapiens',
+        accession => 'GCA_000001405.9',
+        common_name => 'human',
+        display_name => 'Human',
+        taxon_id => '9606',
+        groups => ['core', 'funcgen', 'variation'],
+        aliases => [],
+        release => $core_schema_version,
+        assembly => 'GRCh37',
+        strain => 'test_strain',
+        strain_collection => 'human'
+      }
+    ]
+  };
+  my $expected_hide_strain_info = {
+    species => [
+      { 
+        division => 'EnsemblVertebrates',
+        name => 'homo_sapiens',
+        accession => 'GCA_000001405.9',
+        common_name => 'human',
+        display_name => 'Human',
+        taxon_id => '9606',
+        groups => ['core', 'funcgen', 'variation'],
+        aliases => [],
+        release => $core_schema_version,
+        assembly => 'GRCh37'
+      }
+    ]
+  };
   my $expected_empty_list = {species => [ ]};
 
   eq_or_diff_data(
-    $get_species->('/info/species', 'Checking only DBA available is the test DBA'), $expected, 
-    "/info/species | Checking only DBA available is the test DBA");
+    $get_species->('/info/species', 'Checking only DBA available is the test DBA'),
+    $expected, 
+    "/info/species | Checking only DBA available is the test DBA"
+  );
   eq_or_diff_data(
-    $get_species->('/info/species?division=EnsemblVertebrates', q{Output is same as /info/species if specified 'EnsemblVertebrates' division}), $expected, 
-    "/info/species?division=EnsemblVertebrates | Output is same as /info/species if specified 'Ensembl' division");
+    $get_species->('/info/species?division=EnsemblVertebrates', q{Output is same as /info/species if specified 'EnsemblVertebrates' division}),
+    $expected, 
+    "/info/species?division=EnsemblVertebrates | Output is same as /info/species if specified 'Ensembl' division"
+  );
   eq_or_diff_data(
-    $get_species->('/info/species?division=ensemblvertebrates', q{Output is same as /info/species if specified 'ensemblvertebrates' division}), $expected, 
-    "/info/species?division=ensemblvertebrates | Output is same as /info/species if specified 'ensembl' division");
+    $get_species->('/info/species?division=ensemblvertebrates', q{Output is same as /info/species if specified 'ensemblvertebrates' division}),
+    $expected, 
+    "/info/species?division=ensemblvertebrates | Output is same as /info/species if specified 'ensembl' division"
+  );
   eq_or_diff_data(
-    $get_species->('/info/species?division=EnsEMBLvertebrates', q{Output is same as /info/species if specified 'EnsEMBLvertebrates' division}), $expected, 
-    "/info/species?division=EnsEMBLvertebrates | Output is same as /info/species if specified 'EnsEMBL' division");
+    $get_species->('/info/species?division=EnsEMBLvertebrates', q{Output is same as /info/species if specified 'EnsEMBLvertebrates' division}),
+    $expected, 
+    "/info/species?division=EnsEMBLvertebrates | Output is same as /info/species if specified 'EnsEMBL' division"
+  );
   eq_or_diff_data(
-    $get_species->('/info/species?hide_strain_info=1', q{Output do not have strain and strain_collection info}), $expected_hide_strain_info,
-    "/info/species?hide_strain_info=1 | Output do not have strain and strain_collection info");
+    $get_species->('/info/species?hide_strain_info=1', q{Output does not have strain and strain_collection info}),
+    $expected_hide_strain_info,
+    "/info/species?hide_strain_info=1 | Output does not have strain and strain_collection info"
+  );
   eq_or_diff_data(
-    $get_species->('/info/species?strain_collection=human', q{Output is same as /info/species if specified 'human' strain_collection}), $expected,
-    "/info/species?strain_collection=human | Output is same as /info/species if specified 'human' strain_collection");
+    $get_species->('/info/species?strain_collection=human', q{Output is same as /info/species if specified 'human' strain_collection}),
+    $expected,
+    "/info/species?strain_collection=human | Output is same as /info/species if specified 'human' strain_collection"
+  );
   eq_or_diff_data(
-    $get_species->('/info/species?strain_collection=bogus', q{Output is empty list for unknown collection }), $expected_empty_list,
-    "/info/species?hide_strain_info=1 | Output is empty list");
+    $get_species->('/info/species?strain_collection=bogus', q{Output is empty list for unknown collection }),
+    $expected_empty_list,
+    "/info/species?hide_strain_info=1 | Output is empty list"
+  );
 
-  is_json_GET('/info/species?division=wibble', { species => [] }, 'Bogus division results in no results');
+  is_json_GET('/info/species?division=wibble', $expected_empty_list, 'Bogus division results in no results');
 }
 
 # /info/software


### PR DESCRIPTION
### Description

The addition of a default division to the species/info endpoint (EnsemblVertebrates) has exposed a bug in the Model::Registry->get_species_info, which was made without the expectation of divisions for everything

### Use case

Strains hidden for vertebrates so that users are not surprised with new seemingly unimportant keys in the returned documents.

### Benefits

Code is cleaner, works as intended, and is able to filter on division AND strain collection, not one or the other.

### Possible Drawbacks

None obvious

### Testing

Testing environment required more specific hacks for BioPerl versions to protect Bio::DB::HTS. Tests are otherwise unchanged outside of some whitespace.

_If so, do the tests pass/fail?_

Pass

_Have you run the entire test suite and no regression was detected?_
Indeed

### Changelog

Not relevant to users.