### PR TITLE
Fix for HDF5 issue

### DIFF
--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -151,6 +151,7 @@ sub _get_eqtl_adaptor {
         -filename        => $file,
         -core_db_adaptor => $core_a,
         -var_db_adaptor  => $var_a,
+        -read_only       => 1,
         );
 
       if(ref($eqtl_a) ne 'Bio::EnsEMBL::HDF5::EQTLAdaptor'){


### PR DESCRIPTION

### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

Perl does not propagate readonly through to HDF5, it has now explicitly been added to ensembl-hdf5.

### Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

### Benefits

_If applicable, describe the advantages the changes will have._

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

### Testing

Tested by the webteam

_If so, do the tests pass/fail?_

pass

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians
