### PR TITLE
Bugfix/cpanfile mojo 101

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 
 requires 'Catalyst';
-requires 'Mojo';
+requires 'Mojolicious', '<= 8.43';
 requires 'Catalyst::Devel';
 
 requires 'Catalyst::Runtime';


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

Pin Mojolicious to version 8.43 or earlier in the cpanfile. Mojolicious is no longer compatible with Perl 5.14 after version 8.43. See https://metacpan.org/changes/distribution/Mojolicious

This is a stopgap measure until a decision is made to no longer support Perl 5.14

### Use case

Allows this software to run under Perl 5.14. Allows the test suite to run under 5.14. 

### Benefits

See use case

### Possible Drawbacks

This prevents the code from taking advantage of any improvements or bugfixes in Mojolicious post version 8.34

### Testing

This change allows Perl 5.14 unit tests to run

### Changelog

N/A