### PR TITLE
Python3 print needs parentheses

### DIFF
--- a/root/documentation/examples/python3.tt
+++ b/root/documentation/examples/python3.tt
@@ -36,7 +36,7 @@ if not r.ok:
 decoded = r.json()
 print(repr(decoded))
 [% ELSE %]
-print r.text
+print(r.text)
 [% END -%]
 [% END %]
 </pre>


### PR DESCRIPTION
### Description

(Second version of #338, against master this time)
Add parentheses to the "print" call in the rest API documentation for Python 3 (in case of plain text result).

### Use case

Python3 needs parentheses for "print", contrary to Python2. Users copying-pasting the example code are currently getting an syntax error.

### Benefits

No syntax error for users...

### Possible Drawbacks

None.

### Testing

No tests changed: only a doc template was modified.