### PR TITLE
Patch variation_citation table 99 

### DIFF
--- a/t/test-genome-DBs/homo_sapiens/variation/meta.txt
+++ b/t/test-genome-DBs/homo_sapiens/variation/meta.txt
@@ -118,3 +118,4 @@
 118	\N	patch	patch_98_99_b.sql|Add the column data_source_attrib in the table variation_citation
 119	\N	patch	patch_98_99_c.sql|Increase the size of the title and doi columns in the publication table
 120	\N	patch	patch_98_99_d.sql|add key data_source_attrib
+121	\N	patch	patch_98_99_e.sql|Fix attrib ids in table variation_citation

--- a/t/test-genome-DBs/homo_sapiens/variation/table.sql
+++ b/t/test-genome-DBs/homo_sapiens/variation/table.sql
@@ -608,7 +608,7 @@ CREATE TABLE `variation_attrib` (
 CREATE TABLE `variation_citation` (
   `variation_id` int(10) unsigned NOT NULL,
   `publication_id` int(10) unsigned NOT NULL,
-  `data_source_attrib` set('610','611','612') DEFAULT NULL,
+  `data_source_attrib` set('615','616','617') DEFAULT NULL,
   PRIMARY KEY (`variation_id`,`publication_id`),
   KEY `data_source_attrib_idx` (`data_source_attrib`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;


### PR DESCRIPTION
### Description

Patch variation_citation table. 

### Use case

The attrib ids used in table.sql are wrong. They have to be fixed for the right values. 

### Benefits

attrib_ids in variation_citation match attrib_id in attrib table

### Possible Drawbacks

None 

### Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
Yes, no regression detected.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._
No 
