### PR TITLE
Fix a broken documentation link of variation

### DIFF
--- a/root/documentation/overlap.conf
+++ b/root/documentation/overlap.conf
@@ -157,8 +157,7 @@
       </so_term>
       <variant_set>
         type=String
-        description=Short name of a set to restrict the variants found.  (<a target="_blank" href='http://www.ensembl.org/info/genome/variation/data_description.html\#variation_sets'>See list of short set names</a>)  
-
+        description=Short name of a set to restrict the variants found.  (<a target="_blank" href='http://www.ensembl.org/info/genome/variation/species/sets.html'>See list of short set names</a>)
         example=ClinVar
       </variant_set>
       <misc_set>


### PR DESCRIPTION
### Description
There is a broken documentation link on this endpoint description
https://rest.ensembl.org/documentation/info/overlap_id

### Use case
"(See list of short set names)" now points to a dead link which is
http://www.ensembl.org/info/genome/variation/data_description.html#variation_sets

Propose change to http://www.ensembl.org/info/genome/variation/species/sets.html


