### PR TITLE
update dbNSFP readme file to verion 4.0a

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -140,7 +140,7 @@
       </Conservation>
       <dbNSFP>
         type=String
-        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://drive.google.com/file/d/0B60wROKy6OqcSFNBbWVjNWl5UjQ/view?usp=sharing">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://usf.app.box.com/s/cdws8yx5occ603ccbknwyamz5reapdug">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,MutationTaster_pred
       </dbNSFP>
@@ -358,7 +358,7 @@
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://drive.google.com/file/d/0B60wROKy6OqcSFNBbWVjNWl5UjQ/view?usp=sharing">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://usf.app.box.com/s/cdws8yx5occ603ccbknwyamz5reapdug">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,MutationTaster_pred
       </dbNSFP>
@@ -563,7 +563,7 @@
       </Conservation>
       <dbNSFP>
         type=String
-        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://drive.google.com/file/d/0B60wROKy6OqcSFNBbWVjNWl5UjQ/view?usp=sharing">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://usf.app.box.com/s/cdws8yx5occ603ccbknwyamz5reapdug">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,MutationTaster_pred
       </dbNSFP>
@@ -763,7 +763,7 @@
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://drive.google.com/file/d/0B60wROKy6OqcSFNBbWVjNWl5UjQ/view?usp=sharing">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://usf.app.box.com/s/cdws8yx5occ603ccbknwyamz5reapdug">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,MutationTaster_pred
       </dbNSFP>
@@ -969,7 +969,7 @@
       </Conservation>
       <dbNSFP>
         type=String
-        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://drive.google.com/file/d/0B60wROKy6OqcSFNBbWVjNWl5UjQ/view?usp=sharing">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://usf.app.box.com/s/cdws8yx5occ603ccbknwyamz5reapdug">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,MutationTaster_pred
       </dbNSFP>
@@ -1183,7 +1183,7 @@
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://drive.google.com/file/d/0B60wROKy6OqcSFNBbWVjNWl5UjQ/view?usp=sharing">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="https://usf.app.box.com/s/cdws8yx5occ603ccbknwyamz5reapdug">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,MutationTaster_pred
       </dbNSFP>


### PR DESCRIPTION
### Description
This is late patch for the current release 100.
For release 100 we updated the dbNSFP data file to the latest version 4.0a. VEP endpoints can use the file to add additional information for a given variant to the output. Supported fields which can be selected from the file are described in a README file. The readme file link wan't updated to the latest file and now causes confusion on which version of dbNSFP is supported and which fields can be selected.

### Use case
Users can check the readme file for supported version and fields of the dbNSFP data file

### Benefits
Bugfix

### Possible Drawbacks
None

### Testing
I checked all occurrences of the [readme file](https://usf.app.box.com/s/cdws8yx5occ603ccbknwyamz5reapdug) and that link works on an instance running on a farm node:
--[vep_hgvs_get](http://hx-noah-13-02.ebi.ac.uk:3000/documentation/info/vep_hgvs_get)
--[vep_hgvs_post](http://hx-noah-13-02.ebi.ac.uk:3000/documentation/info/vep_hgvs_post)
--[vep_id_get](http://hx-noah-13-02.ebi.ac.uk:3000/documentation/info/vep_id_get)
--[vep_id_post](http://hx-noah-13-02.ebi.ac.uk:3000/documentation/info/vep_id_post)
--[vep_region_get](http://hx-noah-13-02.ebi.ac.uk:3000/documentation/info/vep_region_get)
--[vep_region_post](http://hx-noah-13-02.ebi.ac.uk:3000/documentation/info/vep_region_post)

### Changelog
NA
