### PR TITLE
Update spliceai input file

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -165,9 +165,10 @@
         default=0
       </MaxEntScan>
       <SpliceAI>
-        type=Boolean
-        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>)
+        type=Integer
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
         default=0
+        example=2
       </SpliceAI>
       <miRNA>
         type=Boolean
@@ -393,9 +394,10 @@
         default=0
       </MaxEntScan>
       <SpliceAI>
-        type=Boolean
-        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>)
+        type=Integer
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
         default=0
+        example=2
       </SpliceAI>
       <miRNA>
         type=Boolean
@@ -608,9 +610,10 @@
         default=0
       </MaxEntScan>
       <SpliceAI>
-        type=Boolean
-        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>)
+        type=Integer
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
         default=0
+        example=2
       </SpliceAI>
       <miRNA>
         type=Boolean
@@ -818,9 +821,10 @@
         default=0
       </MaxEntScan>
       <SpliceAI>
-        type=Boolean
-        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>)
+        type=Integer
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
         default=0
+        example=2
       </SpliceAI>
       <miRNA>
         type=Boolean
@@ -1034,9 +1038,10 @@
         default=0
       </MaxEntScan>
       <SpliceAI>
-        type=Boolean
-        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>)
+        type=Integer
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
         default=0
+        example=2
       </SpliceAI>
       <miRNA>
         type=Boolean
@@ -1258,9 +1263,10 @@
         default=0
       </MaxEntScan>
       <SpliceAI>
-        type=Boolean
-        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>)
+        type=Integer
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
         default=0
+        example=2
       </SpliceAI>
       <miRNA>
         type=Boolean


### PR DESCRIPTION
### Description

Same as https://github.com/Ensembl/ensembl-rest/pull/501 
Add option to SpliceAI plugin: allow users to select a different snv input file.

### Use case

Currently, the annotation scores are only retrieved from the Spliceai Illumina file. We want users to have the option to retrieve scores from the Ensembl MANE transcripts annotation file (SNV only).

### Benefits

The Ensembl MANE transcript scores will be available to users.

### Possible Drawbacks

None

### Testing

_Have you added/modified unit tests to test the changes?_
No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
No regression detected

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._
eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians

Added the option to select SpliceAI annotation scores from Ensembl MANE transcripts (SNV only)
[vep/:species/hgvs/:hgvs_notation]
[vep/:species/id/:id]
[vep/:species/region/:region/:allele/]
