### PR TITLE
Beacon/update

### DIFF
--- a/root/documentation/gabeacon.conf
+++ b/root/documentation/gabeacon.conf
@@ -36,14 +36,42 @@
   
       <start>
         type=Int
-        description=Precise start position, allele locus (0-based). Accepted values: non-negative integers smaller than reference length.
+        description=Precise start position, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: Do not use when querying for imprecise structural variants, use startMin and startMax instead.
         example=__VAR(GA4GH_beacon_start)__
         required=1
       </start>
-    
+   
+      <startMin>
+        type=Int
+        description=Minimum start coordinate, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: only required when using variantType to query imprecise structural variants.
+        example=__VAR(GA4GH_beacon_startmin)__
+        required=1
+      </startMin>
+ 
+      <startMax>
+        type=Int
+        description=Maximum start coordinate, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: only required when using variantType to query imprecise structural variants.
+        example=__VAR(GA4GH_beacon_startmax)__
+        required=1
+      </startMax>
+
+      <endMin>
+        type=Int
+        description=Minimum end coordinate, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: only required when using variantType to query imprecise structural variants.
+        example=__VAR(GA4GH_beacon_endmin)__
+        required=1
+      </endMin>
+
+      <endMax>
+        type=Int
+        description=Maximum end coordinate, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: only required when using variantType to query imprecise structural variants.
+        example=__VAR(GA4GH_beacon_endmax)__
+        required=1
+      </endMax>
+
       <end>
         type=Int
-        description=Precise end position, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: only required when using variantType.
+        description=Precise end position, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: only required when using variantType to query precise structural variants.
         example=__VAR(GA4GH_beacon_end)__
         required=1
       </end>
@@ -78,13 +106,13 @@
 
       <datasetIds>
         type=array of strings
