### PR TITLE
Variation100/mv ancestral allele to mappings

### DIFF
--- a/lib/EnsEMBL/REST/Model/Variation.pm
+++ b/lib/EnsEMBL/REST/Model/Variation.pm
@@ -150,7 +150,6 @@ sub to_hash {
   $variation_hash->{ambiguity} = $variation->ambig_code;
   $variation_hash->{synonyms} = $variation->get_all_synonyms;
   $variation_hash->{failed} = $variation->failed_description if $variation->is_failed;
-  $variation_hash->{ancestral_allele} = $variation->ancestral_allele;
   $variation_hash->{var_class} = $variation->var_class;
   $variation_hash->{most_severe_consequence} = $variation->display_consequence;
   $variation_hash->{MAF} = $variation->minor_allele_frequency;
@@ -190,6 +189,7 @@ sub vf_as_hash {
   $variation_feature->{coord_system} = $vf->coord_system_name;
   $variation_feature->{assembly_name} = $vf->slice->coord_system->version;
   $variation_feature->{allele_string} = $vf->allele_string;
+  $variation_feature->{ancestral_allele} = $vf->ancestral_allele;
 
   return $variation_feature;
 }

--- a/t/variation.t
+++ b/t/variation.t
@@ -42,7 +42,7 @@ my $base = '/variation/homo_sapiens';
   my $id = 'rs142276873';
   my $json = json_GET("$base/$id", 'Variation feature');
   #is(scalar(@$json), 1, '1 variation feature returned');
-  my $expected_variation_1 = {source => 'Variants (including SNPs and indels) imported from dbSNP', name => $id, MAF => '0.123049', minor_allele => 'A', ambiguity => 'R', var_class => 'SNP', synonyms => [], evidence => ['Multiple_observations','1000Genomes'], ancestral_allele => 'G', most_severe_consequence => 'intron_variant', mappings => [{"assembly_name" => "GRCh37", "location"=>"18:23821095-23821095", "strand" => 1, "start" => 23821095, "end" => 23821095, "seq_region_name" => "18", "coord_system" => "chromosome","allele_string"=>"G/A"}]};
+  my $expected_variation_1 = {source => 'Variants (including SNPs and indels) imported from dbSNP', name => $id, MAF => '0.123049', minor_allele => 'A', ambiguity => 'R', var_class => 'SNP', synonyms => [], evidence => ['Multiple_observations','1000Genomes'], most_severe_consequence => 'intron_variant', mappings => [{"assembly_name" => "GRCh37", "location"=>"18:23821095-23821095", "strand" => 1, "start" => 23821095, "end" => 23821095, "seq_region_name" => "18", "coord_system" => "chromosome","allele_string"=>"G/A", "ancestral_allele" => "G"}]};
   cmp_deeply($json, $expected_variation_1, "Checking the result from the variation endpoint");
 
 # Include phenotype information
@@ -53,7 +53,7 @@ my $base = '/variation/homo_sapiens';
 
 # Include genotyping chips information
   $id = 'rs7698608';
-  my $expected_variation_3 = {source => 'Variants (including SNPs and indels) imported from dbSNP', name => $id, MAF => '0.448577', minor_allele => 'C', ambiguity => 'M', var_class => 'SNP', synonyms => bag(qw/rs60248177 rs17215092/), evidence => [], ancestral_allele => undef, most_severe_consequence => '5_prime_UTR_variant', mappings => [{"assembly_name" => "GRCh37", "location"=>"4:103937974-103937974", "strand" => 1, "start" => 103937974, "end" => 103937974, "seq_region_name" => "4", "coord_system" => "chromosome","allele_string"=>"C/A"}]};
+  my $expected_variation_3 = {source => 'Variants (including SNPs and indels) imported from dbSNP', name => $id, MAF => '0.448577', minor_allele => 'C', ambiguity => 'M', var_class => 'SNP', synonyms => bag(qw/rs60248177 rs17215092/), evidence => [], most_severe_consequence => '5_prime_UTR_variant', mappings => [{"assembly_name" => "GRCh37", "location"=>"4:103937974-103937974", "strand" => 1, "start" => 103937974, "end" => 103937974, "seq_region_name" => "4", "coord_system" => "chromosome","allele_string"=>"C/A","ancestral_allele" => undef}]};
   $json = json_GET("$base/$id", 'Variation feature');
   cmp_deeply($json, $expected_variation_3, "Checking the result from the variation endpoint");
 
@@ -74,7 +74,7 @@ my $base = '/variation/homo_sapiens';
 
 # Get additional genotype information
   $id = 'rs67521280';
-  my $expected_variation_2 = {source => 'Variants (including SNPs and indels) imported from dbSNP', name => $id, MAF => undef, minor_allele => undef, failed => 'None of the variant alleles match the reference allele;Mapped position is not compatible with reported alleles', ambiguity => undef, var_class => 'indel', synonyms => [], evidence => [], ancestral_allele => undef, most_severe_consequence => 'intergenic_variant', mappings => [{"assembly_name" => "GRCh37", "location"=> "11:6303493-6303493", "strand" => 1, "start" => 6303493, "end" => 6303493, "seq_region_name" => "11", "coord_system" => "chromosome","allele_string"=>"-/GT"}] };
+  my $expected_variation_2 = {source => 'Variants (including SNPs and indels) imported from dbSNP', name => $id, MAF => undef, minor_allele => undef, failed => 'None of the variant alleles match the reference allele;Mapped position is not compatible with reported alleles', ambiguity => undef, var_class => 'indel', synonyms => [], evidence => [], most_severe_consequence => 'intergenic_variant', mappings => [{"assembly_name" => "GRCh37", "location"=> "11:6303493-6303493", "strand" => 1, "start" => 6303493, "end" => 6303493, "seq_region_name" => "11", "coord_system" => "chromosome","allele_string"=>"-/GT", "ancestral_allele" => undef}] };
   my $expected_genotype = { %{$expected_variation_2}, 
   genotypes => [{genotype => "GT|GT", gender => "Male", sample => "J. CRAIG VENTER", submission_id => 'ss95559393'}] };
   my $genotype_json = json_GET("$base/$id?genotypes=1", "Genotype info");
@@ -118,7 +118,8 @@ is_json_POST($base,$post_data,$expected_result,"Try to POST list of variations")
         'strand' => 1,
         'coord_system' => 'chromosome',
         'allele_string' => 'C/T',
-        'start' => 25744274
+        'start' => 25744274,
+        'ancestral_allele' => undef,
      }
     ],
     'name' => 'COSM946275',
