### PR TITLE
Add Carp::Clan requirement to cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -33,6 +33,7 @@ requires 'DBD::SQLite';
 requires 'List::MoreUtils';
 requires 'Try::Tiny';
 requires 'Starman';
+requires 'Carp::Clan';
 
 # Transient dependencies from Ensembl
 requires 'Parse::RecDescent';


### PR DESCRIPTION
### Description

Carp::Clan has been used in ReurnErrors.pm since at least 104 but wasn't in cpanfile. It seems something used to pull in that dependency transitively for some other purpose so the problem wsan't seen, but now it doesn't (presumably a 3rd-party change in the dependency tree for a package we use), so that dependency needs to be in cpanfile for the server to start up.

This PR is to align 'master', as per [PR #507](https://github.com/Ensembl/ensembl-rest/pull/507)

### Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

### Benefits

Please, see #507 

### Possible Drawbacks

None

### Testing

No changes

### Changelog

N/A
