### PR TITLE
Patch funcgen test db for 106 and change introduced during 105

### DIFF
--- a/t/test-genome-DBs/homo_sapiens/funcgen/meta.txt
+++ b/t/test-genome-DBs/homo_sapiens/funcgen/meta.txt
@@ -1,5 +1,5 @@
 1	1	schema_type	funcgen
-2	\N	schema_version	105
+2	\N	schema_version	106
 3	\N	patch	patch_88_89_a.sql|schema_version
 4	\N	patch	patch_88_89_b.sql|Created probe_seq table
 5	\N	patch	patch_88_89_c.sql|created probe_feature_transcript table
@@ -202,3 +202,5 @@
 777	\N	patch	patch_102_103_a.sql|schema_version
 778	\N	patch	patch_103_104_a.sql|schema_version
 779	\N	patch	patch_104_105_a.sql|schema_version
+780	\N	patch	patch_104_105_b.sql|New indices
+781	\N	patch	patch_105_106_a.sql|schema_version

--- a/t/test-genome-DBs/homo_sapiens/funcgen/table.sql
+++ b/t/test-genome-DBs/homo_sapiens/funcgen/table.sql
@@ -391,7 +391,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=780 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=782 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
@@ -454,7 +454,8 @@ CREATE TABLE `motif_feature_regulatory_feature` (
   PRIMARY KEY (`motif_feature_regulatory_feature_id`),
   UNIQUE KEY `mf_rf_ep_idx` (`motif_feature_id`,`regulatory_feature_id`,`epigenome_id`),
   KEY `motif_feature_idx` (`motif_feature_id`),
-  KEY `regulatory_feature_idx` (`regulatory_feature_id`)
+  KEY `regulatory_feature_idx` (`regulatory_feature_id`),
+  KEY `speedup` (`regulatory_feature_id`,`has_matching_Peak`,`motif_feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `object_xref` (
@@ -490,7 +491,8 @@ CREATE TABLE `peak` (
   `summit` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (`peak_id`),
   UNIQUE KEY `seq_region_feature_set_idx` (`seq_region_id`,`seq_region_start`,`peak_calling_id`),
-  KEY `feature_set_idx` (`peak_calling_id`)
+  KEY `feature_set_idx` (`peak_calling_id`),
+  KEY `peak_track` (`peak_calling_id`,`seq_region_id`,`seq_region_start`,`seq_region_end`,`score`,`seq_region_strand`,`summit`,`peak_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=69669956 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=39;
 
 CREATE TABLE `peak_calling` (


### PR DESCRIPTION
### Description

These changes update Funcgen test database with patches for:
 - Schema change for release 106.
-  Add indexes to `peak` and `motif_feature_regulatory_feature` tables.

### Use case

 - Version-bump schema change for 106.
-  New indexes tackle performance issues with bigWig tracks.

### Testing
 Failing tests in `t/archive.t`. They don't seem to be related to changes in this PR. 
Same failing tests were reported in #497, #496.
