### PR TITLE
Increase gene_tree_root.clusterset_id column size

### DIFF
--- a/t/test-genome-DBs/homology/compara/meta.txt
+++ b/t/test-genome-DBs/homology/compara/meta.txt
@@ -76,3 +76,4 @@
 101	\N	patch	patch_104_105_b.sql|genebuild_varchar255
 103	\N	patch	patch_105_106_a.sql|schema_version
 105	\N	patch	patch_106_107_a.sql|schema_version
+106	\N	patch	patch_105_106_b.sql|clusterset_id_varchar50

--- a/t/test-genome-DBs/homology/compara/table.sql
+++ b/t/test-genome-DBs/homology/compara/table.sql
@@ -231,7 +231,7 @@ CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
   `member_type` enum('protein','ncrna') NOT NULL,
   `tree_type` enum('clusterset','supertree','tree') NOT NULL,
-  `clusterset_id` varchar(20) NOT NULL DEFAULT 'default',
+  `clusterset_id` varchar(50) NOT NULL DEFAULT 'default',
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   `species_tree_root_id` bigint(20) unsigned DEFAULT NULL,
   `gene_align_id` int(10) unsigned DEFAULT NULL,
@@ -436,7 +436,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=106 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=107 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/t/test-genome-DBs/multi/compara/meta.txt
+++ b/t/test-genome-DBs/multi/compara/meta.txt
@@ -120,3 +120,4 @@
 146	\N	patch	patch_104_105_b.sql|genebuild_varchar255
 148	\N	patch	patch_105_106_a.sql|schema_version
 150	\N	patch	patch_106_107_a.sql|schema_version
+151	\N	patch	patch_105_106_b.sql|clusterset_id_varchar50

--- a/t/test-genome-DBs/multi/compara/table.sql
+++ b/t/test-genome-DBs/multi/compara/table.sql
@@ -231,7 +231,7 @@ CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
   `member_type` enum('protein','ncrna') NOT NULL,
   `tree_type` enum('clusterset','supertree','tree') NOT NULL,
-  `clusterset_id` varchar(20) NOT NULL DEFAULT 'default',
+  `clusterset_id` varchar(50) NOT NULL DEFAULT 'default',
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   `species_tree_root_id` bigint(20) unsigned DEFAULT NULL,
   `gene_align_id` int(10) unsigned DEFAULT NULL,
@@ -436,7 +436,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=151 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=152 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
### Description

Compara has included wheat cultivars protein trees in e106 and this has flagged a requirement to increase the column of one of our tables.

It is the same of PR 512 to be merged against "master".

### Testing

On Codon, two tests (2 and 6) from gafeatures.t fail because the value for "updated" and "created" features attributes "2008-04-29 11:17:41" is converted to epoch "1209464261" instead of the expected "1209467861".
We are not changing test data because of Travis automatic build/test.

Also on Codon, there are ld.t tests failing because of ld_vcf (in ensembl-variation repo) segfaulting. This is an issue resolved by https://github.com/Ensembl/ensembl-variation/pull/770

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._
No
