### PR TITLE
Remove some info endpoints on Grch37

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -93,7 +93,7 @@ jsonp=1
   #Expire depends on the type of CHI cache configured in Plugin::Cache section
   # example_expire_time=3600
  
-  # compara end-points had to be taken down for grch37 for e100 as part of removal of non-human resources
+  # compara and ensembl genomes end-points had to be taken down for grch37 for e100 as part of removal of non-human resources
   # so maintain and replace a different conf file for documentation
   # change in response object/removal of actual end-points to be handled from haproxy/load balancer
   # removing/commenting this section will lead to processing of both conf files and 
@@ -103,6 +103,7 @@ jsonp=1
   # for grch37 deployment, compara.conf = compara_grch37.conf
   <conf_replacements>
     compara_grch37.conf=compara.conf
+    info_grch37.conf=info.conf
   </conf_replacements>
 
   #Used to control the parameters used in examples. Please edit as you see fit for your infrastructure

--- a/root/documentation/info_grch37.conf
+++ b/root/documentation/info_grch37.conf
@@ -1,0 +1,494 @@
+<endpoints>
+  <ping>
+    description=Checks if the service is alive.
+    endpoint="info/ping"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <examples>
+      <default>
+        path=/info/ping
+        content=application/json
+      </default>
+    </examples>
+  </ping>
+  
+  <species>
+    description=Lists all available species, their aliases, available adaptor groups and data release.
+    endpoint="info/species"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <params>
+      <division>
+        type=String
+        description=Filter by Ensembl or Ensembl Genomes division.
+        example=__VAR(info_division)__
+        default=EnsemblVertebrates
+      </division>
+      <strain_collection>
+        type=String
+        description=Filter by strain_collection.
+        example=mouse
+      </strain_collection>
+      <hide_strain_info>
+        type=Boolean(0,1)
+        description=Show/hide strain and strain_collection info in the output
+        default=0
+      </hide_strain_info>
+    </params>
+    <examples>
+      <one>
+        path=/info/species
+        content=application/json
+      </one>
+      <two>
+        path=/info/species
+        content=text/xml
+      </two>
+    </examples>
+  </species>
+  
+  <comparas>
+    description=Lists all available comparative genomics databases and their data release. DEPRECATED: use info/genomes/division instead.
+    endpoint="info/comparas"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <examples>
+      <one>
+        path=/info/comparas
+        content=application/json
+      </one>
+      <two>
+        path=/info/comparas
+        content=text/xml
+      </two>
+    </examples>
+  </comparas>
+   
+  <software>
+    description=Shows the current version of the Ensembl API used by the REST server.
+    endpoint="info/software"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <examples>
+      <default>
+        path=/info/software
+        content=application/json
+      </default>
+    </examples>
+  </software>
+  
+  <rest>
+    description=Shows the current version of the Ensembl REST API.
+    endpoint="info/rest"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <examples>
+      <default>
+        path=/info/rest
+        content=application/json
+      </default>
+    </examples>
+  </rest>
+  
+  <data>
+    description=Shows the data releases available on this REST server. May return more than one release (unfrequent non-standard Ensembl configuration).
+    endpoint="info/data"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <examples>
+      <one>
+        path=/info/data/
+        content=application/json
+      </one>
+      <two>
+        path=/info/data/
+        content=text/xml
+      </two>
+    </examples>
+  </data>
+
+  <analysis>
+    description=List the names of analyses involved in generating Ensembl data.
+    endpoint="info/analysis/:species"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <params>
+      <species>
+        type=String
+        description=Species name/alias
+        required=1
+        example=__VAR(species)__
+      </species>
+    </params>
+    <examples>
+      <one>
+        path=/info/analysis/
+        capture=__VAR(species)__
+        content=application/json
+      </one>
+    </examples>
+  </analysis>
+  
+  <biotypes>
+    description=List the functional classifications of gene models that Ensembl associates with a particular species. Useful for restricting the type of genes/transcripts retrieved by other endpoints.
+    endpoint="info/biotypes/:species"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <params>
+      <species>
+        type=String
+        description=Species name/alias
+        required=1
+        example=__VAR(species)__
+      </species>
+    </params>
+    <examples>
+      <one>
+        path=/info/biotypes/
+        capture=__VAR(species)__
+        content=application/json
+      </one>
+    </examples>
+  </biotypes>
+
+  <biotypes_groups>
+    description=Without argument the list of available biotype groups is returned. With :group argument provided, list the properties of biotypes within that group. Object type (gene or transcript) can be provided for filtering.
+    endpoint="info/biotypes/groups/:group/:object_type"
+    method=GET
+    group=Information
+    output=json
+    output=yaml
+    <params>
+      <group>
+        type=String
+        description=Biotype group
+        required=0
+        example=__VAR(biotype_group)__
+      </group>
+      <object_type>
+        type=String
+        description=Object type (gene or transcript)
+        required=0
+        example=__VAR(biotype_ot)__
+      </object_type>
+    </params>
+    <examples>
+      <a>
+        path=/info/biotypes/groups/
+        content=application/json
+      </a>
+      <b>
+        path=/info/biotypes/groups/
+        capture=__VAR(biotype_group)__
+        content=application/json
+      </b>
+      <c>
+        path=/info/biotypes/groups/
+        capture=__VAR(biotype_group)__
+        capture=__VAR(biotype_ot)__
+        content=application/json
+      </c>
+    </examples>
+  </biotypes_groups>
+
+  <biotypes_name>
+    description=List the properties of biotypes with a given name. Object type (gene or transcript) can be provided for filtering.
+    endpoint="info/biotypes/name/:name/:object_type"
+    method=GET
+    group=Information
+    output=json
+    output=yaml
+    <params>
+      <name>
+        type=String
+        description=Biotype name
+        required=1
+        example=__VAR(biotype_name)__
+      </name>
+      <object_type>
+        type=String
+        description=Object type (gene or transcript)
+        required=0
+        example=__VAR(biotype_ot)__
+      </object_type>
+    </params>
+    <examples>
+      <a>
+        path=/info/biotypes/name/
+        capture=__VAR(biotype_name)__
+        content=application/json
+      </a>
+      <b>
+        path=/info/biotypes/name/
+        capture=__VAR(biotype_name)__
+        capture=__VAR(biotype_ot)__
+        content=application/json
+      </b>
+    </examples>
+  </biotypes_name>
+
+  <external_dbs>
+    description=Lists all available external sources for a species.
+    endpoint="info/external_dbs/:species"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <params>
+      <species>
+        type=String
+        description=Species name/alias
+        required=1
+        example=__VAR(species)__
+      </species>
+      <filter>
+        type=String
+        description=Restrict external DB searches to a single source or pattern. SQL-LIKE patterns are supported.
+        required=0
+        example=HGNC
+        example=GO%
+      </filter>
+      <feature>
+        type=Enum(dna_align_feature protein_align_feature unmapped_object xref seq_region_synonym)
+        description=Only return external DB entries for a given feature.
+        required=0
+        example=xref
+        example=dna_align_feature
+      </filter>
+    </params>
+    <examples>
+      <a>
+        path=/info/external_dbs/
+        capture=__VAR(species)__
+        content=application/json
+      </a>
+      <b>
+        path=/info/external_dbs/
+        capture=__VAR(species)__
+        <params>
+          filter=GO%
+        </params>
+        content=application/json
+      </b>
+      <c>
+        path=/info/external_dbs/
+        capture=__VAR(species)__
+        <params>
+          feature=seq_region_synonym
+        </params>
+        content=application/json
+      </c>
+    </examples>
+  </external_dbs>
+
+  <compara_methods>
+    description=List all compara analyses available (an analysis defines the type of comparative data).
+    endpoint="info/compara/methods"
+    method=GET
+    group=Information
+    output=json
+    output=yaml
+    output=xml
+    <params>
+      <compara>
+        type=String
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=__VAR(compara)__
+      </compara>
+      <class>
+        type=String
+        description=The class of the method to query for. Regular expression patterns are supported.
+        example=__VAR(compara_method_type)__
+      </class>
+    </params>
+    <examples>
+      <basic>
+        path=/info/compara/methods/
+        content=application/json
+      </basic>
+    </examples>
+  </compara_methods>
+
+  <compara_species_sets>
+    description=List all collections of species analysed with the specified compara method.
+    endpoint="info/compara/species_sets/:method"
+    method=GET
+    group=Information
+    output=json
+    output=yaml
+    output=xml
+    <params>
+      <method>
+        type=String
+        description=Filter by compara method. Use one the methods returned by <a href='/documentation/info/compara_methods'>/info/compara/methods</a> endpoint.
+        example=__VAR(compara_method)__
+        required=1
+      </method>
+      <compara>
+        type=String
+        description=Name of the compara database to use. Multiple comparas exist on a server for separate species divisions
+        default=vertebrates
+        example=__VAR(compara)__
+      </compara>  
+     </params>
+    <examples>
+      <basic>
+        path=/info/compara/species_sets/
+        capture=__VAR(compara_method)__
+        content=application/json
+      </basic>
+    </examples>
+  </compara_species_sets>
+ 
+  <variation>
+    description=List the variation sources used in Ensembl for a species.
+    endpoint="info/variation/:species"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <params>
+      <species>
+        type=String
+        description=Species name/alias
+        required=1
+        example=__VAR(species)__
+      </species>
+      <filter>
+        type=String
+        description=Restrict the variation source searches to a single source.
+        required=0
+        example=dbSNP
+        example=ClinVar
+        example=OMIM
+        example=UniProt
+        example=HGMD
+      </filter>
+    </params>
+    <examples>
+      <one>
+        path=/info/variation/
+        capture=__VAR(species)__
+        content=application/json
+      </one>
+      <two>
+        path=/info/variation/
+        capture=__VAR(species)__
+        <params>
+          filter=dbSNP
+        </params>
+        content=application/json
+      </two>
+    </examples>
+  </variation>
+
+  <variation_populations> 
+    description=List all populations for a species
+    endpoint="info/variation/populations/:species"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <params>
+      <species>
+        type=String
+        description=Species name/alias
+        required=1
+        example=__VAR(species)__
+      </species>
+      <filter>
+        type=String
+        description=Restrict populations returned to e.g. only populations with LD data. It is highly recommended to set a filter and to avoid loading the complete list of populations.
+        required=0
+        example=LD
+      </filter>
+    </params>
+    <examples>
+      <a>
+        path=/info/variation/populations/
+        capture=__VAR(species)__
+        <params>
+          filter=LD
+        </params>
+        content=application/json
+      </a>
+    </examples>
+  </variation_populations> 
+
+  <variation_population_name>
+    description=List all individuals for a population from a species
+    endpoint="info/variation/populations/:species:/:population_name"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <params>
+      <species>
+        type=String
+        description=Species name/alias
+        required=1
+        example=__VAR(species_common)__
+      </species>
+      <population_name>
+        type=String
+        description=Population name
+        required=1
+        example=__VAR(population_name)__
+      </population_name>
+    </params>
+    <examples>
+      <a>
+        path=/info/variation/populations/
+        capture=__VAR(species_common)__
+        capture=__VAR(population_name)__
+        content=application/json
+      </a>
+    </examples>
+  </variation_population_name>
+
+  <variation_consequence_types>
+    description=Lists all variant consequence types.
+    endpoint="info/variation/consequence_types"
+    method=GET
+    group=Information
+    output=json
+    output=xml
+    <params>
+      <rank>
+        type=Boolean(0,1)
+        description=Include consequence ranking
+        required=0
+        default=0
+      </rank>
+    </params>
+    <examples>
+      <one>
+        path=/info/variation/consequence_types
+        content=application/json
+      </one>
+      <two>
+        path=/info/variation/consequence_types
+        content=text/xml
+      </two>
+    </examples>
+  </variation_consequence_types>
+
+
+</endpoints>


### PR DESCRIPTION
### Description
For now the `info.conf` is shared between www and Grch37. However, there are some info endpoints that are no longer relevant on Grch37, for example:
http://grch37.rest.ensembl.org/documentation/info/eg_version
http://grch37.rest.ensembl.org/documentation/info/info_divisions

This PR is to remove these endpoints from `info.conf`, and save it as `info_grch37.conf`. They include:

1. eg_version
2. info_genome
3. info_divisions
4. info_genomes_division
5. info_genomes_taxonomy
6. info_genomes_assembly
7. info_genomes_accession

`ensembl_rest.conf.j2` in `ensembl-rest_private` is updated so that www and grch37 pick up the right info conf.

### Benefits

Remove broken endpoints

### Possible Drawbacks

None

### Testing

The info_grch37.conf works on my sandbox http://ves-hx2-75:4000/


