### PR TITLE
Patch variation test db 105 

### DIFF
--- a/t/test-genome-DBs/homo_sapiens/variation/meta.txt
+++ b/t/test-genome-DBs/homo_sapiens/variation/meta.txt
@@ -129,3 +129,4 @@
 129	\N	patch	patch_102_103_a.sql|schema version
 130	\N	patch	patch_103_104_a.sql|schema version
 131	\N	patch	patch_104_105_a.sql|schema_version
+132	\N	patch	patch_104_105_b.sql|Increase publication title size

--- a/t/test-genome-DBs/homo_sapiens/variation/table.sql
+++ b/t/test-genome-DBs/homo_sapiens/variation/table.sql
@@ -186,7 +186,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=132 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=133 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
@@ -325,7 +325,7 @@ CREATE TABLE `protein_function_predictions_attrib` (
 
 CREATE TABLE `publication` (
   `publication_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `title` varchar(255) DEFAULT NULL,
+  `title` varchar(400) DEFAULT NULL,
   `authors` varchar(255) CHARACTER SET latin2 DEFAULT NULL,
   `pmid` int(10) DEFAULT NULL,
   `pmcid` varchar(255) DEFAULT NULL,


### PR DESCRIPTION
### Description

Variation has another schema patch for 105. 

### Use case

Variation needs to add another schema patch to 105 because the publication.title current length is not enough. 

### Benefits

### Possible Drawbacks

None

### Testing

No

_If so, do the tests pass/fail?_


### Changelog

No
