### PR TITLE
Add Carp::Clan requirement to cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -33,6 +33,7 @@ requires 'DBD::SQLite';
 requires 'List::MoreUtils';
 requires 'Try::Tiny';
 requires 'Starman';
+requires 'Carp::Clan';
 
 # Transient dependencies from Ensembl
 requires 'Parse::RecDescent';


### PR DESCRIPTION
### Description

Carp::Clan has been used in ReurnErrors.pm since at least 104 but wasn't in cpanfile. It seems something used to pull in that dependency transitively for some other purpose so the problem wsan't seen, but now it doesn't (presumably a 3rd-party change in the dependency tree for a package we use), so that dependency needs to be in cpanfile for the server to start up.

This PR is a prerequisite for the 105 test sites being brought up.

### Use case

Try to start the server via ansible on release/105, it doesn't start, with an error to sdterr about Carp::Clan being missing.

### Benefits

The server can be deployed working with this configuration, but not without it.

### Possible Drawbacks

None foreseen.

### Testing

I have run the ansible deploy for the rest server both with this change and without, using this branch on my own repo, and confirmed the claims above.

### Changelog

No changes needed.
