### PR TITLE
Activate coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: "perl"
 
 perl:
-  - "5.26"
-  - "5.14"
+  - '5.26'
+  - '5.14'
 
 sudo: false
 
@@ -12,7 +12,15 @@ addons:
     - unzip
 
 env:
+  - COVERALLS=true
   - COVERALLS=false
+
+matrix:
+  exclude:
+  - perl: '5.26'
+    env: COVERALLS=false
+  - perl: '5.14'
+    env: COVERALLS=true
 
 before_install:
     - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ API used for our REST server, http://rest.ensembl.org
 
 
 
-[![Build Status](https://travis-ci.org/Ensembl/ensembl-rest.png?branch=master)][travis]
+[![Build Status](https://travis-ci.org/Ensembl/ensembl-rest.png)][travis]
 [![Coverage Status](https://coveralls.io/repos/Ensembl/ensembl-rest/badge.png)][coveralls]
 
 [travis]: https://travis-ci.org/Ensembl/ensembl-rest

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ API used for our REST server, http://rest.ensembl.org
 
 
 
-[![Build Status](https://travis-ci.org/Ensembl/ensembl-rest.png)][travis]
+[![Build Status](https://travis-ci.org/Ensembl/ensembl-rest.svg?branch=master)][travis]
 [![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl-rest/badge.svg?branch=master)][coveralls]
 
 [travis]: https://travis-ci.org/Ensembl/ensembl-rest
-[coveralls]: https://coveralls.io/github/Ensembl/ensembl-rest?branch=master
+[coveralls]: https://coveralls.io/github/Ensembl/ensembl-rest

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ ensembl-rest
 Language agnostic RESTful data access to Ensembl data over HTTP
 
 API used for our REST server, http://rest.ensembl.org
+
+
+
+[![Build Status](https://travis-ci.org/Ensembl/ensembl-rest.png?branch=master)][travis]
+
+[travis]: https://travis-ci.org/Ensembl/ensembl-rest

--- a/README.md
+++ b/README.md
@@ -8,5 +8,7 @@ API used for our REST server, http://rest.ensembl.org
 
 
 [![Build Status](https://travis-ci.org/Ensembl/ensembl-rest.png?branch=master)][travis]
+[![Coverage Status](https://coveralls.io/repos/Ensembl/ensembl-rest/badge.png)][coveralls]
 
 [travis]: https://travis-ci.org/Ensembl/ensembl-rest
+[coveralls]: https://coveralls.io/r/Ensembl/ensembl-rest

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API used for our REST server, http://rest.ensembl.org
 
 
 [![Build Status](https://travis-ci.org/Ensembl/ensembl-rest.png)][travis]
-[![Coverage Status](https://coveralls.io/repos/Ensembl/ensembl-rest/badge.png)][coveralls]
+[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl-rest/badge.svg?branch=master)][coveralls]
 
 [travis]: https://travis-ci.org/Ensembl/ensembl-rest
-[coveralls]: https://coveralls.io/r/Ensembl/ensembl-rest
+[coveralls]: https://coveralls.io/github/Ensembl/ensembl-rest?branch=master


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

This makes travis run coveralls for the most recent (tested) perl version.
Resolves ENSCORESW-3069

### Use case

coveralls was not being run

### Benefits

now it is

### Possible Drawbacks

slightly longer travis build

### Testing

_Have you added/modified unit tests to test the changes?_
no

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._
no

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians
