### PR TITLE
Patched test databases for release 105

### DIFF
--- a/t/test-genome-DBs/homology/compara/meta.txt
+++ b/t/test-genome-DBs/homology/compara/meta.txt
@@ -73,3 +73,4 @@
 97	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 98	\N	patch	patch_103_104_c.sql|fix_int_types
 100	\N	patch	patch_104_105_a.sql|schema_version
+101	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/t/test-genome-DBs/homology/compara/table.sql
+++ b/t/test-genome-DBs/homology/compara/table.sql
@@ -287,7 +287,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -436,7 +436,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=101 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=102 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/t/test-genome-DBs/multi/compara/meta.txt
+++ b/t/test-genome-DBs/multi/compara/meta.txt
@@ -117,3 +117,4 @@
 142	\N	patch	patch_103_104_b.sql|dnafrag_alt_region
 143	\N	patch	patch_103_104_c.sql|fix_int_types
 145	\N	patch	patch_104_105_a.sql|schema_version
+146	\N	patch	patch_104_105_b.sql|genebuild_varchar255

--- a/t/test-genome-DBs/multi/compara/table.sql
+++ b/t/test-genome-DBs/multi/compara/table.sql
@@ -287,7 +287,7 @@ CREATE TABLE `genome_db` (
   `taxon_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(128) NOT NULL DEFAULT '',
   `assembly` varchar(100) NOT NULL DEFAULT '',
-  `genebuild` varchar(100) NOT NULL DEFAULT '',
+  `genebuild` varchar(255) NOT NULL DEFAULT '',
   `has_karyotype` tinyint(1) NOT NULL DEFAULT '0',
   `is_good_for_alignment` tinyint(1) NOT NULL DEFAULT '0',
   `genome_component` varchar(5) DEFAULT NULL,
@@ -436,7 +436,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=146 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=147 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
### Description

Patching Compara test databases following a schema change we have just merged in for e105

### Testing

`perl ${ENSEMBL_ROOT_DIR}/ensembl-test/scripts/runtests.pl t/` failed at `t/gafeatures.t` and `t/ld.t` but they don't seem to be Compara tests. It was agreed with a more senior colleague to open a pull request.  

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

No.