### PR TITLE
Add MANE support

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -66,6 +66,7 @@ has valid_user_params => (
     phastCons
     distance
     ambiguity
+    mane
 
     pick
     pick_allele

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -70,7 +70,7 @@
       </appris>
       <mane>
         type=Boolean
-        description=Include MANE Select annotations (if available)
+        description=Include MANE Select annotations (GRCh38 only)
         default=0
       </mane>
       <tsl>
@@ -258,7 +258,7 @@
       </appris>
       <mane>
         type=Boolean
-        description=Include MANE Select annotations (if available)
+        description=Include MANE Select annotations (GRCh38 only)
         default=0
       </mane>
       <tsl>
@@ -423,7 +423,7 @@
       </appris>
       <mane>
         type=Boolean
-        description=Include MANE Select annotations (if available)
+        description=Include MANE Select annotations (GRCh38 only)
         default=0
       </mane>
       <tsl>
@@ -593,7 +593,7 @@
       </appris>
       <mane>
         type=Boolean
-        description=Include MANE Select annotations (if available)
+        description=Include MANE Select annotations (GRCh38 only)
         default=0
       </mane>
       <tsl>
@@ -759,7 +759,7 @@
       </appris>
       <mane>
         type=Boolean
-        description=Include MANE Select annotations (if available)
+        description=Include MANE Select annotations (GRCh38 only)
         default=0
       </mane>
       <tsl>
@@ -943,7 +943,7 @@
       </appris>
       <mane>
         type=Boolean
-        description=Include MANE Select annotations (if available)
+        description=Include MANE Select annotations (GRCh38 only)
         default=0
       </mane>
       <tsl>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -68,6 +68,11 @@
         description=Include APPRIS isoform annotation
         default=0
       </appris>
+      <mane>
+        type=Boolean
+        description=Include MANE Select annotations (if available)
+        default=0
+      </mane>
       <tsl>
         type=Boolean
         description=Include transcript support level (TSL) annotation
@@ -251,6 +256,11 @@
         description=Include APPRIS isoform annotation
         default=0
       </appris>
+      <mane>
+        type=Boolean
+        description=Include MANE Select annotations (if available)
+        default=0
+      </mane>
       <tsl>
         type=Boolean
         description=Include transcript support level (TSL) annotation
@@ -411,6 +421,11 @@
         description=Include APPRIS isoform annotation
         default=0
       </appris>
+      <mane>
+        type=Boolean
+        description=Include MANE Select annotations (if available)
+        default=0
+      </mane>
       <tsl>
         type=Boolean
         description=Include transcript support level (TSL) annotation
@@ -576,6 +591,11 @@
         description=Include APPRIS isoform annotation
         default=0
       </appris>
+      <mane>
+        type=Boolean
+        description=Include MANE Select annotations (if available)
+        default=0
+      </mane>
       <tsl>
         type=Boolean
         description=Include transcript support level (TSL) annotation
@@ -737,6 +757,11 @@
         description=Include APPRIS isoform annotation
         default=0
       </appris>
+      <mane>
+        type=Boolean
+        description=Include MANE Select annotations (if available)
+        default=0
+      </mane>
       <tsl>
         type=Boolean
         description=Include transcript support level (TSL) annotation
@@ -916,6 +941,11 @@
         description=Include APPRIS isoform annotation
         default=0
       </appris>
+      <mane>
+        type=Boolean
+        description=Include MANE Select annotations (if available)
+        default=0
+      </mane>
       <tsl>
         type=Boolean
         description=Include transcript support level (TSL) annotation


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

Switches on support for VEPs MANE flag

### Use case

Adds a flag showing the matching refseq transcript if the related transcript is MANE

### Benefits

Improves VEP functionality

### Possible Drawbacks

None - the VEP changes were in release/97, this is just switching REST on

### Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

Yes

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

Added the ability to identify MANE transcripts
