### PR TITLE
Changes needed to support the use of release branches in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
     - echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-hdf5.git
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-hdf5.git
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-compara.git
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-variation.git
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-vep.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
 
 before_install:
     - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
-    - export ENSEMBL_BRANCH=master
+    - export ENSEMBL_BRANCH='master'
     - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; fi
     - echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git


### PR DESCRIPTION
### Description

Two changes:
 - have the cloning of _ensembl-hdf5_ honour the value of $ENSEMBL_BRANCH instead of always using the master branch,
 - quote the value of $ENSEMBL_BRANCH to future-proof ourselves against funky branch names and broken shells.

### Use case

Core release procedures have just been updated so that _ensembl-rest_ Travis builds on release branches use corresponding release branches in other Ensembl repositories instead of master. Right now implementing this required the branch-name changes in two places, and with variable values being unquoted there is potential for getting something wrong.

### Benefits

Release-branch builds of _ensembl-rest_ will only require a change in one place with respect to master to make sure all Ensembl dependencies use the correct release branch, and always quoting the branch name means it won't be necessary for whoever branches _ensembl-rest_ to think about whether they should introduce quotes upon changing the branch name or not.

### Possible Drawbacks

None.

### Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Change affects Travis only. The build on the pushed branch has not completed yet but with this being essentially #363 with the branch name changed back to _master_, problems are unlikely.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

Changes only affect the execution of tests on Travis, no endpoint-related changes of any sort have been involved.