-        description=Identifiers of datasets. Option not used currently as single dataset.
+        description=Identifiers of datasets. Identifiers have to be chosen from 'Short name' column in the Variant sets list (<a target="_blank" href="http://www.ensembl.org/info/genome/variation/species/sets.html">http://www.ensembl.org/info/genome/variation/species/sets.html</a>)
         required=0    
       </datasetIds>
   
       <includeDatasetResponses>
-        type=boolean
-        description=Indicator of whether responses for individual datasets should be included.
+        type=String
+        description=Indicator of whether responses for individual datasets should be included. Accepted values: ALL, HIT, MISS, NONE.
         default=NONE
         required=0    
       </includeDatasetResponses>
@@ -110,7 +138,7 @@
           referenceBases=__VAR(GA4GH_beacon_referenceBases)__
           alternateBases=__VAR(GA4GH_beacon_alternateBases)__
           assemblyId=__VAR(GA4GH_beacon_assemblyId)__
-          includeDatasetResponses=true
+          includeDatasetResponses=NONE
         </params>
         content=application/json
       </basicdsr>
@@ -134,14 +162,43 @@
   
       <start>
         type=Int
-        description=Precise start position, allele locus (0-based). Accepted values: non-negative integers smaller than reference length.
+        description=Precise start position, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: Do not use when querying for imprecise structural variants, use startMin
+ and startMax instead.
         example=__VAR(GA4GH_beacon_start)__
         required=1
       </start>
 
+      <startMin>
+        type=Int
+        description=Minimum start coordinate, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: only required when using variantType to query imprecise structural variants.
+        example=__VAR(GA4GH_beacon_startmin)__
+        required=1
+      </startMin>
+
+      <startMax>
+        type=Int
+        description=Maximum start coordinate, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: only required when using variantType to query imprecise structural variants.
+        example=__VAR(GA4GH_beacon_startmax)__
+        required=1
+      </startMax>
+
+      <endMin>
+        type=Int
+        description=Minimum end coordinate, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: only required when using variantType to query imprecise structural variants.
+        example=__VAR(GA4GH_beacon_endmin)__
+        required=1
+      </endMin>
+
+      <endMax>
+        type=Int
+        description=Maximum end coordinate, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: only required when using variantType to query imprecise structural variants.
+        example=__VAR(GA4GH_beacon_endmax)__
+        required=1
+      </endMax>
+
       <end>
         type=Int
-        description=Precise end position, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: only required when using variantType.
+        description=Precise end position, allele locus (0-based). Accepted values: non-negative integers smaller than reference length. Note: only required when using variantType to query precise structural variants.
         example=__VAR(GA4GH_beacon_end)__
         required=1
       </end>
@@ -176,13 +233,13 @@
 
       <datasetIds>
         type=array of strings
-        description=Identifiers of datasets. Option not used currently as single dataset.
+        description=Identifiers of datasets. Identifiers have to be chosen from 'Short name' column in the Variant sets list (<a target="_blank" href="http://www.ensembl.org/info/genome/variation/species/sets.html">http://www.ensembl.org/info/genome/variation/species/sets.html</a>)
         required=0    
       </datasetIds>
   
       <includeDatasetResponses>
-        type=boolean
-        description=Indicator of whether responses for individual datasets should be included.
+        type=String
+        description=Indicator of whether responses for individual datasets should be included. Accepted values: ALL, HIT, MISS, NONE.
         default=NONE
         required=0    
       </includeDatasetResponses>
@@ -201,7 +258,7 @@
         path=/ga4gh/beacon/query
         accept=application/json
         content=application/json
-        body={ "referenceName": "__VAR(GA4GH_beacon_referenceName)__", "start" : __VAR(GA4GH_beacon_start)__, "referenceBases": "__VAR(GA4GH_beacon_referenceBases)__", "alternateBases": "__VAR(GA4GH_beacon_alternateBases)__","assemblyId" : "__VAR(GA4GH_beacon_assemblyId)__","includeDatasetResponses": "true"  }
+        body={ "referenceName": "__VAR(GA4GH_beacon_referenceName)__", "start" : __VAR(GA4GH_beacon_start)__, "referenceBases": "__VAR(GA4GH_beacon_referenceBases)__", "alternateBases": "__VAR(GA4GH_beacon_alternateBases)__","assemblyId" : "__VAR(GA4GH_beacon_assemblyId)__","includeDatasetResponses": "NONE"  }
       </basicdsr>
     </examples>
   </beacon_query_post>

--- a/t/gabeacon.t
+++ b/t/gabeacon.t
@@ -44,7 +44,7 @@ my $q_base = $base . '/query';
 # For tests setting assembly to GRCh37 as that is the assembly
 # in the test database
 my $assemblyId = "GRCh37";
-my $beaconId = "ensembl";
+my $beaconId = "ensembl.grch37";
 my $datasetId = "Ensembl ". $schema_version;
 my $externalURL = "http://grch37.ensembl.org/Homo_sapiens/Variation/Explore?v="; 
 my $dataset_response;
@@ -60,7 +60,7 @@ cmp_ok($beacon_json->{id}, 'eq', $beaconId, 'Beacon id');
 cmp_ok($beacon_json->{version}, '==', $schema_version, 'Version');
 
 # Is there at least one dataset
-cmp_ok(scalar(@{$beacon_json->{'datasets'}}), '==', 1, 'Check have one dataset');
+cmp_ok(scalar(@{$beacon_json->{'datasets'}}), '==', 42, 'Check number of datasets');
 my $first_dataset = $beacon_json->{'datasets'}->[0];
 cmp_ok(keys(%{$first_dataset}), '==', 12, 'Check dataset has correct number of fields');
 
@@ -80,7 +80,6 @@ my $post_data1 = '{"referenceName": "7", "start" : 86442403, "referenceBases": "
 my $allele_request = {
   "referenceName" => "7",
   "start" => "86442403",
-  "end" => undef,
   "variantType" => undef,
   "referenceBases" => "T",
   "alternateBases" => "C",
@@ -99,23 +98,22 @@ my $expected_data1 = {
 $json = json_POST( $q_base , $post_data1, 'POST dataset - 1 entry' );
 eq_or_diff($json, $expected_data1, "GA4GH Beacon query - variant at location");
 
-# Found variant with includeDataSetResponses true
+# Found variant with includeDataSetResponses HIT
 my $post_data1_ds = '{"referenceName": "7", "start" : 86442403, "referenceBases": "T", "alternateBases": "C",' .
-                  '"assemblyId" : "' . $assemblyId . '", "includeDatasetResponses":"ALL"}'; 
+                  '"assemblyId" : "' . $assemblyId . '", "includeDatasetResponses" : "HIT", "datasetIds" : "hapmap_ceu,clin_assoc"}'; 
 
 $allele_request = {
   "referenceName" => "7",
   "start" => "86442403",
-  "end" => undef,
   "variantType" => undef,
   "referenceBases" => "T",
   "alternateBases" => "C",
   "assemblyId" => $assemblyId,
-  "datasetIds" => undef,
-  "includeDatasetResponses" => JSON::true };
+  "datasetIds" => 'hapmap_ceu,clin_assoc',
+  "includeDatasetResponses" => 'HIT' };
 
 $dataset_response = {
-   "datasetId" => $datasetId,
+   "datasetId" => 'hapmap_ceu',
    "exists" => JSON::true,
    "error" => undef,
    "frequency" => undef,
@@ -135,23 +133,98 @@ my $expected_data1_ds = {
   "datasetAlleleResponses" => [$dataset_response]
 };
 
-$json = json_POST( $q_base , $post_data1_ds, 'POST query 1 - dataset response true' );
+$json = json_POST( $q_base , $post_data1_ds, 'POST query 1 - dataset response HIT' );
 eq_or_diff($json, $expected_data1_ds, "GA4GH Beacon ds 1 - variant exists - dataset response");
 
-# Found variant with includeDataSetResponses false
+# Found variant with includeDataSetResponses MISS
+my $post_data3_ds = '{"referenceName": "7", "start" : 86442403, "referenceBases": "T", "alternateBases": "C",' .
+                  '"assemblyId" : "' . $assemblyId . '", "includeDatasetResponses" : "MISS", "datasetIds" : "hapmap_ceu,clin_assoc"}';
+
+my $allele_request_miss = {
+  "referenceName" => "7",
+  "start" => "86442403",
+  "variantType" => undef,
+  "referenceBases" => "T",
+  "alternateBases" => "C",
+  "assemblyId" => $assemblyId,
+  "datasetIds" => 'hapmap_ceu,clin_assoc',
+  "includeDatasetResponses" => 'MISS' };
+
+my $dataset_response_miss = {
+   "datasetId" => 'clin_assoc',
+   "exists" => JSON::false,
+   "error" => undef,
+   "frequency" => undef,
+   "variantCount" => undef,
+   "callCount" => undef,
+   "sampleCount" => undef,
+   "note" => undef,
+   "externalUrl" => undef,
+   "info" => undef
+};
+
+my $expected_data3_ds = {
+  "beaconId" => $beaconId,
+  "exists" => JSON::true,
+  "error" => undef,
+  "alleleRequest" => $allele_request_miss,
+  "datasetAlleleResponses" => [$dataset_response_miss]
+};
+
+$json = json_POST( $q_base , $post_data3_ds, 'POST query 3 - dataset response MISS' );
+eq_or_diff($json, $expected_data3_ds, "GA4GH Beacon ds 3 - variant exists - dataset response MISS");
+
+# Not found variant with dataset and includeDataSetResponses ALL
+my $post_data4_ds = '{"referenceName": "7", "start" : 86442403, "referenceBases": "T", "alternateBases": "C",' .
+                  '"assemblyId" : "' . $assemblyId . '", "includeDatasetResponses" : "ALL", "datasetIds" : "clin_assoc"}';
+
+my $allele_request_all = {
+  "referenceName" => "7",
+  "start" => "86442403",
+  "variantType" => undef,
+  "referenceBases" => "T",
+  "alternateBases" => "C",
+  "assemblyId" => $assemblyId,
+  "datasetIds" => 'clin_assoc',
+  "includeDatasetResponses" => 'ALL' };
+
+my $dataset_response_all = {
+   "datasetId" => 'clin_assoc',
+   "exists" => JSON::false,
+   "error" => undef,
+   "frequency" => undef,
+   "variantCount" => undef,
+   "callCount" => undef,
+   "sampleCount" => undef,
+   "note" => undef,
+   "externalUrl" => undef,
+   "info" => undef
+};
+
+my $expected_data4_ds = {
+  "beaconId" => $beaconId,
+  "exists" => JSON::false,
+  "error" => undef,
+  "alleleRequest" => $allele_request_all,
+  "datasetAlleleResponses" => [$dataset_response_all]
+};
+
+$json = json_POST( $q_base , $post_data4_ds, 'POST query 4 - dataset response ALL' );
+eq_or_diff($json, $expected_data4_ds, "GA4GH Beacon ds 4 - variant exists - dataset response ALL");
+
+# Found variant with includeDataSetResponses NONE
 $post_data1_ds = '{"referenceName": "7", "start" : 86442403, "referenceBases": "T", "alternateBases": "C",' .
                   '"assemblyId" : "' . $assemblyId . '", "includeDatasetResponses":"NONE"}'; 
 
 $allele_request = {
   "referenceName" => "7",
   "start" => "86442403",
-  "end" => undef,
   "variantType" => undef,
   "referenceBases" => "T",
   "alternateBases" => "C",
   "assemblyId" => $assemblyId,
   "datasetIds" => undef,
-  "includeDatasetResponses" => JSON::false
+  "includeDatasetResponses" => 'NONE'
 };
 
 my $expected_data1_ds_false = {
@@ -162,8 +235,8 @@ my $expected_data1_ds_false = {
   "datasetAlleleResponses" => undef
 };
 
-$json = json_POST( $q_base , $post_data1_ds, 'POST query 1 - dataset response false' );
-eq_or_diff($json, $expected_data1_ds_false, "GA4GH Beacon ds 1 - variant exists - no dataset response'");
+$json = json_POST( $q_base , $post_data1_ds, 'POST query 1 - dataset response NONE' );
+eq_or_diff($json, $expected_data1_ds_false, "GA4GH Beacon ds 1 - variant exists - no dataset response");
 
 # Found variant with includeDataSetResponse empty
 $post_data1_ds = '{"referenceName": "7", "start" : 86442403, "referenceBases": "T", "alternateBases": "C",' .
@@ -172,19 +245,20 @@ $post_data1_ds = '{"referenceName": "7", "start" : 86442403, "referenceBases": "
 $allele_request = {
   "referenceName" => "7",
   "start" => "86442403",
-  "end" => undef,
   "variantType" => undef,
   "referenceBases" => "T",
   "alternateBases" => "C",
   "assemblyId" => $assemblyId,
   "datasetIds" => undef,
-  "includeDatasetResponses" => undef
+  "includeDatasetResponses" => ""
 };
 
 my $expected_data1_ds_empty = {
   "beaconId" => $beaconId,
-  "exists" => JSON::true,
-  "error" => undef,
+  "exists" => undef,
+  "error" => { "errorCode" => 400,
+               "errorMessage" => "Invalid includeDatasetResponses"
+             },
   "alleleRequest" => $allele_request,
   "datasetAlleleResponses" => undef
 };
@@ -200,7 +274,6 @@ my $post_data2 = '{"referenceName": "7", "start" : 86442403, "referenceBases": "
 $allele_request = {
   "referenceName" => "7",
   "start" => "86442403",
-  "end" => undef,
   "variantType" => undef,
   "referenceBases" => "C",
   "alternateBases" => "T",
@@ -221,23 +294,22 @@ eq_or_diff($json, $expected_data2, "GA4GH Beacon query - variant at location - a
 
 
 # Test with includeDatasetResponses
-# Variant not found  with includeDataSetResponses true
+# Variant not found  with includeDataSetResponses ALL
 my $post_data2_ds = '{"referenceName": "7", "start" : 86442403, "referenceBases": "C", "alternateBases": "T",' .
-                  '"assemblyId" : "' . $assemblyId . '", "includeDatasetResponses":"ALL"}'; 
+                  '"assemblyId" : "' . $assemblyId . '", "includeDatasetResponses" : "ALL", "datasetIds" : "hapmap_jpt"}'; 
 
 $allele_request = {
   "referenceName" => "7",
   "start" => "86442403",
-  "end" => undef,
   "variantType" => undef,
   "referenceBases" => "C",
   "alternateBases" => "T",
   "assemblyId" => $assemblyId,
-  "datasetIds" => undef,
-  "includeDatasetResponses" => JSON::true };
+  "datasetIds" => 'hapmap_jpt',
+  "includeDatasetResponses" => 'ALL' };
 
 $dataset_response = {
-   "datasetId" => $datasetId,
+   "datasetId" => 'hapmap_jpt',
    "exists" => JSON::false,
    "error" => undef,
    "frequency" => undef,
@@ -254,10 +326,10 @@ my $expected_data2_ds = {
   "exists" => JSON::false,
   "error" => undef,
   "alleleRequest" => $allele_request,
-  "datasetAlleleResponses" => [$dataset_response]
+  "datasetAlleleResponses" => [$dataset_response],
 };
 
-$json = json_POST( $q_base , $post_data2_ds, 'POST query 2 - dataset response true' );
+$json = json_POST( $q_base , $post_data2_ds, 'POST query 2 - dataset response ALL' );
 eq_or_diff($json, $expected_data2_ds, "GA4GH Beacon ds 2 - variant not exists - dataset response");
 
 # Testing for a variant that does not exist at a given location
@@ -267,7 +339,6 @@ my $post_data3 = '{"referenceName": "7", "start" : 86442405, "referenceBases": "
 $allele_request = {
   "referenceName" => "7",
   "start" => "86442405",
-  "end" => undef,
   "variantType" => undef,
   "referenceBases" => "T",
   "alternateBases" => "C",
@@ -303,7 +374,6 @@ my $post_data4 = '{"referenceName": "7", "start" : 86442405, "referenceBases": "
 $allele_request = {
   "referenceName" => "7",
   "start" => "86442405",
-  "end" => undef,
   "referenceBases" => "T",
   "alternateBases" => "C",
   "variantType" => undef,
@@ -331,7 +401,6 @@ my $post_data5 = '{"referenceNamex": "7", "start" : 86442403, "referenceBases": 
 $allele_request = {
   "referenceName" => undef,
   "start" => "86442403",
-  "end" => undef,
   "referenceBases" => "T",
   "alternateBases" => "C",
   "variantType" => undef,
@@ -360,7 +429,6 @@ my $post_data6 = '{"referenceName": "7", "start" : 86442403, "variantType" : "SN
 $allele_request = {
   "referenceName" => "7",
   "start" => "86442403",
-  "end" => undef,
   "variantType" => "SNV",
   "referenceBases" => "T",
   "alternateBases" => "C",
@@ -382,13 +450,13 @@ $json = json_POST( $q_base , $post_data6, 'POST dataset - 6 invalid parameter' )
 eq_or_diff($json, $expected_data6, "GA4GH Beacon query - invalid parameter");
 
 # Testing CNV 
-my $post_data7 = '{"referenceName": "8", "start" : 7803890, "end" : 7823439, "variantType" : "CNV", "referenceBases": "N", ' .
+my $post_data7 = '{"referenceName": "8", "start" : 7803890, "end" : 7825339, "variantType" : "CNV", "referenceBases": "N", ' .
                    '"assemblyId" : "' . $assemblyId . '" }';
 
 $allele_request = {
   "referenceName" => "8",
   "start" => "7803890",
-  "end" => "7823439",
+  "end" => "7825339",
   "variantType" => "CNV",
   "referenceBases" => "N",
   "alternateBases" => undef,
@@ -407,6 +475,28 @@ my $expected_data7 = {
 $json = json_POST( $q_base , $post_data7, 'POST dataset - 7 structural variant' );
 eq_or_diff($json, $expected_data7, "GA4GH Beacon query - structural variant");
 
+$allele_request = {
+  "referenceName" => "8",
+  "start" => undef,
+  "startMin" => "7803800",
+  "startMax" => "7803900",
+  "endMin" => "7825300",
+  "endMax" => "7825400",
+  "variantType" => "CNV",
+  "referenceBases" => "N",
+  "alternateBases" => undef,
+  "assemblyId" => $assemblyId,
+  "datasetIds" => undef,
+  "includeDatasetResponses" => undef };
+
+my $expected_data8 = {
+  "beaconId" => $beaconId,
+  "exists" => JSON::true,
+  "error" => undef,
+  "alleleRequest" => $allele_request,
+  "datasetAlleleResponses" => undef
+};
+
 # GET checks
 # GET and POST return the same data
 # TODO - re-structure tests
@@ -415,7 +505,7 @@ my $get_content = 'content-type=application/json';
 my $get_base_uri = $q_base . '?' . $get_content;
 my $uri;
 
-# Check for missing paramters
+# Check for missing parameters
 $uri = $get_base_uri . ";referenceNamex=7;start=86442403;referenceBases=T;alternateBases=C;assemblyId=$assemblyId";
 $json = json_GET($uri, 'GET dataset 5 - missing parameter');
 eq_or_diff($json, $expected_data5, "GA4GH Beacon query - missing parameter");
@@ -427,9 +517,9 @@ $json = json_GET($uri_1, 'GET dataset - 1 entry');
 eq_or_diff($json, $expected_data1, "GA4GH Beacon query - variant at location");
 
 # Testing with an includeDataSetResponses
-my $uri_ds_1 = $get_base_uri . ";referenceName=7;start=86442403;referenceBases=T;alternateBases=C;assemblyId=$assemblyId;includeDatasetResponses=ALL";
+my $uri_ds_1 = $get_base_uri . ";referenceName=7;start=86442403;referenceBases=T;alternateBases=C;assemblyId=$assemblyId;includeDatasetResponses=HIT;datasetIds=hapmap_ceu,clin_assoc";
 $json = json_GET($uri_ds_1, 'GET dataset - 1 entry with dataset response');
-eq_or_diff($json, $expected_data1_ds, "GA4GH Beacon query - variant exists - dataset response");
+eq_or_diff($json, $expected_data1_ds, "GA4GH Beacon query - variant exists - dataset response HIT");
 
 # Testing for a variant that exists at a given location by alleles swapped
 my $uri_2 = $get_base_uri . ";referenceName=7;start=86442403;referenceBases=C;alternateBases=T;assemblyId=$assemblyId";
@@ -437,9 +527,14 @@ $json = json_GET($uri_2, 'GET dataset - 2 entry');
 eq_or_diff($json, $expected_data2, "GA4GH Beacon query - variant at location");
 
 # Testing with an includeDataSetResponses
-my $uri_ds_2 = $get_base_uri . ";referenceName=7;start=86442403;referenceBases=C;alternateBases=T;assemblyId=$assemblyId;includeDatasetResponses=ALL";
+my $uri_ds_2 = $get_base_uri . ";referenceName=7;start=86442403;referenceBases=C;alternateBases=T;assemblyId=$assemblyId;includeDatasetResponses=ALL;datasetIds=hapmap_jpt";
 $json = json_GET($uri_ds_2, 'GET dataset - 2 entry');
-eq_or_diff($json, $expected_data2_ds, "GA4GH Beacon query - no variant - dataset response");
+eq_or_diff($json, $expected_data2_ds, "GA4GH Beacon query - no variant - dataset response ALL");
+
+# Testing with an includeDataSetResponses
+my $uri_ds_3 = $get_base_uri . ";referenceName=7;start=86442403;referenceBases=T;alternateBases=C;assemblyId=$assemblyId;includeDatasetResponses=MISS;datasetIds=hapmap_ceu,clin_assoc";
+$json = json_GET($uri_ds_3, 'GET dataset - 3 entry');
+eq_or_diff($json, $expected_data3_ds, "GA4GH Beacon query - variant exists - dataset response MISS");
 
 # Testing for a variant that does not exist at a given location
 my $uri_3 = $get_base_uri . ";referenceName=7;start=86442405;referenceBases=T;alternateBases=C;assemblyId=$assemblyId";
@@ -456,8 +551,14 @@ my $uri_5 = $get_base_uri . ";referenceName=7;start=86442403;variantType=SNV;ref
 $json = json_GET($uri_5, 'GET dataset 6 - invalid parameter');
 eq_or_diff($json, $expected_data6, "GA4GH Beacon query - invalid parameter");
 
-my $uri_6 = $get_base_uri . ";referenceName=8;start=7803890;end=7823439;variantType=CNV;referenceBases=N;assemblyId=$assemblyId";
+# Testing structural variant with precise coordinates
+my $uri_6 = $get_base_uri . ";referenceName=8;start=7803890;end=7825339;variantType=CNV;referenceBases=N;assemblyId=$assemblyId";
 $json = json_GET($uri_6, 'GET dataset 7 - structural variant');
 eq_or_diff($json, $expected_data7, "GA4GH Beacon query - structural variant");
+
+# Testing structural variant with a range of coordinates
+my $uri_7 = $get_base_uri . ";referenceName=8;startMin=7803800;startMax=7803900;endMin=7825300;endMax=7825400;variantType=CNV;referenceBases=N;assemblyId=$assemblyId";
+$json = json_GET($uri_7, 'GET dataset 7 - structural variant range query');
+eq_or_diff($json, $expected_data8, "GA4GH Beacon query - structural variant range query");
 
 done_testing();


### PR DESCRIPTION
Duplicated #381 

Description
Update Beacon endpoint according to the specification: add support to imprecise structural variants (imprecise start and end locations) and an option to search variants in different datasets.

Use case
Beacon specification supports datasets, this update is necessary to support that functionality.

Benefits
More options to query variants.

Possible Drawbacks
The output of old queries is different, this may create a few problems for users.

Testing
Updated old tests according to the new output.
Added new tests to make sure new options are available.
Run all tests and no regression detected.

Changelog
Old queries still work however their outputs have some differences.
New input options to search for variants. The new options affect:
ga4gh/beacon (only output affected)
ga4gh/beacon/query