### PR TITLE
Add option to include SO consequence ranking

### DIFF
--- a/lib/EnsEMBL/REST/Controller/Info.pm
+++ b/lib/EnsEMBL/REST/Controller/Info.pm
@@ -320,8 +320,11 @@ sub consequence_types: Path('variation/consequence_types') Args(0) ActionClass('
 sub consequence_types_GET {
   my ($self, $c) = @_;
   my $consequence_types;
+
+  my $rank = $c->request->param('rank');
+
   try {
-    $consequence_types = $c->model('Variation')->fetch_consequence_types();
+    $consequence_types = $c->model('Variation')->fetch_consequence_types($rank);
   } catch {
     $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;
     $c->go('ReturnError', 'custom', [qq{$_}]);

--- a/lib/EnsEMBL/REST/Model/Variation.pm
+++ b/lib/EnsEMBL/REST/Model/Variation.pm
@@ -465,20 +465,33 @@ sub fetch_population_infos {
 }
 
 sub fetch_consequence_types {
-  my ($self) = @_;
+  my ($self, $rank) = @_;
 
   my @consequence_types = ();
 
   my $oc;
   foreach my $key(keys %OVERLAP_CONSEQUENCES) {
     $oc = $OVERLAP_CONSEQUENCES{$key};
-    push @consequence_types,
+
+    if (defined $rank && $rank == 1) {
+        push @consequence_types,
+          {
+            SO_term => $oc->SO_term,
+            SO_accession => $oc->SO_accession,
+            label => $oc->label,
+            description =>  $oc->description,
+            consequence_ranking => $oc->rank
+          }
+    }
+    else {
+      push @consequence_types,
         {
           SO_term => $oc->SO_term,
           SO_accession => $oc->SO_accession,
           label => $oc->label,
           description =>  $oc->description
         }
+    }
  }
   return \@consequence_types;
 }

--- a/lib/EnsEMBL/REST/Model/Variation.pm
+++ b/lib/EnsEMBL/REST/Model/Variation.pm
@@ -473,25 +473,18 @@ sub fetch_consequence_types {
   foreach my $key(keys %OVERLAP_CONSEQUENCES) {
     $oc = $OVERLAP_CONSEQUENCES{$key};
 
-    if (defined $rank && $rank == 1) {
-        push @consequence_types,
-          {
-            SO_term => $oc->SO_term,
-            SO_accession => $oc->SO_accession,
-            label => $oc->label,
-            description =>  $oc->description,
-            consequence_ranking => $oc->rank
-          }
+    my $so_hash = {
+      SO_term => $oc->SO_term,
+      SO_accession => $oc->SO_accession,
+      label => $oc->label,
+      description => $oc->description
+    };
+
+    if ($rank) {
+      $so_hash->{'consequence_ranking'} = $oc->rank;
     }
-    else {
-      push @consequence_types,
-        {
-          SO_term => $oc->SO_term,
-          SO_accession => $oc->SO_accession,
-          label => $oc->label,
-          description =>  $oc->description
-        }
-    }
+
+    push @consequence_types, $so_hash;
  }
   return \@consequence_types;
 }

--- a/root/documentation/info.conf
+++ b/root/documentation/info.conf
@@ -470,6 +470,14 @@
     group=Information
     output=json
     output=xml
+    <params>
+      <rank>
+        type=Boolean(0,1)
+        description=Include consequence ranking
+        required=0
+        default=0
+      </rank>
+    </params>
     <examples>
       <one>
         path=/info/variation/consequence_types

--- a/t/info.t
+++ b/t/info.t
@@ -378,6 +378,18 @@ is_json_GET(
                        )
                      } @$consequence_types_json;
   cmp_ok(scalar(@matched), '==', 1, "Get match for known consequence type");
+
+  my $consequence_types_rank_json = json_GET('/info/variation/consequence_types?rank=1', 'Get the consequence_types with consequence ranking hash');
+  my $so_term = 'feature_truncation';
+  my $rank = '37';
+  my @matched_rank = grep {
+                       (
+                         ($_->{SO_term} eq $so_term)
+                         &&
+                         ($_->{consequence_ranking} eq $rank)
+                       )
+                     } @$consequence_types_rank_json;
+  cmp_ok(scalar(@matched_rank), '==', 1, "Get match for known consequence type with consequence ranking");
 }
 
 done_testing();


### PR DESCRIPTION
### Description

Add an option to include the consequence ranking for the sequence ontology terms. 

### Use case

There was a request to add the consequence rank for the SO terms. 

### Benefits

One more option to get more info from the consequence terms. 

### Possible Drawbacks

None. This change doesn't affect old queries. 

### Testing

_Have you added/modified unit tests to test the changes?_
Yes

_If so, do the tests pass/fail?_
The tests pass. 

_Have you run the entire test suite and no regression was detected?_
No regression detected. 

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._
No, the functionality is the same there's only one more option. 
/info/variation/consequence_types

