### PR TITLE
Add flags shift_3prime and shift_genomic to REST

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -69,6 +69,8 @@ has valid_user_params => (
     distance
     ambiguity
     mane
+    shift_3prime
+    shift_genomic
 
     pick
     pick_allele

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -83,6 +83,16 @@
         description=Include MANE Select annotations (GRCh38 only)
         default=0
       </mane>
+      <shift_3prime>
+        type=Boolean
+        description=Shift transcript-overlapping variants as far as possible in the 3' direction before providing consequences
+        default=0
+      </shift_3prime>
+      <shift_genomic>
+        type=Boolean
+        description=Shift all variants as far as possible in the 3' direction before providing consequences
+        default=0
+      </shift_genomic>
       <tsl>
         type=Boolean
         description=Include transcript support level (TSL) annotation
@@ -291,6 +301,16 @@
         description=Include MANE Select annotations (GRCh38 only)
         default=0
       </mane>
+      <shift_3prime>
+        type=Boolean
+        description=Shift transcript-overlapping variants as far as possible in the 3' direction before providing consequences
+        default=0
+      </shift_3prime>
+      <shift_genomic>
+        type=Boolean
+        description=Shift all variants as far as possible in the 3' direction before providing consequences
+        default=0
+      </shift_genomic>
       <tsl>
         type=Boolean
         description=Include transcript support level (TSL) annotation
@@ -476,6 +496,16 @@
         description=Include MANE Select annotations (GRCh38 only)
         default=0
       </mane>
+      <shift_3prime>
+        type=Boolean
+        description=Shift transcript-overlapping variants as far as possible in the 3' direction before providing consequences
+        default=0
+      </shift_3prime>
+      <shift_genomic>
+        type=Boolean
+        description=Shift all variants as far as possible in the 3' direction before providing consequences
+        default=0
+      </shift_genomic>
       <tsl>
         type=Boolean
         description=Include transcript support level (TSL) annotation
@@ -666,6 +696,16 @@
         description=Include MANE Select annotations (GRCh38 only)
         default=0
       </mane>
+      <shift_3prime>
+        type=Boolean
+        description=Shift transcript-overlapping variants as far as possible in the 3' direction before providing consequences
+        default=0
+      </shift_3prime>
+      <shift_genomic>
+        type=Boolean
+        description=Shift all variants as far as possible in the 3' direction before providing consequences
+        default=0
+      </shift_genomic>
       <tsl>
         type=Boolean
         description=Include transcript support level (TSL) annotation
@@ -852,6 +892,16 @@
         description=Include MANE Select annotations (GRCh38 only)
         default=0
       </mane>
+      <shift_3prime>
+        type=Boolean
+        description=Shift transcript-overlapping variants as far as possible in the 3' direction before providing consequences
+        default=0
+      </shift_3prime>
+      <shift_genomic>
+        type=Boolean
+        description=Shift all variants as far as possible in the 3' direction before providing consequences
+        default=0
+      </shift_genomic>
       <tsl>
         type=Boolean
         description=Include transcript support level (TSL) annotation
@@ -1056,6 +1106,16 @@
         description=Include MANE Select annotations (GRCh38 only)
         default=0
       </mane>
+      <shift_3prime>
+        type=Boolean
+        description=Shift transcript-overlapping variants as far as possible in the 3' direction before providing consequences
+        default=0
+      </shift_3prime>
+      <shift_genomic>
+        type=Boolean
+        description=Shift all variants as far as possible in the 3' direction before providing consequences
+        default=0
+      </shift_genomic>
       <tsl>
         type=Boolean
         description=Include transcript support level (TSL) annotation


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

We're allowing the flags --shift_3prime and --shift_genomic to be used on REST

### Use case

The idea is to provide a standardised way of handling ambiguous variants. VEP will shift variants as far as possible before consequence calling with these flags switched on

### Benefits

Improves handling of ambiguous variants

### Possible Drawbacks

None, it doesn't change default behaviour

### Testing

_Have you added/modified unit tests to test the changes?_

No

_Have you run the entire test suite and no regression was detected?_

Yes

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

[/vep] Added the flags --shift_3prime and --shift_genomic to allow for the 3' shifting of insertions and deletions in repetitive regions before consequence calculation
