### PR TITLE
Bump documentation and REST API version to 11.2

### DIFF
--- a/lib/EnsEMBL/REST.pm
+++ b/lib/EnsEMBL/REST.pm
@@ -64,7 +64,7 @@ use Catalyst qw/
 /;
 
 
-our $VERSION = '11.1';
+our $VERSION = '11.2';
 
 # Configure the application.
 #


### PR DESCRIPTION
This is to merge the two version-bumping commits from _release/99_ into _master_.