### PR TITLE
Travis [release/97]: use release/97 branch of dependent Ensembl repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ env:
 
 before_install:
     - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
-    - export ENSEMBL_BRANCH=master
+    - export ENSEMBL_BRANCH='release/97'
     - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; fi
     - echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-hdf5.git
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-hdf5.git
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-compara.git
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-variation.git
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-vep.git


### PR DESCRIPTION
### Description

Make Travis use the _release/97_ branch of dependent Ensembl repositories rather than _master_.

### Use case

At present Travis builds of ensembl-rest always pull respective master branches even when ensembl-rest itself is on a release branch. This will no longer be the case starting with release 98, and it does make sense to backport the change to release 97 in light of the ongoing issue with failing Variation tests, which will have to be fixed for both _master_ and _release/97_ and which may or may not require changes in _ensembl-variation_ in addition to / rather than _ensembl-rest_.

### Benefits

Travis builds of _ensembl-rest_ for release 97 will no longer pull in master branches of Ensembl repositories, which have already branched to 98 and will diverge more and more from the 97 code base.

### Possible Drawbacks

None I can think of.

### Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Change affects Travis only. The build on the pushed branch has successfully cloned the dependent repositories and failes in exactly the same way as before the change (i.e. on variation.t failures).

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

Changes only affect the execution of tests on Travis, no endpoint-related changes of any sort have been involved.