### PR TITLE
add test back after blob to hex-blob conversion

### DIFF
--- a/t/variation.t
+++ b/t/variation.t
@@ -78,8 +78,7 @@ my $base = '/variation/homo_sapiens';
   my $expected_genotype = { %{$expected_variation_2}, 
   genotypes => [{genotype => "GT|GT", gender => "Male", sample => "J. CRAIG VENTER", submission_id => 'ss95559393'}] };
   my $genotype_json = json_GET("$base/$id?genotypes=1", "Genotype info");
-# test is temporarily switched off while work on converting blob to hex-blob is ongoing
-# cmp_deeply($genotype_json, $expected_genotype, "Returning genotype information");
+  cmp_deeply($genotype_json, $expected_genotype, "Returning genotype information");
 
 # Include population allele frequency information
   my $expected_pops = { %{$expected_variation_2},


### PR DESCRIPTION
### Description

Variation test data has been converted to HEX and the test runs successfully again.

### Use case

NA

### Benefits

NA

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

### Testing

Tests ran on travis https://travis-ci.org/github/at7/ensembl-rest/builds/754441684

### Changelog

NA