### PR TITLE
Add docs for new functionality Loftee plugin option on VEP endpoint - e99

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -154,6 +154,11 @@
         description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
         default=0
       </miRNA>
+      <LoF>
+        type=Boolean
+        description=LOFTEE identifies LoF (loss-of-function) variation (<a target="_blank" href="https://raw.githubusercontent.com/konradjk/loftee/master/LoF.pm">plugin details</a>)
+        default=0
+      </LoF>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -347,6 +352,11 @@
         description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
         default=0
       </miRNA>
+      <LoF>
+        type=Boolean
+        description=LOFTEE identifies LoF (loss-of-function) variation (<a target="_blank" href="https://raw.githubusercontent.com/konradjk/loftee/master/LoF.pm">plugin details</a>)
+        default=0
+      </LoF>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -527,6 +537,11 @@
         description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
         default=0
       </miRNA>
+      <LoF>
+        type=Boolean
+        description=LOFTEE identifies LoF (loss-of-function) variation (<a target="_blank" href="https://raw.githubusercontent.com/konradjk/loftee/master/LoF.pm">plugin details</a>)
+        default=0
+      </LoF>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -702,6 +717,11 @@
         description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
         default=0
       </miRNA>
+      <LoF>
+        type=Boolean
+        description=LOFTEE identifies LoF (loss-of-function) variation (<a target="_blank" href="https://raw.githubusercontent.com/konradjk/loftee/master/LoF.pm">plugin details</a>)
+        default=0
+      </LoF>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -883,6 +903,11 @@
         description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
         default=0
       </miRNA>
+      <LoF>
+        type=Boolean
+        description=LOFTEE identifies LoF (loss-of-function) variation (<a target="_blank" href="https://raw.githubusercontent.com/konradjk/loftee/master/LoF.pm">plugin details</a>)
+        default=0
+      </LoF>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -1072,6 +1097,11 @@
         description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
         default=0
       </miRNA>
+      <LoF>
+        type=Boolean
+        description=LOFTEE identifies LoF (loss-of-function) variation (<a target="_blank" href="https://raw.githubusercontent.com/konradjk/loftee/master/LoF.pm">plugin details</a>)
+        default=0
+      </LoF>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -156,7 +156,7 @@
       </miRNA>
       <LoF>
         type=Boolean
-        description=LOFTEE identifies LoF (loss-of-function) variation (<a target="_blank" href="https://raw.githubusercontent.com/konradjk/loftee/master/LoF.pm">plugin details</a>)
+        description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
       <distance>
@@ -354,7 +354,7 @@
       </miRNA>
       <LoF>
         type=Boolean
-        description=LOFTEE identifies LoF (loss-of-function) variation (<a target="_blank" href="https://raw.githubusercontent.com/konradjk/loftee/master/LoF.pm">plugin details</a>)
+        description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
       <distance>
@@ -539,7 +539,7 @@
       </miRNA>
       <LoF>
         type=Boolean
-        description=LOFTEE identifies LoF (loss-of-function) variation (<a target="_blank" href="https://raw.githubusercontent.com/konradjk/loftee/master/LoF.pm">plugin details</a>)
+        description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
       <distance>
@@ -719,7 +719,7 @@
       </miRNA>
       <LoF>
         type=Boolean
-        description=LOFTEE identifies LoF (loss-of-function) variation (<a target="_blank" href="https://raw.githubusercontent.com/konradjk/loftee/master/LoF.pm">plugin details</a>)
+        description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
       <distance>
@@ -905,7 +905,7 @@
       </miRNA>
       <LoF>
         type=Boolean
-        description=LOFTEE identifies LoF (loss-of-function) variation (<a target="_blank" href="https://raw.githubusercontent.com/konradjk/loftee/master/LoF.pm">plugin details</a>)
+        description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
       <distance>
@@ -1099,7 +1099,7 @@
       </miRNA>
       <LoF>
         type=Boolean
-        description=LOFTEE identifies LoF (loss-of-function) variation (<a target="_blank" href="https://raw.githubusercontent.com/konradjk/loftee/master/LoF.pm">plugin details</a>)
+        description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
       <distance>


### PR DESCRIPTION
### Description

_Using one or more sentences, describe in detail the proposed changes._

Add documentation for the new optional LoF (LOFTEE) plugin in the VEP REST endpoint. The corresponding configuration update is PR Ensembl/ensembl-rest_private#63

### Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

Existing plugin functionality will now be available through REST, new LoF.
live: http://rest.ensembl.org/documentation/info/vep_id_get
proposed: http://hx-noah-01-02:3000/documentation/info/vep_id_get

### Benefits

_If applicable, describe the advantages the changes will have._

Without this documentation, the endpoint will not display the availability of the functionality in the background.

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

### Testing

_Have you added/modified unit tests to test the changes?_
No tests added. Local test server page and results checked manually.

_If so, do the tests pass/fail?_
Pass.

_Have you run the entire test suite and no regression was detected?_
No change to code. Test ran.

Tested for presence of ' "lof": "HC" ' : http://hx-noah-01-02:3000/vep/human/id/rs782135880?content-type=application/json;LoF=1

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

[/vep/:species/hgvs/] new plugin option added: LoF
[/vep/:species/id/] new plugin option added: LoF
[/vep/:species/region/] new plugin option added: LoF