### PR TITLE
EPO_LOW_COVERAGE->EPO_EXTENDED rename in compara

### DIFF
--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -734,7 +734,7 @@
 	example=mus_musculus
       </species_set>
       <method>
-        type=Enum(EPO, EPO_LOW_COVERAGE, PECAN, LASTZ_NET, BLASTZ_NET, TRANSLATED_BLAT_NET, CACTUS_HAL, CACTUS_HAL_PW)
+        type=Enum(EPO, EPO_EXTENDED, PECAN, LASTZ_NET, BLASTZ_NET, TRANSLATED_BLAT_NET, CACTUS_HAL, CACTUS_HAL_PW)
 	description=The alignment method
 	default=__VAR(compara_method)__
 	example=PECAN
@@ -748,7 +748,7 @@
       </display_species_set>
       <compact>
         type=Boolean
-	description= Applicable to EPO_LOW_COVERAGE alignments. If true, concatenate the low coverage species sequences together to create a single sequence. Otherwise, separates out all sequences.
+	description= Applicable to EPO_EXTENDED alignments. If true, concatenate the extended species sequences together to create a single sequence. Otherwise, separates out all sequences.
 	default=__VAR(compara_compact)__
       </compact>
     </params>

--- a/t/test-genome-DBs/multi/compara/method_link.txt
+++ b/t/test-genome-DBs/multi/compara/method_link.txt
@@ -3,7 +3,7 @@
 10	PECAN	GenomicAlignBlock.multiple_alignment	Mercator-Pecan
 11	GERP_CONSTRAINED_ELEMENT	ConstrainedElement.constrained_element	GERP Constrained Elements
 13	EPO	GenomicAlignTree.ancestral_alignment	EPO
-14	EPO_LOW_COVERAGE	GenomicAlignTree.tree_alignment	EPO-Low-Coverage
+14	EPO_EXTENDED	GenomicAlignTree.tree_alignment	EPO-Extended
 16	LASTZ_NET	GenomicAlignBlock.pairwise_alignment	LastZ
 19	LASTZ_PATCH	GenomicAlignBlock.pairwise_alignment	LastZ-path
 101	SYNTENY	SyntenyRegion.synteny	synteny


### PR DESCRIPTION
### Description

_Jira ticket: [ENSINT-334](https://www.ebi.ac.uk/panda/jira/browse/ENSINT-334)._
_EPO\_LOW\_COVERAGE_ method_link.type has been changed to _EPO\_EXTENDED_ to better reflect what the multiple alignment is. The display_name has been changed to `EPO-Extended` to match this also. 

### Use case

_EPO_LOW\_COVERAGE_ used to be computed on the more fragmented genomes. Now it is used to extend EPO alignments with additional species, which do not have to be "low coverage". Renaming the method to suggest an extension to the EPO alignment is more accurate, and will reduce confusion among users.

### Benefits

_As above._

### Possible Drawbacks

_NA_

### Testing

Tests have not been modified, but test databases have, with the method having been renamed. The unit tests have been run, and the change has not caused any failures or regression.

### Changelog

_NA_
