### PR TITLE
add documentation to VEP endpoint for new plugin - e96

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -149,6 +149,11 @@
         description=Filter results by Transcript ID
         default=Not Used
       </transcript_id>
+      <Phenotypes>
+        type=Boolean
+        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
+        default=0
+      </Phenotypes>
     </params>
     <examples>
       <a>
@@ -317,6 +322,11 @@
         description=Filter results by Transcript ID
         default=Not Used
       </transcript_id>
+      <Phenotypes>
+        type=Boolean
+        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
+        default=0
+      </Phenotypes>
     </params>
     postformat={ "variants": array }
     <examples>
@@ -472,6 +482,11 @@
         description=Filter results by Transcript ID
         default=Not Used
       </transcript_id>
+      <Phenotypes>
+        type=Boolean
+        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
+        default=0
+      </Phenotypes>
     </params>
    <examples>
      <one>
@@ -622,6 +637,11 @@
         description=Filter results by Transcript ID
         default=Not Used
       </transcript_id>
+      <Phenotypes>
+        type=Boolean
+        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
+        default=0
+      </Phenotypes>
     </params>
     postformat={ "ids": array }
     <examples>
@@ -778,6 +798,11 @@
         description=Filter results by Transcript ID
         default=Not Used
       </transcript_id>
+      <Phenotypes>
+        type=Boolean
+        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
+        default=0
+      </Phenotypes>
     </params>
    <examples>
      <one>
@@ -942,6 +967,11 @@
         description=Filter results by Transcript ID
         default=Not Used
       </transcript_id>
+      <Phenotypes>
+        type=Boolean
+        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
+        default=0
+      </Phenotypes>
     </params>
     postformat={ "hgvs_notations": array }
     <examples>


### PR DESCRIPTION
### Description

_Using one or more sentences, describe in detail the proposed changes._
Add the existing Phenotypes VEP plugin as an option to the REST VEP endpoint. This is a duplicate of master PR https://github.com/Ensembl/ensembl-rest/pull/344.

### Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
This documentation is needed for the plugin to be visible on the REST endpoint page.

### Benefits

_If applicable, describe the advantages the changes will have._
Users will be able to retrieve phenotypic information reported by the plugin.

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
None.

### Testing

_Have you added/modified unit tests to test the changes?_
No tests added. Local test server page checked manually.

_Have you run the entire test suite and no regression was detected?_
No change to code. Test ran.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

[/vep/:species/hgvs/:hgvs_notation] new plugin option added: Phenotypes
[/vep/:species/hgvs] new plugin option added: Phenotypes
/[vep/:species/id/:id] new plugin option added: Phenotypes
[/vep/:species/region/:region/:allele/] new plugin option added: Phenotypes
[/vep/:species/region] new plugin option added: Phenotypes
