### PR TITLE
Documentation add optional field in variant_recoder/ 

### DIFF
--- a/root/documentation/variation.conf
+++ b/root/documentation/variation.conf
@@ -215,7 +215,7 @@
       </species>
       <fields>
         type=String
-        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic), vcf (VCF format)
+        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic), vcf_string (VCF format)
         default=id,hgvsg,hgvsc,hgvsp,spdi
       </fields>
     </params>

--- a/root/documentation/variation.conf
+++ b/root/documentation/variation.conf
@@ -176,7 +176,7 @@
       </species>
       <fields>
         type=String
-        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic)
+        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic), vcf (VCF format)
         default=id,hgvsg,hgvsc,hgvsp,spdi
       </fields>
     </params>
@@ -215,7 +215,7 @@
       </species>
       <fields>
         type=String
-        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic)
+        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic), vcf (VCF format)
         default=id,hgvsg,hgvsc,hgvsp,spdi
       </fields>
     </params>

--- a/root/documentation/variation.conf
+++ b/root/documentation/variation.conf
@@ -176,7 +176,7 @@
       </species>
       <fields>
         type=String
-        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic), vcf (VCF format)
+        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic), vcf_string (VCF format)
         default=id,hgvsg,hgvsc,hgvsp,spdi
       </fields>
     </params>


### PR DESCRIPTION
### Description
  
Need to change the description of endpoint variant_recoder/ because a new optional field was added 

### Use case

This documentation is needed to allow users to know it is possible to output VCF format.  

### Benefits

Users may get VCF format as output.  

### Possible Drawbacks

None 

### Testing

No tests needed 

### Changelog

The functionality of the endpoint is the same. 