@@ -139,7 +140,6 @@ is_json_POST($base,$post_data,$expected_result,"Try to POST list of variations")
     'var_class' => 'somatic SNV',
     'synonyms' => [],
     'evidence' => [],
-    'ancestral_allele' => undef,
     'most_severe_consequence' => 'missense_variant',
     'minor_allele' => undef
    };
@@ -164,7 +164,8 @@ my $publication_output =
         "strand" => 1,
         "coord_system" => "chromosome",
         "allele_string" => "C/A",
-        "start" => 103937974 
+        "start" => 103937974, 
+        "ancestral_allele" => undef,
       }
     ],
     "name" => "rs7698608",
@@ -179,7 +180,6 @@ my $publication_output =
     "evidence" => 
       [
       ],
-    "ancestral_allele" => undef,
     "minor_allele" => "C",
     "most_severe_consequence" => "5_prime_UTR_variant"
   }
@@ -210,7 +210,6 @@ my $publication_output =
   is($variants_json->[0]->{MAF},$publication_output->[0]->{MAF} ,'PMID MAF key'); # Interestingly these are not numerically equal under certain testing conditions...
   is($variants_json->[0]->{ambiguity}, $publication_output->[0]->{ambiguity} ,'PMID ambiguity key');
   is($variants_json->[0]->{var_class}, $publication_output->[0]->{var_class} ,'PMID source key');
-  ok(!$variants_json->[0]->{ancestral_allele},'PMID ancestral_allele key not set');
   is($variants_json->[0]->{minor_allele}, $publication_output->[0]->{minor_allele} ,'PMID minor_allele key');
   is($variants_json->[0]->{most_severe_consequence}, $publication_output->[0]->{most_severe_consequence} ,'PMID most_severe_consequence key');
 
@@ -249,7 +248,6 @@ my $publication_output =
   is($variants_json->[0]->{MAF},$publication_output->[0]->{MAF} ,'PMID MAF key');
   is($variants_json->[0]->{ambiguity}, $publication_output->[0]->{ambiguity} ,'PMID ambiguity key');
   is($variants_json->[0]->{var_class}, $publication_output->[0]->{var_class} ,'PMID source key');
-  ok(!$variants_json->[0]->{ancestral_allele},'PMID ancestral_allele key not set');
   is($variants_json->[0]->{minor_allele}, $publication_output->[0]->{minor_allele} ,'PMID minor_allele key');
   is($variants_json->[0]->{most_severe_consequence}, $publication_output->[0]->{most_severe_consequence} ,'PMID most_severe_consequence key');
  


### PR DESCRIPTION
### Description
We moved the ancestral allele from the variation into the variation_feature table and updated our API accordingly. The ancestral allele is now retrieved from the variation_feature object. 

### Use case
Get ancestral allele from variation feature object and therefore store the ancestral allele in the mappings hash for the variation endpoint.
Move ancestral_allele from the toplevel hash into mappings hash:
https://rest.ensembl.org/documentation/info/variation_id
{
  "name": "rs56116432",
  "MAF": 0.002596,
  "ancestral_allele": "C",
  "source": "Variants (including SNPs and indels) imported from dbSNP",
  "ambiguity": "Y",
  "mappings": [
    {
      "assembly_name": "GRCh38",
      "location": "9:133256042-133256042",
      "allele_string": "C/T",
      "coord_system": "chromosome",
      "seq_region_name": "9",
      "end": 133256042,
      "start": 133256042,
      "strand": 1
    },
...
===>
{
  "name": "rs56116432",
  "MAF": 0.002596,
  "source": "Variants (including SNPs and indels) imported from dbSNP",
  "ambiguity": "Y",
  "mappings": [
    {
      **"ancestral_allele": "C",**
      "assembly_name": "GRCh38",
      "location": "9:133256042-133256042",
      "allele_string": "C/T",
      "coord_system": "chromosome",
      "seq_region_name": "9",
      "end": 133256042,
      "start": 133256042,
      "strand": 1
    },
...

### Benefits
The ancestral allele is defined by its location. A variation object doesn't have a location only associated variation feature has. 

### Possible Drawbacks
Users need to update their parsers to retrieve the ancestral allele from a different location in the returned hash.

### Testing
Updated and pass

### Changelog
Updated endpoints
[variation/:species/:id]: The ancestral_allele field is now reported in each location hash of the mappings array.
