### PR TITLE
Compara endpoint update for grch37

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -151,9 +151,16 @@ jsonp=1
     ontology_term_id=GO:0005667
     ontology_term_name=transcription factor complex
     
-    compara=multi
+    compara=vertebrates
     compara_method=EPO
     compara_method_type=GenomicAlign
+    compara_hom_format=full
+    compara_hom_type=all
+    compara_aligned=1
+    compara_sequence=protein
+    compara_cigar_line=1
+    compara_species_set_group=mammals
+    compara_compact=1
     
     genetree_stable_id=ENSGT00390000003602
     compara_gene_stable_id=ENSG00000173786

--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -354,6 +354,18 @@ jsonp=1
    vcf_config = __path_to(vcf_config.json)__
 </Model::Variation>
 
+<Model::Compara>
+  species_set_group = mammals
+  method            = EPO
+  no_branch_lengths = 0
+  compact           = 1
+  aligned           = 1
+  cigar_line        = 1
+  format            = full
+  sequence          = protein
+  type              = all
+</Model::Compara>
+
 <Model::LDFeatureContainer>
    use_vcf = 1
    vcf_config = __path_to(vcf_config.json)__

--- a/ensembl_rest_testing.conf
+++ b/ensembl_rest_testing.conf
@@ -50,10 +50,18 @@ jsonp=1
     target_taxon=10090
     target_species=bos_taurus
     
-    compara=multi
+    compara=vertebrates
     compara_method=EPO
     compara_method_type=GenomicAlign
-    
+    compara_hom_format=full
+    compara_hom_type=all
+    compara_aligned=1
+    compara_sequence=protein
+    compara_cigar_line=1
+    compara_species_set_group=mammals
+    compara_compact=1
+    compara_gene_stable_id=ENSG00000173786
+
     genetree_stable_id=???
     
     from_coord_system=GRCh37
@@ -134,6 +142,18 @@ jsonp=1
   vcf_config = __path_to(t/test-genome-DBs/testdata/haplotypes_vcf_config.json)__
   dir = __path_to(t/test-genome-DBs/testdata/)__
 </Model::Variation>
+
+<Model::Compara>
+  species_set_group = mammals
+  method            = EPO
+  no_branch_lengths = 0
+  compact           = 1
+  aligned           = 1
+  cigar_line        = 1
+  format            = full
+  sequence          = protein
+  type              = all
+</Model::Compara>
 
 <Model::LDFeatureContainer>
   use_vcf = 1

--- a/lib/EnsEMBL/REST/Controller/GenomicAlignment.pm
+++ b/lib/EnsEMBL/REST/Controller/GenomicAlignment.pm
@@ -102,14 +102,15 @@ sub region : Chained("get_species") PathPart("") Args(1) ActionClass('REST') {
       $c->go('ReturnError', 'custom', [qq{$_}]);
     };
 
-    #Set aligned option (default 1)
-    $c->stash->{"aligned"} = (defined $c->request()->param('aligned')) ? $c->request()->param('aligned') : 1; 
+    #Set aligned option (default from config)
+    my $compara_defaults = $c->config->{'Model::Compara'};
+    $c->stash->{"aligned"} = (defined $c->request()->param('aligned')) ? $c->request()->param('aligned') : $compara_defaults->{aligned}; 
 
-    #Set compact option (default 1)
-    $c->stash->{"compact"} = (defined $c->request->param('compact')) ? $c->request->param('compact') : 1;
+    #Set compact option (default from config)
+    $c->stash->{"compact"} = (defined $c->request->param('compact')) ? $c->request->param('compact') : $compara_defaults->{compact};
 
     #Set no branch lengths option (default 0, ie display branch lengths)
-    $c->stash->{"no_branch_lengths"} = (defined $c->request->param('no_branch_lengths')) ? $c->request->param('no_branch_lengths') : 0;
+    $c->stash->{"no_branch_lengths"} = (defined $c->request->param('no_branch_lengths')) ? $c->request->param('no_branch_lengths') : $compara_defaults->{no_branch_lengths};
 
     #Never give branch lengths for pairwise, even if requested
     $c->go("ReturnError", "custom", ["no alignment available for this region"]) if !$alignments;

