### PR TITLE
add epigenome schema changes

### DIFF
--- a/t/regulatory.t
+++ b/t/regulatory.t
@@ -41,10 +41,14 @@ my $epigenomes_all = '/regulatory/species/homo_sapiens/epigenome?content-type=ap
 $output = [
   {
     description   => 'REMC Epigenome (Class2) for Lung',
-    display_label => 'Lung',                                         
-    efo_accession => undef,                                          
+    short_name    => 'Lung',                                         
+    efo_accession => undef,
+    encode_accession => undef,
+    epirr_accession => undef,
+    full_name => undef,                                           
     gender        => 'female',                                              
-    name          => 'Lung' 
+    name          => 'Lung',
+    search_terms => undef,  
   },
 ];
 $json = json_GET($epigenomes_all,'GET list of all epigenomes');

--- a/t/test-genome-DBs/homo_sapiens/funcgen/meta.txt
+++ b/t/test-genome-DBs/homo_sapiens/funcgen/meta.txt
@@ -183,3 +183,6 @@
 755	\N	patch	patch_96_97_a.sql|schema_version
 756	\N	patch	patch_96_97_b.sql|Changed to text
 757	\N	patch	patch_96_97_c.sql|Added flag
+758	\N	patch	patch_96_97_d.sql|Fix foreign key data type inconsistencies
+759	\N	patch	patch_96_97_e.sql|Update mirna_target_feature
+760	\N	patch	patch_96_97_f.sql|Add search_terms and full_name columns to epigenome table, rename display_label column to short_name and change description to TEXT

