### PR TITLE
VEP option to return alleles in VCF format

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -49,6 +49,7 @@ has valid_user_params => (
     failed
     variant_class
     minimal
+    vcf_string
 
     everything
     appris

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -53,6 +53,11 @@
         description=Include a flag indicating the canonical transcript for a gene
         default=0
       </canonical>
+      <vcf_string>
+        type=Boolean
+        description=Include alleles in VCF format
+        default=0
+      </vcf_string>
       <protein>
         type=Boolean
         description=Include Ensembl protein identifiers
@@ -241,6 +246,11 @@
         description=Include a flag indicating the canonical transcript for a gene
         default=0
       </canonical>
+      <vcf_string>
+        type=Boolean
+        description=Include alleles in VCF format
+        default=0
+      </vcf_string>
       <protein>
         type=Boolean
         description=Include Ensembl protein identifiers
@@ -406,6 +416,11 @@
         description=Include a flag indicating the canonical transcript for a gene
         default=0
       </canonical>
+      <vcf_string>
+        type=Boolean
+        description=Include alleles in VCF format
+        default=0
+      </vcf_string>
       <protein>
         type=Boolean
         description=Include Ensembl protein identifiers
@@ -576,6 +591,11 @@
         description=Include a flag indicating the canonical transcript for a gene
         default=0
       </canonical>
+      <vcf_string>
+        type=Boolean
+        description=Include alleles in VCF format
+        default=0
+      </vcf_string>
       <protein>
         type=Boolean
         description=Include Ensembl protein identifiers
@@ -742,6 +762,11 @@
         description=Include a flag indicating the canonical transcript for a gene
         default=0
       </canonical>
+      <vcf_string>
+        type=Boolean
+        description=Include alleles in VCF format
+        default=0
+      </vcf_string>
       <protein>
         type=Boolean
         description=Include Ensembl protein identifiers
@@ -926,6 +951,11 @@
         description=Include a flag indicating the canonical transcript for a gene
         default=0
       </canonical>
+      <vcf_string>
+        type=Boolean
+        description=Include alleles in VCF format
+        default=0
+      </vcf_string>
       <protein>
         type=Boolean
         description=Include Ensembl protein identifiers


### PR DESCRIPTION
### Description

VEP has a new optional field to return the alleles in VCF format. 

### Use case

This new option allows to return the exact ref or alt alleles in case of an insertion or deletion. 

### Benefits

More output alleles info.

### Possible Drawbacks

None

### Testing

Run all tests and no regression detected. 

### Changelog

The default functionality is the same, there's only one more optional field in:
vep/species/hgvs
vep/species/id
vep/species/region
