### PR TITLE
Add new VEP plugin documentation 

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -194,11 +194,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <DisGeNet>
+      <DisGeNET>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
         default=0
-      </DisGeNet>
+      </DisGeNET>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -417,11 +417,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <DisGeNet>
+      <DisGeNET>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
         default=0
-      </DisGeNet>
+      </DisGeNET>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -627,11 +627,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <DisGeNet>
+      <DisGeNET>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
         default=0
-      </DisGeNet>
+      </DisGeNET>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -832,11 +832,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <DisGeNet>
+      <DisGeNET>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
         default=0
-      </DisGeNet>
+      </DisGeNET>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -1043,11 +1043,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <DisGeNet>
+      <DisGeNET>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
         default=0
-      </DisGeNet>
+      </DisGeNET>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -1262,11 +1262,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <DisGeNet>
+      <DisGeNET>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
         default=0
-      </DisGeNet>
+      </DisGeNET>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -196,7 +196,7 @@
       </Phenotypes>
       <DisGeNet>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
         default=0
       </DisGeNet>
       <CADD>
@@ -419,7 +419,7 @@
       </Phenotypes>
       <DisGeNet>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
         default=0
       </DisGeNet>
       <CADD>
@@ -629,7 +629,7 @@
       </Phenotypes>
       <DisGeNet>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
         default=0
       </DisGeNet>
       <CADD>
@@ -834,7 +834,7 @@
       </Phenotypes>
       <DisGeNet>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
         default=0
       </DisGeNet>
       <CADD>
@@ -1045,7 +1045,7 @@
       </Phenotypes>
       <DisGeNet>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
         default=0
       </DisGeNet>
       <CADD>
@@ -1264,7 +1264,7 @@
       </Phenotypes>
       <DisGeNet>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
         default=0
       </DisGeNet>
       <CADD>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -194,6 +194,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
+      <DisGeNet>
+        type=Boolean
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        default=0
+      </DisGeNet>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -412,6 +417,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
+      <DisGeNet>
+        type=Boolean
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        default=0
+      </DisGeNet>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -617,6 +627,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
+      <DisGeNet>
+        type=Boolean
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        default=0
+      </DisGeNet>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -817,6 +832,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
+      <DisGeNet>
+        type=Boolean
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        default=0
+      </DisGeNet>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -1023,6 +1043,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
+      <DisGeNet>
+        type=Boolean
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        default=0
+      </DisGeNet>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -1237,6 +1262,11 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
+      <DisGeNet>
+        type=Boolean
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNet.pm">plugin details</a>)
+        default=0
+      </DisGeNet>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)


### PR DESCRIPTION
### Description

One more VEP plugin will be available through the VEP endpoint. This documentation is needed for the plugin.

### Use case

Plugin functionality available through REST.

### Benefits

The endpoint needs documentation to be displayed.

### Possible Drawbacks

None, the default behavior is the same.

### Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
No regression detected.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

[/vep/:species/hgvs/] new plugin option added: DisGeNet
[/vep/:species/id/] new plugin option added: DisGeNet
[/vep/:species/region/] new plugin option added: DisGeNet
