### PR TITLE
Add new VEP plugin documentation release 100

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -154,6 +154,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <SpliceAI>
+        type=Boolean
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>)
+        default=0
+      </SpliceAI>
       <miRNA>
         type=Boolean
         description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
@@ -357,6 +362,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <SpliceAI>
+        type=Boolean
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>)
+        default=0
+      </SpliceAI>
       <miRNA>
         type=Boolean
         description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
@@ -547,6 +557,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <SpliceAI>
+        type=Boolean
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>)
+        default=0
+      </SpliceAI>
       <miRNA>
         type=Boolean
         description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
@@ -732,6 +747,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <SpliceAI>
+        type=Boolean
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>)
+        default=0
+      </SpliceAI>
       <miRNA>
         type=Boolean
         description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
@@ -923,6 +943,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <SpliceAI>
+        type=Boolean
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>)
+        default=0
+      </SpliceAI>
       <miRNA>
         type=Boolean
         description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
@@ -1122,6 +1147,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <SpliceAI>
+        type=Boolean
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>)
+        default=0
+      </SpliceAI>
       <miRNA>
         type=Boolean
         description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)


### PR DESCRIPTION
### Description

This is the same change as #416 for release 100.
One more VEP plugin will be available through the VEP endpoint. This documentation is needed for the plugin.

### Use case

Plugin functionality available through REST.

### Benefits

The endpoint needs documentation to be displayed.

### Possible Drawbacks

None, the default behavior is the same.

### Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_
The tests are failing because of branches.

_Have you run the entire test suite and no regression was detected?_
No regression detected.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

[/vep/:species/hgvs/] new plugin option added: SpliceAI
[/vep/:species/id/] new plugin option added: SpliceAI
[/vep/:species/region/] new plugin option added: SpliceAI