--- a/t/test-genome-DBs/homo_sapiens/funcgen/table.sql
+++ b/t/test-genome-DBs/homo_sapiens/funcgen/table.sql
@@ -150,7 +150,7 @@ CREATE TABLE `binding_matrix` (
 
 CREATE TABLE `binding_matrix_frequencies` (
   `binding_matrix_frequencies_id` int(11) NOT NULL AUTO_INCREMENT,
-  `binding_matrix_id` int(11) NOT NULL,
+  `binding_matrix_id` int(11) unsigned NOT NULL,
   `position` int(11) unsigned NOT NULL,
   `nucleotide` enum('A','C','G','T') NOT NULL,
   `frequency` int(10) unsigned NOT NULL,
@@ -161,7 +161,7 @@ CREATE TABLE `binding_matrix_frequencies` (
 
 CREATE TABLE `binding_matrix_transcription_factor_complex` (
   `binding_matrix_transcription_factor_complex_id` int(11) NOT NULL AUTO_INCREMENT,
-  `binding_matrix_id` int(11) NOT NULL,
+  `binding_matrix_id` int(11) unsigned NOT NULL,
   `transcription_factor_complex_id` int(11) NOT NULL,
   PRIMARY KEY (`binding_matrix_transcription_factor_complex_id`),
   UNIQUE KEY `binding_matrix_id_transcription_factor_complex_id_idx` (`binding_matrix_id`,`transcription_factor_complex_id`),
@@ -171,9 +171,9 @@ CREATE TABLE `binding_matrix_transcription_factor_complex` (
 
 CREATE TABLE `chance` (
   `chance_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `signal_alignment_id` int(10) DEFAULT NULL,
-  `control_alignment_id` int(10) DEFAULT NULL,
-  `analysis_id` int(10) unsigned DEFAULT NULL,
+  `signal_alignment_id` int(10) unsigned DEFAULT NULL,
+  `control_alignment_id` int(10) unsigned DEFAULT NULL,
+  `analysis_id` smallint(10) unsigned DEFAULT NULL,
   `p` double DEFAULT NULL,
   `q` double DEFAULT NULL,
   `divergence` double DEFAULT NULL,
@@ -206,13 +206,15 @@ CREATE TABLE `data_file` (
 CREATE TABLE `epigenome` (
   `epigenome_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(120) NOT NULL,
-  `display_label` varchar(120) NOT NULL,
-  `description` varchar(80) DEFAULT NULL,
+  `short_name` varchar(120) NOT NULL,
+  `description` mediumtext DEFAULT NULL,
   `production_name` varchar(120) DEFAULT NULL,
   `gender` enum('male','female','hermaphrodite','mixed','unknown') DEFAULT 'unknown',
+  `search_terms` mediumtext,
+  `full_name` mediumtext,
   PRIMARY KEY (`epigenome_id`),
   UNIQUE KEY `name_idx` (`name`),
-  UNIQUE KEY `display_label_idx` (`display_label`)
+  UNIQUE KEY `short_name_idx` (`short_name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=126 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `execution_plan` (
@@ -389,7 +391,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=758 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=761 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
@@ -400,22 +402,21 @@ CREATE TABLE `meta_coord` (
 
 CREATE TABLE `mirna_target_feature` (
   `mirna_target_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `feature_set_id` int(10) unsigned NOT NULL,
   `feature_type_id` int(10) unsigned DEFAULT NULL,
   `accession` varchar(60) DEFAULT NULL,
   `display_label` varchar(60) DEFAULT NULL,
   `evidence` varchar(60) DEFAULT NULL,
-  `interdb_stable_id` int(10) unsigned DEFAULT NULL,
   `method` varchar(60) DEFAULT NULL,
   `seq_region_id` int(10) unsigned NOT NULL,
   `seq_region_start` int(10) unsigned NOT NULL,
   `seq_region_end` int(10) unsigned NOT NULL,
   `seq_region_strand` tinyint(1) NOT NULL,
   `supporting_information` varchar(100) DEFAULT NULL,
+  `analysis_id` smallint(10) unsigned DEFAULT NULL,
+  `gene_stable_id` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`mirna_target_feature_id`),
-  UNIQUE KEY `interdb_stable_id_idx` (`interdb_stable_id`),
+  UNIQUE KEY `unique_idx` (`accession`,`gene_stable_id`,`seq_region_start`,`seq_region_end`),
   KEY `feature_type_idx` (`feature_type_id`),
-  KEY `feature_set_idx` (`feature_set_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
 ) ENGINE=MyISAM AUTO_INCREMENT=316842 DEFAULT CHARSET=latin1 MAX_ROWS=100000000;
 
@@ -437,8 +438,8 @@ CREATE TABLE `motif_feature` (
 
 CREATE TABLE `motif_feature_peak` (
   `motif_feature_peak_id` int(11) NOT NULL AUTO_INCREMENT,
-  `motif_feature_id` int(11) NOT NULL,
-  `peak_id` int(11) NOT NULL,
+  `motif_feature_id` int(11) unsigned NOT NULL,
+  `peak_id` int(11) unsigned NOT NULL,
   PRIMARY KEY (`motif_feature_peak_id`),
   KEY `motif_feature_idx` (`motif_feature_id`),
   KEY `peak_idx` (`peak_id`)
@@ -446,9 +447,9 @@ CREATE TABLE `motif_feature_peak` (
 
 CREATE TABLE `motif_feature_regulatory_feature` (
   `motif_feature_regulatory_feature_id` int(11) NOT NULL AUTO_INCREMENT,
-  `motif_feature_id` int(11) NOT NULL,
-  `regulatory_feature_id` int(11) NOT NULL,
-  `epigenome_id` int(11) DEFAULT NULL,
+  `motif_feature_id` int(11) unsigned NOT NULL,
+  `regulatory_feature_id` int(11) unsigned NOT NULL,
+  `epigenome_id` int(11) unsigned DEFAULT NULL,
   `has_matching_Peak` tinyint(3) unsigned DEFAULT '0',
   PRIMARY KEY (`motif_feature_regulatory_feature_id`),
   UNIQUE KEY `mf_rf_ep_idx` (`motif_feature_id`,`regulatory_feature_id`,`epigenome_id`),
@@ -621,7 +622,7 @@ CREATE TABLE `probe_set` (
   `name` varchar(100) NOT NULL,
   `size` smallint(6) unsigned NOT NULL,
   `family` varchar(20) DEFAULT NULL,
-  `array_chip_id` int(10) DEFAULT NULL,
+  `array_chip_id` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (`probe_set_id`),
   KEY `name` (`name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1919342 DEFAULT CHARSET=latin1;
@@ -743,7 +744,7 @@ CREATE TABLE `regulatory_feature` (
 
 CREATE TABLE `segmentation` (
   `segmentation_id` int(18) unsigned NOT NULL AUTO_INCREMENT,
-  `regulatory_build_id` int(22) DEFAULT NULL,
+  `regulatory_build_id` int(22) unsigned DEFAULT NULL,
   `name` varchar(255) NOT NULL,
   `superclass` varchar(255) NOT NULL,
   `class` varchar(255) NOT NULL,
@@ -843,8 +844,8 @@ CREATE TABLE `transcription_factor_complex_composition` (
 
 CREATE TABLE `underlying_structure` (
   `underlying_structure_id` int(11) NOT NULL AUTO_INCREMENT,
-  `regulatory_feature_id` int(11) NOT NULL,
-  `motif_feature_id` int(11) NOT NULL,
+  `regulatory_feature_id` int(11) unsigned NOT NULL,
+  `motif_feature_id` int(11) unsigned NOT NULL,
   PRIMARY KEY (`underlying_structure_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

Changes in the regulatory.t test are done to match the schema changes in the Epigenome table of the funcgen DB. Also, the test DB has been patched.

### Use case

The schema of the epigenome table in the funcgen DB has changed. 
These changes are:
The 'display_name' column has been renamed to 'short_name'
And we have added these new columns 'full_name' and 'search_terms'

The changes in the Perl API are:
(Epigenome)
The 'display_label' method has been deprecated, now the 'short_name' method should be used.
The methods 'full_name', 'search_terms' and 'encode_accession' have been added.

(Epigenome adaptor)
The 'fetch_by_display_label' method has been deprecated, now the 'fetch_by_short_name' method should be used.

### Benefits

...

### Possible Drawbacks

...

### Testing

There are changes in the regulatory.t test

The test was passed.

### Changelog

...
