### PR TITLE
correction for allowed region size

### DIFF
--- a/root/documentation/ld.conf
+++ b/root/documentation/ld.conf
@@ -98,7 +98,7 @@
       </species>
       <region>
         type=String
-        description=Query region. A maximum of 1Mb is allowed.
+        description=Query region. A maximum region size of 500 kb is allowed.
         example=__VAR(ld_sequence_region)__
         required=1
       </region>


### PR DESCRIPTION
Same as https://github.com/Ensembl/ensembl-rest/pull/368

### Description
Documentation update. Correct the maximum allowed region size. We added a check to the code for restricting the maximum allowed region size a long time ago but forgot to update the documentation. This has been reported by a user on the ensembl-dev list.

### Use case

NA

### Benefits

Correct documentation

### Possible Drawbacks

None

### Testing

Not needed

### Changelog

Not needed