### PR TITLE
Patch variation database for e106

### DIFF
--- a/t/test-genome-DBs/homo_sapiens/variation/meta.txt
+++ b/t/test-genome-DBs/homo_sapiens/variation/meta.txt
@@ -1,5 +1,5 @@
 1	\N	schema_type	variation
-2	\N	schema_version	105
+2	\N	schema_version	106
 3	\N	patch	patch_73_74_a.sql|schema version
 4	\N	patch	patch_73_74_b.sql|Add doi and UCSC id to publication table
 5	\N	patch	patch_73_74_c.sql|Add clinical_significance to variation_feature table
@@ -130,3 +130,4 @@
 130	\N	patch	patch_103_104_a.sql|schema version
 131	\N	patch	patch_104_105_a.sql|schema_version
 132	\N	patch	patch_104_105_b.sql|Increase publication title size
+133	\N	patch	patch_105_106_a.sql|schema version

--- a/t/test-genome-DBs/homo_sapiens/variation/table.sql
+++ b/t/test-genome-DBs/homo_sapiens/variation/table.sql
@@ -186,7 +186,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=133 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=134 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

Apply e106 patch for variation test databases

### Use case

Test databases will be  on e106 schema

### Benefits



### Possible Drawbacks



### Testing

The following tests are failing
archive.t  - version difference 105/106 due to core db not patched in this PR

gafeatures.t  - date differences possibly due to BST/GMT as 1 hour difference
1209464261 2008-04-29 11:17:41
1209467861 2008-04-29 12:17:41 


### Changelog


