### PR TITLE
Add options to Variant Recoder

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VariantRecoder.pm
+++ b/lib/EnsEMBL/REST/Controller/VariantRecoder.pm
@@ -46,6 +46,9 @@ has valid_user_params => (
     minimal
     fields
 
+    vcf_string
+    var_synonyms
+
     pick
     pick_allele
     per_gene

--- a/root/documentation/variation.conf
+++ b/root/documentation/variation.conf
@@ -176,9 +176,19 @@
       </species>
       <fields>
         type=String
-        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic), vcf_string (VCF format)
+        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic)
         default=id,hgvsg,hgvsc,hgvsp,spdi
       </fields>
+      <vcf_string>
+        type=String
+        description=VCF represented in a string
+        default=0
+      </vcf_string>
+      <var_synonyms>
+        type=String
+        description=Known variation synonyms and their sources
+        default=0
+      </var_synonyms>
     </params>
 
     <examples>
@@ -215,9 +225,19 @@
       </species>
       <fields>
         type=String
-        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic), vcf_string (VCF format)
+        description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic)
         default=id,hgvsg,hgvsc,hgvsp,spdi
       </fields>
+      <vcf_string>
+        type=String
+        description=VCF represented in a string
+        default=0
+      </vcf_string>
+      <var_synonyms>
+        type=String
+        description=Known variation synonyms and their sources
+        default=0
+      </var_synonyms>
     </params>
 
     postformat={ "ids": array }

--- a/root/documentation/variation.conf
+++ b/root/documentation/variation.conf
@@ -180,12 +180,12 @@
         default=id,hgvsg,hgvsc,hgvsp,spdi
       </fields>
       <vcf_string>
-        type=String
+        type=Boolean(0,1)
         description=VCF represented in a string
         default=0
       </vcf_string>
       <var_synonyms>
-        type=String
+        type=Boolean(0,1)
         description=Known variation synonyms and their sources
         default=0
       </var_synonyms>
@@ -229,12 +229,12 @@
         default=id,hgvsg,hgvsc,hgvsp,spdi
       </fields>
       <vcf_string>
-        type=String
+        type=Boolean(0,1)
         description=VCF represented in a string
         default=0
       </vcf_string>
       <var_synonyms>
-        type=String
+        type=Boolean(0,1)
         description=Known variation synonyms and their sources
         default=0
       </var_synonyms>

--- a/t/variation.t
+++ b/t/variation.t
@@ -402,6 +402,79 @@ is_json_POST(
   'variant_recoder - POST - restrict fields'
 );
 
+# test options vcf_string and var_synonyms
+my $exp_options = [
+  {
+    'T' => {
+      'hgvsp' => [
+        'ENSP00000371073.2:p.Arg146Cys',
+        'ENSP00000371079.3:p.Arg146Cys',
+        'ENSP00000381976.1:p.Arg146Cys',
+        'ENSP00000399510.1:p.Arg146Cys',
+        'ENSP00000394848.2:p.Arg146Cys',
+        'ENSP00000405307.1:p.Arg146Cys'
+      ],
+      'hgvsc' => [
+        'ENST00000381657.2:c.436C>T',
+        'ENST00000381663.3:c.436C>T',
+        'ENST00000399012.1:c.436C>T',
+        'ENST00000415337.1:c.436C>T',
+        'ENST00000430923.2:c.436C>T',
+        'ENST00000447472.1:c.436C>T'
+      ],
+      'input' => 'rs142663151',
+      'id' => [
+        'rs142663151'
+      ],
+      'hgvsg' => [
+        'X:g.208208C>T'
+      ],
+      'spdi' => [
+        'X:208207:C:T'
+      ],
+      'vcf_string' => [
+        'X-208208-C-T'
+      ],
+    }
+  }
+];
+
+my $exp_options_2 = [
+  {
+    'A' => {
+      'input' => 'rs7569578',
+      'id' => [
+        'rs7569578'
+      ],
+      'hgvsg' => [
+        '2:g.45411130N>A'
+      ],
+      'spdi' => [
+        '2:45411129:T:A'
+      ],
+      'vcf_string' => [
+        '2-45411130-T-A'
+      ],
+      var_synonyms => [
+        'Archive dbSNP: rs57302278'
+      ],
+    }
+  }
+];
+
+is_deeply(
+  json_GET("$base/rs7569578?vcf_string=1&var_synonyms=1", "variant_recoder - option vcf_string and var_synonyms"),
+  $exp_options_2,
+  'variant_recoder - GET - option vcf_string and var_synonyms'
+);
+
+is_json_POST(
+  $base,
+  '{"ids" : ["rs142663151", "rs7569578"], "vcf_string": "1", "var_synonyms" : "1"}',
+  [$exp_options->[0], $exp_options_2->[0]],
+  'variant_recoder - POST - option vcf_string and var_synonyms'
+);
+
 # test errors
 action_bad_post($base, '{}', qr/key in your POST/, 'error - POST missing key');
 


### PR DESCRIPTION
### Description

Variant Recoder has two more options available. 

### Use case

We need to add two options:
- vcf_string (at the moment, it can be switched on using `fields` but it's more correct if `vcf_string` is a separate option)
- var_synonyms (new option to report variation synonyms)

### Benefits

More Variant Recoder options.

### Possible Drawbacks

None

### Testing

_Have you added/modified unit tests to test the changes?_
Yes, tests added to t/variation.t

_If so, do the tests pass/fail?_
Tests pass

_Have you run the entire test suite and no regression was detected?_
No regression detected.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._
[variant_recoder/:species/:id] Has the option to return VCF and variation synonyms