### PR TITLE
Added git-ensembl to manage renaming of master branch in repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,13 @@ before_install:
     - export SECONDARY_BRANCH='main'
     - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; export SECONDARY_BRANCH=$TRAVIS_BRANCH; fi
     - echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"
-    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-test
-    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl
-    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-compara
-    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-variation
-    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-vep
-    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-funcgen
-    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-io
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH ensembl-test
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH ensembl
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH ensembl-compara
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH ensembl-variation
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH ensembl-vep
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH ensembl-funcgen
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH ensembl-io
     - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
     - git clone --branch 1.3.2 --depth 1 https://github.com/samtools/htslib.git
     - cd htslib

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,17 +28,20 @@ matrix:
     env: COVERALLS=true
 
 before_install:
+    - git clone --depth 1 https://github.com/Ensembl/ensembl-git-tools.git
+    - export PATH=$PWD/ensembl-git-tools/bin:$PATH
     - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
     - export ENSEMBL_BRANCH='master'
-    - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; fi
+    - export SECONDARY_BRANCH='main'
+    - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; export SECONDARY_BRANCH=$TRAVIS_BRANCH; fi
     - echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-compara.git
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-variation.git
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-vep.git
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-io.git
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-test
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-compara
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-variation
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-vep
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-funcgen
+    - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-io
     - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
     - git clone --branch 1.3.2 --depth 1 https://github.com/samtools/htslib.git
     - cd htslib


### PR DESCRIPTION
### Description

Travis build is broken because of some EnsEMBL repos renamed their "master" branch.
Updating Travis settings to fix it.

### Use case

See above

### Benefits

Restore Travis CI

### Possible Drawbacks

Not having Travis CI working anymore

### Testing

No

### Changelog

N/A
