### PR TITLE
Increase gene_tree_root.clusterset_id column length

### DIFF
--- a/t/test-genome-DBs/homology/compara/meta.txt
+++ b/t/test-genome-DBs/homology/compara/meta.txt
@@ -75,3 +75,4 @@
 100	\N	patch	patch_104_105_a.sql|schema_version
 101	\N	patch	patch_104_105_b.sql|genebuild_varchar255
 103	\N	patch	patch_105_106_a.sql|schema_version
+104	\N	patch	patch_105_106_b.sql|clusterset_id_varchar50

--- a/t/test-genome-DBs/homology/compara/table.sql
+++ b/t/test-genome-DBs/homology/compara/table.sql
@@ -231,7 +231,7 @@ CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
   `member_type` enum('protein','ncrna') NOT NULL,
   `tree_type` enum('clusterset','supertree','tree') NOT NULL,
-  `clusterset_id` varchar(20) NOT NULL DEFAULT 'default',
+  `clusterset_id` varchar(50) NOT NULL DEFAULT 'default',
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   `species_tree_root_id` bigint(20) unsigned DEFAULT NULL,
   `gene_align_id` int(10) unsigned DEFAULT NULL,
@@ -436,7 +436,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=104 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=105 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/t/test-genome-DBs/multi/compara/meta.txt
+++ b/t/test-genome-DBs/multi/compara/meta.txt
@@ -119,3 +119,4 @@
 145	\N	patch	patch_104_105_a.sql|schema_version
 146	\N	patch	patch_104_105_b.sql|genebuild_varchar255
 148	\N	patch	patch_105_106_a.sql|schema_version
+149	\N	patch	patch_105_106_b.sql|clusterset_id_varchar50

--- a/t/test-genome-DBs/multi/compara/table.sql
+++ b/t/test-genome-DBs/multi/compara/table.sql
@@ -231,7 +231,7 @@ CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
   `member_type` enum('protein','ncrna') NOT NULL,
   `tree_type` enum('clusterset','supertree','tree') NOT NULL,
-  `clusterset_id` varchar(20) NOT NULL DEFAULT 'default',
+  `clusterset_id` varchar(50) NOT NULL DEFAULT 'default',
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   `species_tree_root_id` bigint(20) unsigned DEFAULT NULL,
   `gene_align_id` int(10) unsigned DEFAULT NULL,
@@ -436,7 +436,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=149 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=150 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
### Description

Compara has included wheat cultivars protein trees in e106 and this has flagged a requirement to increase the column of one of our tables.

### Testing

This patch has been successfully applied to all Compara production pipelines and databases in e106 without raising any incompatibilities or issues.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._
No
