### PR TITLE
Reistate info/species endpoint

### DIFF
--- a/lib/EnsEMBL/REST/Controller/Info.pm
+++ b/lib/EnsEMBL/REST/Controller/Info.pm
@@ -90,6 +90,17 @@ sub data_GET :Args(0) {
   return;
 }
 
+sub species : Local : ActionClass('REST') :Args(0) { }
+
+sub species_GET :Local :Args(0) {
+  my ($self, $c) = @_;
+  my $division = $c->request->param('division') // 'EnsemblVertebrates';
+  my $strain_collection = $c->request->param('strain_collection');
+  my $hide_strain_info = $c->request->param('hide_strain_info') || 0;
+  $self->status_ok($c, entity => { species => $c->model('Registry')->get_species($division, $strain_collection, $hide_strain_info)});
+  return;
+}
+
 sub comparas : Local : ActionClass('REST') :Args(0) { }
 
 sub comparas_GET :Local :Args(0) {

--- a/root/documentation/info.conf
+++ b/root/documentation/info.conf
@@ -52,7 +52,7 @@
   </species>
   
   <comparas>
-    description=Lists all available comparative genomics databases and their data release.
+    description=Lists all available comparative genomics databases and their data release. DEPRECATED: use info/genomes/division instead.
     endpoint="info/comparas"
     method=GET
     group=Information

--- a/root/documentation/info.conf
+++ b/root/documentation/info.conf
@@ -14,6 +14,43 @@
     </examples>
   </ping>
   
+  <species>
+    description=Lists all available species, their aliases, available adaptor groups and data release.
+    endpoint="info/species"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <params>
+      <division>
+        type=String
+        description=Filter by Ensembl or Ensembl Genomes division.
+        example=__VAR(info_division)__
+        default=EnsemblVertebrates
+      </division>
+      <strain_collection>
+        type=String
+        description=Filter by strain_collection.
+        example=mouse
+      </strain_collection>
+      <hide_strain_info>
+        type=Boolean(0,1)
+        description=Show/hide strain and strain_collection info in the output
+        default=0
+      </hide_strain_info>
+    </params>
+    <examples>
+      <one>
+        path=/info/species
+        content=application/json
+      </one>
+      <two>
+        path=/info/species
+        content=text/xml
+      </two>
+    </examples>
+  </species>
+  
   <comparas>
     description=Lists all available comparative genomics databases and their data release.
     endpoint="info/comparas"


### PR DESCRIPTION
Revert "remove info/species endpoint, superseded by info/genomes/division endpoint"

This reverts commit b13284c1af6294005e6a68a1787cae0bd6129ac3.

Keep both endpoints for backward compatibility.

As agreed with @magaliruffier 
