### PR TITLE
Test DB: add missing ontology patches

### DIFF
--- a/t/test-genome-DBs/multi/ontology/table.sql
+++ b/t/test-genome-DBs/multi/ontology/table.sql
@@ -14,7 +14,7 @@ CREATE TABLE `closure` (
   `subparent_term_id` int(10) unsigned DEFAULT NULL,
   `distance` tinyint(3) unsigned NOT NULL,
   `ontology_id` int(10) unsigned NOT NULL,
-  `confident_relationship` tinyint(1) NOT NULL DEFAULT '0',
+  `confident_relationship` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`closure_id`),
   UNIQUE KEY `child_parent_idx` (`child_term_id`,`parent_term_id`,`subparent_term_id`,`ontology_id`),
   KEY `parent_subparent_idx` (`parent_term_id`,`subparent_term_id`)
@@ -43,7 +43,7 @@ CREATE TABLE `relation` (
   `child_term_id` int(10) unsigned NOT NULL,
   `parent_term_id` int(10) unsigned NOT NULL,
   `relation_type_id` int(10) unsigned NOT NULL,
-  `intersection_of` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `intersection_of` tinyint(3) unsigned NOT NULL DEFAULT 0,
   `ontology_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`relation_id`),
   UNIQUE KEY `child_parent_idx` (`child_term_id`,`parent_term_id`,`relation_type_id`,`intersection_of`,`ontology_id`),
@@ -60,7 +60,7 @@ CREATE TABLE `relation_type` (
 CREATE TABLE `subset` (
   `subset_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
-  `definition` varchar(128) NOT NULL,
+  `definition` varchar(1023) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`subset_id`),
   UNIQUE KEY `name_idx` (`name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1;
@@ -79,12 +79,12 @@ CREATE TABLE `synonym` (
 CREATE TABLE `term` (
   `term_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `ontology_id` int(10) unsigned NOT NULL,
-  `subsets` text,
+  `subsets` text DEFAULT NULL,
   `accession` varchar(64) NOT NULL,
   `name` varchar(255) NOT NULL,
-  `definition` text,
-  `is_root` int(11) NOT NULL DEFAULT '0',
-  `is_obsolete` int(11) NOT NULL DEFAULT '0',
+  `definition` text DEFAULT NULL,
+  `is_root` int(11) NOT NULL DEFAULT 0,
+  `is_obsolete` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`term_id`),
   UNIQUE KEY `accession_idx` (`accession`),
   UNIQUE KEY `ontology_acc_idx` (`ontology_id`,`accession`),


### PR DESCRIPTION
The last patching of test databases in this repository missed ontology-DB patches because the patcher script has only just been updated to look for said patches in their new home. Make sure test databases are up to date before the release date.