### PR TITLE
Model::Lookup::find_object_location(): only pass the expected three substitution arguments to sprintf()

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -69,3 +69,4 @@ test_requires 'HTTP::Request::Common';
 test_requires 'Plack::Test';
 test_requires 'Net::CIDR::Lite';
 test_requires 'Test::Time::HiRes';
+test_requires 'Test::Warnings';

--- a/lib/EnsEMBL/REST/Model/Lookup.pm
+++ b/lib/EnsEMBL/REST/Model/Lookup.pm
@@ -346,8 +346,8 @@ sub find_object_location {
   }
 
   if($log->is_debug()) {
-    if(@captures && $captures[0]) {
-      $log->debug(sprintf('Found %s, %s and %s', @captures));
+    if(@captures && $captures[2]) {
+      $log->debug(sprintf('Found %s, %s and %s', @captures[0..2]));
     }
     else {
       $log->debug('Found no ID');

--- a/t/archive.t
+++ b/t/archive.t
@@ -26,6 +26,7 @@ BEGIN {
 
 use Test::More;
 use Test::Differences;
+use Test::Warnings;
 use Catalyst::Test ();
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Test::TestUtils;


### PR DESCRIPTION
### Description

Make sure that the sprintf() call in line 350 of _lib/EnsEMBL/REST/Model/Lookup.pm_ doesn't receive more than the 3 substitution arguments it expects.

### Use case

Previously said sprintf() call was passed the entire @captures array and at least nowadays that array is longer than 3 elements, resulting in a "redundant arguments" warning which spams the output of the test suite.

### Benefits

Less noise in test output.

### Possible Drawbacks

None I can think of.

### Testing

_Have you added/modified unit tests to test the changes?_

Yes, _archive.t_ - the first test file to have previously produced this warning - now uses _Test::Warnings_. Note that this adds a new test-time dependency to _ensembl-rest_, which however shouldn't be a problem because other Ensembl repositories already depend on _Test::Warnings_.

_If so, do the tests pass/fail?_

The test passes _i.e._ no warnings are detected.

_Have you run the entire test suite and no regression was detected?_

Yes, no regression detected. The errors in _archive.t_ are the same as before with the bugfix branch based on _master_ and gone when based on the branch of #374.