### PR TITLE
Add transcript_version option for VEP endpoint - e99

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -50,6 +50,7 @@ has valid_user_params => (
     variant_class
     minimal
     vcf_string
+    transcript_version
 
     everything
     appris

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -38,6 +38,11 @@
         description=Include CCDS transcript identifiers
         default=0
       </ccds>
+      <transcript_version>
+        type=Boolean
+        description=Include version numbers to Ensembl transcript identifiers
+        default=0
+      </transcript_version>
       <numbers>
         type=Boolean
         description=Include affected exon and intron positions within the transcript
@@ -231,6 +236,11 @@
         description=Include CCDS transcript identifiers
         default=0
       </ccds>
+      <transcript_version>
+        type=Boolean
+        description=Include version numbers to Ensembl transcript identifiers
+        default=0
+      </transcript_version>
       <numbers>
         type=Boolean
         description=Include affected exon and intron positions within the transcript
@@ -401,6 +411,11 @@
         description=Include CCDS transcript identifiers
         default=0
       </ccds>
+      <transcript_version>
+        type=Boolean
+        description=Include version numbers to Ensembl transcript identifiers
+        default=0
+      </transcript_version>
       <numbers>
         type=Boolean
         description=Include affected exon and intron positions within the transcript
@@ -576,6 +591,11 @@
         description=Include CCDS transcript identifiers
         default=0
       </ccds>
+      <transcript_version>
+        type=Boolean
+        description=Include version numbers to Ensembl transcript identifiers
+        default=0
+      </transcript_version>
       <numbers>
         type=Boolean
         description=Include affected exon and intron positions within the transcript
@@ -747,6 +767,11 @@
         description=Include CCDS transcript identifiers
         default=0
       </ccds>
+      <transcript_version>
+        type=Boolean
+        description=Include version numbers to Ensembl transcript identifiers
+        default=0
+      </transcript_version>
       <numbers>
         type=Boolean
         description=Include affected exon and intron positions within the transcript
@@ -936,6 +961,11 @@
         description=Include CCDS transcript identifiers
         default=0
       </ccds>
+      <transcript_version>
+        type=Boolean
+        description=Include version numbers to Ensembl transcript identifiers
+        default=0
+      </transcript_version>
       <numbers>
         type=Boolean
         description=Include affected exon and intron positions within the transcript

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -40,7 +40,7 @@
       </ccds>
       <transcript_version>
         type=Boolean
-        description=Include version numbers to Ensembl transcript identifiers
+        description=Add version numbers to Ensembl transcript identifiers
         default=0
       </transcript_version>
       <numbers>
@@ -238,7 +238,7 @@
       </ccds>
       <transcript_version>
         type=Boolean
-        description=Include version numbers to Ensembl transcript identifiers
+        description=Add version numbers to Ensembl transcript identifiers
         default=0
       </transcript_version>
       <numbers>
@@ -413,7 +413,7 @@
       </ccds>
       <transcript_version>
         type=Boolean
-        description=Include version numbers to Ensembl transcript identifiers
+        description=Add version numbers to Ensembl transcript identifiers
         default=0
       </transcript_version>
       <numbers>
@@ -593,7 +593,7 @@
       </ccds>
       <transcript_version>
         type=Boolean
-        description=Include version numbers to Ensembl transcript identifiers
+        description=Add version numbers to Ensembl transcript identifiers
         default=0
       </transcript_version>
       <numbers>
@@ -769,7 +769,7 @@
       </ccds>
       <transcript_version>
         type=Boolean
-        description=Include version numbers to Ensembl transcript identifiers
+        description=Add version numbers to Ensembl transcript identifiers
         default=0
       </transcript_version>
       <numbers>
@@ -963,7 +963,7 @@
       </ccds>
       <transcript_version>
         type=Boolean
-        description=Include version numbers to Ensembl transcript identifiers
+        description=Add version numbers to Ensembl transcript identifiers
         default=0
       </transcript_version>
       <numbers>

--- a/t/vep.t
+++ b/t/vep.t
@@ -636,6 +636,12 @@ $json = json_GET($vep_hgvs_get,'GET Ambiguity flag with HGVS notation');
 eq_or_diff($json, $vep_output, 'VEP Ambiguity Flag GET');
 
 
+# test transcript version flag
+$vep_hgvs_get = '/vep/homo_sapiens/hgvs/6:g.1102327G>T?content-type=application/json&transcript_version=1';
+$json = json_GET($vep_hgvs_get,'GET consequences with transcript_version option');
+$vep_output->[0]->{transcript_consequences}->[0]->{transcript_id} = 'ENST00000314040.1';
+cmp_bag($json, $vep_output, 'VEP transcript version test');
+
 
 my $body = '{ "blurb" : "stink" }';
 # Test malformed messages

--- a/t/vep.t
+++ b/t/vep.t
@@ -639,6 +639,7 @@ eq_or_diff($json, $vep_output, 'VEP Ambiguity Flag GET');
 # test transcript version flag
 $vep_hgvs_get = '/vep/homo_sapiens/hgvs/6:g.1102327G>T?content-type=application/json&transcript_version=1';
 $json = json_GET($vep_hgvs_get,'GET consequences with transcript_version option');
+delete($vep_output->[0]->{ambiguity});
 $vep_output->[0]->{transcript_consequences}->[0]->{transcript_id} = 'ENST00000314040.1';
 cmp_bag($json, $vep_output, 'VEP transcript version test');
 


### PR DESCRIPTION
### Description

_Using one or more sentences, describe in detail the proposed changes._

Add option to display transcript_version for Ensembl transcripts in VEP endpoint results.

### Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

Current setup does not report the Ensembl transcript versions, this will still be the default. The new option will allow the transcript version to be reported by using this new option. 

### Benefits

_If applicable, describe the advantages the changes will have._

Improved traceability of VEP annotations on specific transcript versions.

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

None.

### Testing

_Have you added/modified unit tests to test the changes?_

Added new test and also tested on local server.

_If so, do the tests pass/fail?_

Test pass.

_Have you run the entire test suite and no regression was detected?_

Tested:
http://hx-noah-77-15:3000/documentation/info/vep_id_get
http://hx-noah-77-15:3000/vep/human/id/rs56116432?content-type=application/json;transcript_version=1

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

[/vep/:species/hgvs/] new option added: transcript_version
[/vep/:species/id/] new option added: transcript_version
[/vep/:species/region/] new option added: transcript_version