### PR TITLE
update endpoint docs

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -154,6 +154,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
+      <CADD>
+        type=Boolean
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
+        default=0
+      </CADD>
     </params>
     <examples>
       <a>
@@ -327,6 +332,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
+      <CADD>
+        type=Boolean
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
+        default=0
+      </CADD>
     </params>
     postformat={ "variants": array }
     <examples>
@@ -487,6 +497,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
+      <CADD>
+        type=Boolean
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
+        default=0
+      </CADD>
     </params>
    <examples>
      <one>
@@ -642,6 +657,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
+      <CADD>
+        type=Boolean
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
+        default=0
+      </CADD>
     </params>
     postformat={ "ids": array }
     <examples>
@@ -803,6 +823,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
+      <CADD>
+        type=Boolean
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
+        default=0
+      </CADD>
     </params>
    <examples>
      <one>
@@ -972,6 +997,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
+      <CADD>
+        type=Boolean
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
+        default=0
+      </CADD>
     </params>
     postformat={ "hgvs_notations": array }
     <examples>


### PR DESCRIPTION
Copy of PR https://github.com/Ensembl/ensembl-rest/pull/376 (`release/98`) now on `master`
### Description

_Using one or more sentences, describe in detail the proposed changes._

One more VEP plugin will be available through the VEP endpoint. The documentation in this PR is needed for the plugin. The corresponding parameters config are in PR https://github.com/Ensembl/ensembl-rest_private/pull/61

### Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

Plugin functionality available through REST.

live: http://rest.ensembl.org/documentation/info/vep_id_get
sandbox: http://ves-hx2-76.ebi.ac.uk:6083/documentation/info/vep_id_get

### Benefits

_If applicable, describe the advantages the changes will have._

Without this documentation, the endpoint will not display the availability of the functionality in the background.

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

### Testing

_Have you added/modified unit tests to test the changes?_
No tests added. Local test server page checked manually.

_If so, do the tests pass/fail?_
pass

_Have you run the entire test suite and no regression was detected?_
No change to code. Test ran.

Tested : http://hx-noah-74-15:3000/vep/human/id/rs699?content-type=application/json;CADD=1

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

[/vep/:species/hgvs/] new plugin option added: CADD
[/vep/:species/id/] new plugin option added: CADD
[/vep/:species/region/] new plugin option added: CADD