--- a/lib/EnsEMBL/REST/Controller/Homology.pm
+++ b/lib/EnsEMBL/REST/Controller/Homology.pm
@@ -125,13 +125,16 @@ sub get_orthologs : Args(0) ActionClass('REST') {
   #Get the compara DBAdaptor
   $c->forward('get_adaptors');
   
+  # get defaults from config
+  my $compara_defaults = $c->config->{'Model::Compara'};
+
   # Sort out the encoder
-  my $format = $c->request->param('format') || 'full';
+  my $format = $c->request->param('format') || $compara_defaults->{format};
   my $target = $FORMAT_LOOKUP->{$format};
   $c->go('ReturnError', 'custom', [qq{The format '$format' is not an understood encoding}]) unless $target;
   
   #Sort out the type of response
-  my $user_type = $c->request->param('type') || 'all';
+  my $user_type = $c->request->param('type') || $compara_defaults->{type};
   my $method_link_type= $TYPE_TO_COMPARA_TYPE->{lc($user_type)};
   $c->go('ReturnError', 'custom', [qq{The type '$user_type' is not a known available type}]) unless defined $method_link_type;
   $c->stash(method_link_type => $method_link_type);
@@ -179,13 +182,16 @@ sub get_orthologs : Args(0) ActionClass('REST') {
 sub get_orthologs_GET {
   my ( $self, $c ) = @_;
 
+  # get defaults from config
+  my $compara_defaults = $c->config->{'Model::Compara'};
+
   if($self->is_content_type($c, $CONTENT_TYPE_REGEX)) {
-    my $format          = $c->request->param('format') || 'full';
-    my $sequence_param  = $c->request->param('sequence') || 'protein';
+    my $format          = $c->request->param('format') || $compara_defaults->{format};
+    my $sequence_param  = $c->request->param('sequence') || $compara_defaults->{sequence};
     my $seq_type        = $sequence_param eq 'protein' ? undef : 'cds';
     my $no_seq          = $sequence_param eq 'none' ? 1 : 0;
-    my $aligned         = $c->request->param('aligned') // 1;
-    my $cigar_line      = $c->request->param('cigar_line') // 1;
+    my $aligned         = $c->request->param('aligned') // $compara_defaults->{aligned};
+    my $cigar_line      = $c->request->param('cigar_line') // $compara_defaults->{cigar_line};
 
     try {
       foreach my $ref (@{$c->stash->{homology_data}}) {

--- a/lib/EnsEMBL/REST/Model/GenomicAlignment.pm
+++ b/lib/EnsEMBL/REST/Model/GenomicAlignment.pm
@@ -59,6 +59,7 @@ sub get_alignment {
   #set default species_set_group only if species_set hasn't been set
   unless ($species_set || $species_set_group) {
     $species_set_group = $compara_defaults->{species_set_group};
+    $species_set = $compara_defaults->{species_set} unless $species_set_group;
   }
 
   #Check that both $species_set and $species_set_group have not been set

--- a/lib/EnsEMBL/REST/Model/GenomicAlignment.pm
+++ b/lib/EnsEMBL/REST/Model/GenomicAlignment.pm
@@ -47,6 +47,9 @@ sub get_alignment {
   my $c = $self->context();
   my $alignments;
 
+  # set defaults as per config file
+  my $compara_defaults = $c->config->{'Model::Compara'};
+
   #Get species_set
   my $species_set = $c->request->parameters->{species_set};
 
@@ -55,7 +58,7 @@ sub get_alignment {
 
   #set default species_set_group only if species_set hasn't been set
   unless ($species_set || $species_set_group) {
-    $species_set_group = 'mammals';
+    $species_set_group = $compara_defaults->{species_set_group};
   }
 
   #Check that both $species_set and $species_set_group have not been set
@@ -73,7 +76,7 @@ sub get_alignment {
   $c->forward('get_adaptors');
 
   #Get method
-  my $method_type = $c->request->parameters->{method} || 'EPO';
+  my $method_type = $c->request->parameters->{method} || $compara_defaults->{method};
   my $method = $c->stash->{method_adaptor}->fetch_by_type($method_type);
   Catalyst::Exception->throw("The method '$method_type' is not understood by this service") unless $method;
   my $method_is_alignment = $method->class =~ /^GenomicAlign/;

--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -35,12 +35,12 @@
       <format>
         type=Enum(full,condensed)
         description=Layout of the response
-        default=full
+        default=__VAR(compara_hom_format)__
       </format>
       <type>
         type=Enum(orthologues, paralogues, projections, all)
         description=The type of homology to return from this call. Projections are orthology calls defined between alternative assemblies and the genes shared between them. Useful if you need only one type of homology back from the service
-        default=all
+        default=__VAR(compara_hom_type)__
       </type>
       <target_species>
         type=String
@@ -57,17 +57,17 @@
       <aligned>
         type=Boolean
         description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
-        default=1
+        default=__VAR(compara_aligned)__
       </aligned>
       <sequence>
         type=Enum(none, cdna, protein)
         description=The type of sequence to bring back. Setting it to none results in no sequence being returned
-        default=protein
+        default=__VAR(compara_sequence)__
       </sequence>
       <cigar_line>
         type=Boolean
         description=Return the aligned sequence encoded in CIGAR format
-        default=1
+        default=__VAR(compara_cigar_line)__
       </cigar_line>
     </params>
     <examples>
@@ -143,12 +143,12 @@
       <format>
         type=Enum(full, condensed)
         description=Layout of the response
-        default=full
+        default=__VAR(compara_hom_format)__
       </format>
       <type>
         type=Enum(orthologues, paralogues, projections, all)
         description=The type of homology to return from this call. Projections are orthology calls defined between alternative assemblies and the genes shared between them. Useful if you need only one type of homology back from the service
-        default=all
+        default=__VAR(compara_hom_type)__
       </type>
       <target_species>
         type=String
@@ -165,17 +165,17 @@
       <aligned>
         type=Boolean
         description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
-        default=1
+        default=__VAR(compara_aligned)__
       </aligned>
       <sequence>
         type=Enum(none, cdna, protein)
         description=The type of sequence to bring back. Setting it to none results in no sequence being returned
-        default=protein
+        default=__VAR(compara_sequence)__
       </sequence>
       <cigar_line>
         type=Boolean
         description=Return the aligned sequence encoded in CIGAR format
-        default=1
+        default=__VAR(compara_cigar_line)__
       </cigar_line>
     </params>
     <examples>
@@ -509,7 +509,7 @@
         example=core
       </db_type>
       <object_type>
-        type=String
+	type=String
         description=Filter by feature type
         example=gene
         example=transcript
@@ -714,7 +714,7 @@
       <aligned>
         type=Boolean
 	description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
-	default=1
+	default=__VAR(compara_aligned)__
       </aligned>
       <mask>
         type=Enum(hard,soft)
@@ -724,7 +724,7 @@
       <species_set_group>
         type=String
         description=The species set group name of the multiple alignment. Should not be used with the species_set parameter. Use <a href="/documentation/info/compara_species_sets">/info/compara/species_sets/:method</a> with one of the methods listed above to obtain a valid list of group names.
-        default=mammals
+        default=__VAR(compara_species_set_group)__
 	example=mammals, amniotes, fish, sauropsids, murinae
       </species_set_group>
       <species_set>
@@ -736,7 +736,7 @@
       <method>
         type=Enum(EPO, EPO_LOW_COVERAGE, PECAN, LASTZ_NET, BLASTZ_NET, TRANSLATED_BLAT_NET, CACTUS_HAL, CACTUS_HAL_PW)
 	description=The alignment method
-	default=EPO
+	default=__VAR(compara_method)__
 	example=PECAN
       </method>
       <display_species_set>
@@ -749,7 +749,7 @@
       <compact>
         type=Boolean
 	description= Applicable to EPO_LOW_COVERAGE alignments. If true, concatenate the low coverage species sequences together to create a single sequence. Otherwise, separates out all sequences.
-	default=1
+	default=__VAR(compara_compact)__
       </compact>
     </params>
     <examples>

--- a/root/documentation/compara_grch37.conf
+++ b/root/documentation/compara_grch37.conf
@@ -21,12 +21,6 @@
         example=__VAR(gene_symbol_compara37)__
         required=1
       </symbol>
-      <compara>
-        type=String
-        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
-        default=vertebrates
-        example=vertebrates
-      </compara>
       <external_db>
         type=String
         description=Filter by external database
@@ -35,39 +29,27 @@
       <format>
         type=Enum(full,condensed)
         description=Layout of the response
-        default=full
+        default=__VAR(compara_hom_format)__
       </format>
       <type>
-        type=Enum(orthologues, paralogues, projections, all)
+        type=Enum(paralogues, projections, all)
         description=The type of homology to return from this call. Projections are orthology calls defined between alternative assemblies and the genes shared between them. Useful if you need only one type of homology back from the service
-        default=all
+        default=__VAR(compara_hom_type)__
       </type>
-      <target_species>
-        type=String
-        description=Filter by species. Supports all species aliases
-        example=__VAR(species)__
-        example=__VAR(species_common)__
-      </target_species>
-      <target_taxon>
-        type=Integer
-        description=Filter by taxon
-        example=__VAR(taxon)__
-        example=__VAR(target_taxon)__
-      </target_taxon>
       <aligned>
         type=Boolean
         description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
-        default=1
+        default=__VAR(compara_aligned)__
       </aligned>
       <sequence>
         type=Enum(none, cdna, protein)
         description=The type of sequence to bring back. Setting it to none results in no sequence being returned
-        default=protein
+        default=__VAR(compara_sequence)__
       </sequence>
       <cigar_line>
         type=Boolean
         description=Return the aligned sequence encoded in CIGAR format
-        default=1
+        default=__VAR(compara_cigar_line)__
       </cigar_line>
     </params>
     <examples>
@@ -89,7 +71,7 @@
         capture=__VAR(gene_symbol_compara37)__
         content=text/xml
         <params>
-          type=orthologues
+          type=projections
           format=condensed
         </params>
       </format_xml>
@@ -99,10 +81,8 @@
         capture=__VAR(gene_symbol_compara37)__
         content=application/json
         <params>
-          type=orthologues
+          type=projections
           format=condensed
-          target_taxon=__VAR(target_taxon)__
-          target_species=__VAR(target_species)__
         </params>
       </format_limits>
       <format_limits_cdna>
@@ -111,9 +91,7 @@
         capture=__VAR(gene_symbol_compara37)__
         content=application/json
         <params>
-          type=orthologues
-          target_taxon=__VAR(target_taxon)__
-          target_species=__VAR(target_species)__
+          type=projections
           sequence=cdna
         </params>
       </format_limits_cdna>
@@ -134,95 +112,71 @@
         example=__VAR(compara_gene_stable_id)__
         required=1
       </id>
-      <compara>
-        type=String
-        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
-        default=vertebrates
-        example=vertebrates
-      </compara>
       <format>
         type=Enum(full, condensed)
         description=Layout of the response
-        default=full
+        default=__VAR(compara_hom_format)__
       </format>
       <type>
-        type=Enum(orthologues, paralogues, projections, all)
+        type=Enum(paralogues, projections, all)
         description=The type of homology to return from this call. Projections are orthology calls defined between alternative assemblies and the genes shared between them. Useful if you need only one type of homology back from the service
-        default=all
+        default=__VAR(compara_hom_type)__
       </type>
-      <target_species>
-        type=String
-        description=Filter by species. Supports all species aliases
-        example=__VAR(species_common)__
-        example=__VAR(target_species)__
-      </target_species>
-      <target_taxon>
-        type=Integer
-        description=Filter by taxon
-        example=__VAR(taxon)__
-        example=__VAR(target_taxon)__
-      </target_taxon>
       <aligned>
         type=Boolean
         description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
-        default=1
+        default=__VAR(compara_aligned)__
       </aligned>
       <sequence>
         type=Enum(none, cdna, protein)
         description=The type of sequence to bring back. Setting it to none results in no sequence being returned
-        default=protein
+        default=__VAR(compara_sequence)__
       </sequence>
       <cigar_line>
         type=Boolean
         description=Return the aligned sequence encoded in CIGAR format
-        default=1
+        default=__VAR(compara_cigar_line)__
       </cigar_line>
     </params>
     <examples>
       <basic>
         path=/homology/id/
-        capture=__VAR(compara_gene_stable_id)__
+        capture=__VAR(gene_stable_id_compara37)__
         content=application/json
       </basic>
       <orthoxml>
         path=/homology/id/
-        capture=__VAR(compara_gene_stable_id)__
+        capture=__VAR(gene_stable_id_compara37)__
         content=text/x-orthoxml+xml
       </orthoxml>
       <compara_xml>
         path=/homology/id/
-        capture=__VAR(compara_gene_stable_id)__
-        <params>
-          compara=__VAR(compara)__
-        </params>
+        capture=__VAR(gene_stable_id_compara37)__
         content=text/xml
       </compara_xml>
       <format_xml>
         path=/homology/id/
-        capture=__VAR(compara_gene_stable_id)__
+        capture=__VAR(gene_stable_id_compara37)__
         content=text/xml
         <params>
-          type=orthologues
+          type=projections
           format=condensed
         </params>
       </format_xml>
       <orthoxml_limits>
         path=/homology/id/
-        capture=__VAR(compara_gene_stable_id)__
+        capture=__VAR(gene_stable_id_compara37)__
         content=text/x-orthoxml+xml
         <params>
-          type=orthologues
-          target_taxon=__VAR(target_taxon)__
+          type=projections
         </params>
       </orthoxml_limits>
       <format_limits_cdna>
         path=/homology/id/
-        capture=__VAR(compara_gene_stable_id)__
+        capture=__VAR(gene_stable_id_compara37)__
         content=application/json
         <params>
-          type=orthologues
-          target_taxon=__VAR(target_taxon)__
-          target_species=__VAR(target_species)__
+          type=projections
           sequence=cdna
         </params>
       </format_limits_cdna>
@@ -252,52 +206,22 @@
         example=__VAR(species_common)__
         required=1
       </species>
-      <compara>
-        type=String
-        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
-        default=vertebrates
-        example=vertebrates
-      </compara>
       <aligned>
         type=Boolean
 	description=Return the aligned string if true. Otherwise, return the original sequence (no insertions)
-	default=1
+	default=__VAR(compara_aligned)__
       </aligned>
       <mask>
         type=Enum(hard,soft)
         description=Request the sequence masked for repeat sequences. Hard will mask all repeats as N's and soft will mask repeats as lowercased characters. 
         example=hard
       </mask> 
-      <species_set_group>
-        type=String
-        description=The species set group name of the multiple alignment. Should not be used with the species_set parameter. Use <a href="/documentation/info/compara_species_sets">/info/compara/species_sets/:method</a> with one of the methods listed above to obtain a valid list of group names.
-        default=mammals
-	example=mammals, amniotes, fish, sauropsids, murinae
-      </species_set_group>
-      <species_set>
-        type=String
-	description=The set of species used to define the pairwise alignment (multiple values). Should not be used with the species_set_group parameter. Use <a href="/documentation/info/compara_species_sets">/info/compara/species_sets/:method</a> with one of the methods listed above to obtain a valid list of species sets. Any valid alias may be used.
-	example=homo_sapiens
-	example=mus_musculus
-      </species_set>
       <method>
-        type=Enum(EPO, EPO_LOW_COVERAGE, PECAN, LASTZ_NET, BLASTZ_NET, TRANSLATED_BLAT_NET, CACTUS_HAL, CACTUS_HAL_PW)
+        type=Enum(LASTZ_PATCH, LASTZ_NET)
 	description=The alignment method
-	default=EPO
-	example=PECAN
+	default=__VAR(compara_method)__
+	example=LASTZ_PATCH
       </method>
-      <display_species_set>
-        type=String
-        description= Subset of species in the alignment to be displayed (multiple values). All the species in the alignment will be displayed if this is not set. Any valid alias may be used.
-	example=human
-	example=chimp
-	example=gorilla
-      </display_species_set>
-      <compact>
-        type=Boolean
-	description= Applicable to EPO_LOW_COVERAGE alignments. If true, concatenate the low coverage species sequences together to create a single sequence. Otherwise, separates out all sequences.
-	default=1
-      </compact>
     </params>
     <examples>
       <basic>
@@ -305,28 +229,20 @@
         capture=__VAR(genomic_alignment_species)__
         capture=__VAR(genomic_alignment_region)__
         content=application/json
-	<params>
-	  species_set_group=__VAR(genomic_alignment_group)__
-        </params>
       </basic>
       <basic_xml>
         path=/alignment/region/
         capture=__VAR(genomic_alignment_species)__
         capture=__VAR(genomic_alignment_region)__
         content=text/x-phyloxml
-	<params>
-	  species_set_group=__VAR(genomic_alignment_group)__
-        </params>
       </basic_xml>
       <json>
         path=/alignment/region/
         capture=__VAR(genomic_alignment_species)__
         capture=__VAR(genomic_alignment_pw_region)__
         content=application/json
-  <params>
-    method=__VAR(genomic_alignment_pw_method)__
-    species_set=__VAR(genomic_alignment_species)__
-    species_set=__VAR(genomic_alignment_species2)__
+  	<params>
+    	    method=__VAR(genomic_alignment_pw_method)__
         </params>
       </json>
     </examples>


### PR DESCRIPTION
### Description

Updated compara endpoints to support removal of many species and analyses from GRCh37 REST service. This includes moving default values to the conf file (instead of hardcoding in the endpoint) and updating documentation & examples for GRCh37 purposes