### PR TITLE
Add Starman to the cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -32,6 +32,7 @@ requires 'Readonly::XS';
 requires 'DBD::SQLite';
 requires 'List::MoreUtils';
 requires 'Try::Tiny';
+requires 'Starman';
 
 # Transient dependencies from Ensembl
 requires 'Parse::RecDescent';


### PR DESCRIPTION
### Description

The current cpanfile does not install Starman, which is a module required to run REST (https://github.com/Ensembl/ensembl-rest/blob/master/bin/production/server_control.pl#L28)

### Use case

I think the cpanfile installed Starman when we setup REST 101. But since 2 months ago, we have found an issue of missing Starman when setting up REST covid19 and REST 102

### Benefits

Without Starman, REST server won't start

### Possible Drawbacks

_NONE_

### Testing

Manually install Starman using `cpanm Starman` and I can start the server