### PR TITLE
Change the example regulation_id

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -155,7 +155,7 @@ jsonp=1
     cds_coordinates=1..1000
     translation_coordinates=100..300
 
-    regulation_id=ENSR00000006733
+    regulation_id=ENSR00000060894
 
     phenotype_region=9:22125500-22136000
 


### PR DESCRIPTION
### Description

_The endpoint at http://rest.ensembl.org/documentation/info/regulatory_id returns
{"error":"ENSR00000006733 not found for homo_sapiens"}_
_This PR is to change the example regulation_id to fix that_

### Use case

_No need to fix manually for future releases_

### Benefits

_Huge :D_

### Possible Drawbacks

_None_

### Testing
_The new regulation_id works on the test site at: http://test.rest.ensembl.org/documentation/info/regulatory_id_


