### PR TITLE
Add Mastermind plugin

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -199,6 +199,11 @@
         description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
         default=0
       </DisGeNET>
+      <Mastermind>
+        type=Boolean
+        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Mastermind.pm">plugin details</a>)
+        default=0
+      </Mastermind>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -422,6 +427,11 @@
         description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
         default=0
       </DisGeNET>
+      <Mastermind>
+        type=Boolean
+        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Mastermind.pm">plugin details</a>)
+        default=0
+      </Mastermind>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -632,6 +642,11 @@
         description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
         default=0
       </DisGeNET>
+      <Mastermind>
+        type=Boolean
+        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Mastermind.pm">plugin details</a>)
+        default=0
+      </Mastermind>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -837,6 +852,11 @@
         description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
         default=0
       </DisGeNET>
+      <Mastermind>
+        type=Boolean
+        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Mastermind.pm">plugin details</a>)
+        default=0
+      </Mastermind>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -1048,6 +1068,11 @@
         description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
         default=0
       </DisGeNET>
+      <Mastermind>
+        type=Boolean
+        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Mastermind.pm">plugin details</a>)
+        default=0
+      </Mastermind>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
@@ -1267,6 +1292,11 @@
         description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
         default=0
       </DisGeNET>
+      <Mastermind>
+        type=Boolean
+        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Mastermind.pm">plugin details</a>)
+        default=0
+      </Mastermind>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)


### PR DESCRIPTION
### Description

One more VEP plugin will be available through the VEP endpoint. This documentation is needed for the plugin.

### Use case

Plugin functionality available through REST.

### Benefits

The endpoint needs documentation to be displayed.

### Possible Drawbacks

None, the default behavior is the same.

### Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
No regression detected.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

[/vep/:species/hgvs/] new plugin option added: Mastermind
[/vep/:species/id/] new plugin option added: Mastermind
[/vep/:species/region/] new plugin option added: Mastermind
