### PR TITLE
correction in variable ids used for grch37 rest documentation

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -98,10 +98,12 @@ jsonp=1
   # change in response object/removal of actual end-points to be handled from haproxy/load balancer
   # removing/commenting this section will lead to processing of both conf files and 
   # use of merged values if keys overlap between the two conf files
-  # meant mainly for deployment and to be enabled in grch37.conf under rest_private repo
-  #<conf_replacements>
-  #  compara.conf=compara_grch37.conf
-  #</conf_replacements>
+  # meant mainly for deployment and to be enabled in conf files under rest_private repo
+  # for grch38 deployment, compara_grch37.conf = compara.conf
+  # for grch37 deployment, compara.conf = compara_grch37.conf
+  <conf_replacements>
+    compara_grch37.conf=compara.conf
+  </conf_replacements>
 
   #Used to control the parameters used in examples. Please edit as you see fit for your infrastructure
   <replacements>

--- a/root/documentation/compara_grch37.conf
+++ b/root/documentation/compara_grch37.conf
@@ -141,22 +141,22 @@
     <examples>
       <basic>
         path=/homology/id/
-        capture=__VAR(gene_stable_id_compara37)__
+        capture=__VAR(compara_gene_stable_id)__
         content=application/json
       </basic>
       <orthoxml>
         path=/homology/id/
-        capture=__VAR(gene_stable_id_compara37)__
+        capture=__VAR(compara_gene_stable_id)__
         content=text/x-orthoxml+xml
       </orthoxml>
       <compara_xml>
         path=/homology/id/
-        capture=__VAR(gene_stable_id_compara37)__
+        capture=__VAR(compara_gene_stable_id)__
         content=text/xml
       </compara_xml>
       <format_xml>
         path=/homology/id/
-        capture=__VAR(gene_stable_id_compara37)__
+        capture=__VAR(compara_gene_stable_id)__
         content=text/xml
         <params>
           type=projections
@@ -165,7 +165,7 @@
       </format_xml>
       <orthoxml_limits>
         path=/homology/id/
-        capture=__VAR(gene_stable_id_compara37)__
+        capture=__VAR(compara_gene_stable_id)__
         content=text/x-orthoxml+xml
         <params>
           type=projections
@@ -173,7 +173,7 @@
       </orthoxml_limits>
       <format_limits_cdna>
         path=/homology/id/
-        capture=__VAR(gene_stable_id_compara37)__
+        capture=__VAR(compara_gene_stable_id)__
         content=application/json
         <params>
           type=projections


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

Corrections in variable ids used for grch37 rest compara documentation

### Use case

Disabling of compara end-points

### Benefits

Correction made

### Possible Drawbacks

NA

### Testing

NA

_If so, do the tests pass/fail?_

NA

### Changelog
No change in any endpoint functionality
