### PR TITLE
Bugfix/ld exception handling

### DIFF
--- a/lib/EnsEMBL/REST/Controller/LD.pm
+++ b/lib/EnsEMBL/REST/Controller/LD.pm
@@ -43,8 +43,8 @@ sub id_GET {
   try {
     $LDFeatureContainer = $c->model('LDFeatureContainer')->fetch_LDFeatureContainer_variation_name($id, $population_name);
   } catch {
-    $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;    
-    $c->go('ReturnError', 'custom', [qq{$_}]);
+    $c->go('ReturnError', 'from_ensembl', [ qq{$_} ]) if $_ =~ /STACK/;    
+    $c->go('ReturnError', 'custom', [ qq{$_} ]);
   };
   $self->status_ok($c, entity => $LDFeatureContainer);
 }
@@ -59,8 +59,8 @@ sub region_GET {
     my $slice = $c->model('Lookup')->find_slice($region);
     $LDFeatureContainer = $c->model('LDFeatureContainer')->fetch_LDFeatureContainer_slice($slice, $population_name);
   } catch {
-    $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;
-    $c->go('ReturnError', 'custom', [qq{$_}]);
+    $c->go('ReturnError', 'from_ensembl', [ qq{$_} ]) if $_ =~ /STACK/;
+    $c->go('ReturnError', 'custom', [ qq{$_} ]);
   };
   $self->status_ok($c, entity => $LDFeatureContainer);
 }
@@ -74,8 +74,8 @@ sub pairwise_GET {
   try {
     $LDFeatureContainer = $c->model('LDFeatureContainer')->fetch_LDFeatureContainer_pairwise($id1, $id2);
   } catch {
-    $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;    
-    $c->go('ReturnError', 'custom', [qq{$_}]);
+    $c->go('ReturnError', 'from_ensembl', [ qq{$_} ]) if $_ =~ /STACK/;    
+    $c->go('ReturnError', 'custom', [ qq{$_} ]);
   };
   $self->status_ok($c, entity => $LDFeatureContainer);
 }

