### PR TITLE
Travis: Add mysql to the list of services [release/97]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ perl:
   - "5.26"
   - "5.14"
 
+services:
+  - mysql
+
 sudo: false
 
 addons:


### PR DESCRIPTION
## Description

Travis is now in the process of changing the default Linux distribution it uses for builds from Ubuntu Trusty to Ubuntu Xenial. One of the differences between Travis Trusty and Xenial images is that the latter no longer implicitly start services such as the MySQL daemon. Update our travis configuration to explicitly start the MySQL service. See https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment for details.

## Use case

The vast majority of Infrastructure repositories both use MySQL and do _not_ specify the distribution to use, meaning we might end up with our builds suddently going Xenial and being unable to connect to MySQL.

## Benefits

Travis builds will hopefully continue to work once the default distro for our repositories has been changed from Trusty to Xenial.

## Possible Drawbacks

None I can think of.

## Testing

_Have you added/modified unit tests to test the changes?_

No, changes affect Travis only.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

No, changes affect Travis only. Travis builds for the merge branch continue to succeed.