--- a/lib/EnsEMBL/REST/Controller/LD.pm
+++ b/lib/EnsEMBL/REST/Controller/LD.pm
@@ -43,7 +43,7 @@ sub id_GET {
   try {
     $LDFeatureContainer = $c->model('LDFeatureContainer')->fetch_LDFeatureContainer_variation_name($id, $population_name);
   } catch {
-    $c->go('ReturnError', 'from_ensembl', []) if $_ =~ /STACK/;    
+    $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;    
     $c->go('ReturnError', 'custom', [qq{$_}]);
   };
   $self->status_ok($c, entity => $LDFeatureContainer);
@@ -55,11 +55,11 @@ sub region_GET {
   my ($self, $c, $region, $population_name) = @_;
   unless ($population_name) {$c->go('ReturnError', 'custom', ["A population name is required for this endpoint. Use GET /info/variation/populations/:species?filter=LD to retrieve a list of all populations with LD data."]);}
   my $LDFeatureContainer;
-  my $slice = $c->model('Lookup')->find_slice($region);
   try {
+    my $slice = $c->model('Lookup')->find_slice($region);
     $LDFeatureContainer = $c->model('LDFeatureContainer')->fetch_LDFeatureContainer_slice($slice, $population_name);
   } catch {
-    $c->go('ReturnError', 'from_ensembl', []) if $_ =~ /STACK/;    
+    $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;
     $c->go('ReturnError', 'custom', [qq{$_}]);
   };
   $self->status_ok($c, entity => $LDFeatureContainer);
@@ -74,7 +74,7 @@ sub pairwise_GET {
   try {
     $LDFeatureContainer = $c->model('LDFeatureContainer')->fetch_LDFeatureContainer_pairwise($id1, $id2);
   } catch {
-    $c->go('ReturnError', 'from_ensembl', []) if $_ =~ /STACK/;    
+    $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;    
     $c->go('ReturnError', 'custom', [qq{$_}]);
   };
   $self->status_ok($c, entity => $LDFeatureContainer);

--- a/lib/EnsEMBL/REST/Model/LDFeatureContainer.pm
+++ b/lib/EnsEMBL/REST/Model/LDFeatureContainer.pm
@@ -43,8 +43,8 @@ sub _get_LDFeatureContainerAdaptor {
   try {
     $ldfca = $c->model('Registry')->get_adaptor($species, 'Variation', 'LDFeatureContainer');
   } catch {
-    $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;
-    $c->go('ReturnError', 'custom', [qq{$_}]);
+    $c->go('ReturnError', 'from_ensembl', [ qq{$_} ]) if $_ =~ /STACK/;
+    $c->go('ReturnError', 'custom', [ qq{$_} ]);
     $c->log->error("LD endpoint caused an error: $_");
   };
   Catalyst::Exception->throw("Cannot compute LD for species: $species. The species doesn't have a variation database.") if (!$ldfca);

--- a/lib/EnsEMBL/REST/Model/LDFeatureContainer.pm
+++ b/lib/EnsEMBL/REST/Model/LDFeatureContainer.pm
@@ -33,13 +33,38 @@ sub build_per_context_instance {
   return $self->new({ context => $c, %$self, @args });
 }
 
+# This will deal with errors caused when using unsupported species e.g. fly or species without a variation database e.g. gorilla  
+sub _get_LDFeatureContainerAdaptor {
+  my $self = shift;
+  my $c = $self->context();
+  my $species = $c->stash->{species};
+
+  my $ldfca;
+  try {
+    $ldfca = $c->model('Registry')->get_adaptor($species, 'Variation', 'LDFeatureContainer');
+  } catch {
+    $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;
+    $c->go('ReturnError', 'custom', [qq{$_}]);
+    $c->log->error("LD endpoint caused an error: $_");
+  };
+  Catalyst::Exception->throw("Cannot compute LD for species: $species. The species doesn't have a variation database.") if (!$ldfca);
+  my $ld_config = $c->config->{'Model::LDFeatureContainer'};
+  if ($ld_config && $ld_config->{use_vcf}) {
+    $ldfca->db->use_vcf($ld_config->{use_vcf});
+    $ldfca->db->vcf_config_file($ld_config->{vcf_config});
+    $ldfca->db->vcf_root_dir($ld_config->{dir}) if (defined $ld_config->{dir});
+  }
+  return $ldfca;
+}
+
 sub fetch_LDFeatureContainer_variation_name {
   my ($self, $variation_name, $population_name) = @_;
   my $c = $self->context();
   my $species = $c->stash->{species};
 
+  my $ldfca = $self->_get_LDFeatureContainerAdaptor();
   my $va = $c->model('Registry')->get_adaptor($species, 'Variation', 'Variation');
-  my $ldfca = $c->model('Registry')->get_adaptor($species, 'Variation', 'LDFeatureContainer');
+
   my $vf_attribs = $c->request->param('attribs');
   my $window_size = $c->request->param('window_size') || 500; # default is 500KB
   Catalyst::Exception->throw("window_size needs to be a value between 0 and 500.") if (!looks_like_number($window_size));
@@ -49,12 +74,6 @@ sub fetch_LDFeatureContainer_variation_name {
   my $max_snp_distance = ($window_size / 2) * 1000;
   $ldfca->max_snp_distance($max_snp_distance);
 
-  my $ld_config = $c->config->{'Model::LDFeatureContainer'};
-  if ($ld_config && $ld_config->{use_vcf}) {
-    $ldfca->db->use_vcf($ld_config->{use_vcf});
-    $ldfca->db->vcf_config_file($ld_config->{vcf_config});
-    $ldfca->db->vcf_root_dir($ld_config->{dir}) if (defined $ld_config->{dir});
-  }
   my $variation = $va->fetch_by_name($variation_name);
   Catalyst::Exception->throw("Could not fetch variation object for id: $variation_name.") if ! $variation;
   my @vfs = grep { $_->slice->is_reference } @{$variation->get_all_VariationFeatures()};
@@ -85,14 +104,7 @@ sub fetch_LDFeatureContainer_slice {
   my $c = $self->context();
   my $species = $c->stash->{species};
 
-  my $ldfca = $c->model('Registry')->get_adaptor($species, 'Variation', 'LDFeatureContainer');
-
-  my $ld_config = $c->config->{'Model::LDFeatureContainer'};
-  if ($ld_config && $ld_config->{use_vcf}) {
-    $ldfca->db->use_vcf($ld_config->{use_vcf});
-    $ldfca->db->vcf_config_file($ld_config->{vcf_config});
-    $ldfca->db->vcf_root_dir($ld_config->{dir}) if (defined $ld_config->{dir});
-  }
+  my $ldfca = $self->_get_LDFeatureContainerAdaptor();
 
   my $pa = $c->model('Registry')->get_adaptor($species, 'Variation', 'Population');     
   my $population = $pa->fetch_by_name($population_name);
@@ -117,16 +129,9 @@ sub fetch_LDFeatureContainer_pairwise {
   my $c = $self->context();
   my $species = $c->stash->{species};
 
+  my $ldfca = $self->_get_LDFeatureContainerAdaptor();
   my $va = $c->model('Registry')->get_adaptor($species, 'Variation', 'Variation');
-  my $ldfca = $c->model('Registry')->get_adaptor($species, 'Variation', 'LDFeatureContainer');
   my $pa = $c->model('Registry')->get_adaptor($species, 'Variation', 'Population');
-
-  my $ld_config = $c->config->{'Model::LDFeatureContainer'};
-  if ($ld_config && $ld_config->{use_vcf}) {
-    $ldfca->db->use_vcf($ld_config->{use_vcf});
-    $ldfca->db->vcf_config_file($ld_config->{vcf_config});
-    $ldfca->db->vcf_root_dir($ld_config->{dir}) if (defined $ld_config->{dir});
-  }
 
   my @vfs_pair = ();
   foreach my $variation_name ($variation_name1, $variation_name2) {

--- a/t/ld.t
+++ b/t/ld.t
@@ -34,6 +34,8 @@ use Bio::EnsEMBL::Test::TestUtils;
 use Catalyst::Test();
 use JSON;
 my $dba = Bio::EnsEMBL::Test::MultiTestDB->new('homo_sapiens');
+my $chicken = Bio::EnsEMBL::Test::MultiTestDB->new('gallus_gallus');
+
 my $multi = Bio::EnsEMBL::Test::MultiTestDB->new('multi');
 Catalyst::Test->import('EnsEMBL::REST');
 
@@ -198,6 +200,9 @@ cmp_bag($json, $expected_output, "Example region, population, r2");
 
 $ld_region_get = '/ld/homo_sapiens/region/9:22125265..23125505/1000GENOMES:phase_1_ASW?r2=0.5';
 action_bad($ld_region_get, 'Specified region is too large');
+
+$ld_region_get = '/ld/gallus_gallus/region/2:106040050-106040100/1000GENOMES:phase_1_ASW?r2=0.5';
+action_bad($ld_region_get, "The species doesn't have a variation database");
 
 # tests for ld/:species/pairwise
 


### PR DESCRIPTION
### Description

I'm addressing weak exception handling which has been brought to our attention by a dev user. I summarised it in a [ticket](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-2325). 

1) https://rest.ensembl.org/ld/fly/region/1:1..10000/1000GENOMES:phase_3:CEU?d_prime=0;r2=0;content-type=application/json failed because of missing qq{$_} in Controller/LD.pm
2) https://rest.ensembl.org/ld/gorilla/region/1:1..10000/1000GENOMES:phase_3:CEU?d_prime=0;r2=0;content-type=application/json with my PR returns a message that the species doesn't have variation database
3)https://rest.ensembl.org/ld/gorilla/rs1042779/1000GENOMES:phase_3:CEU?window_size=50;d_prime=0;r2=0 same as 2)

### Use case

Improved error messages

### Benefits

Improved exceptions which don't expose internal code and give clue about why the endpoint doesn't return data

### Possible Drawbacks

None

### Testing

I added a test for 2) and 3) I don't know how to test 1)

archive.t fails. But I'm sure this is not related to my updates.

### Changelog

Not needed
