### PR TITLE
New VEP plugin UTRannotator (e107)

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -180,6 +180,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRannotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://github.com/ImperialCardioGenetics/UTRannotator/blob/master/README.md">README</a> for more details.
+        default=0
+      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -409,6 +414,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRannotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://github.com/ImperialCardioGenetics/UTRannotator/blob/master/README.md">README</a> for more details.
+        default=0
+      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -625,6 +635,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRannotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://github.com/ImperialCardioGenetics/UTRannotator/blob/master/README.md">README</a> for more details.
+        default=0
+      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -836,6 +851,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRannotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://github.com/ImperialCardioGenetics/UTRannotator/blob/master/README.md">README</a> for more details.
+        default=0
+      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -1053,6 +1073,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRannotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://github.com/ImperialCardioGenetics/UTRannotator/blob/master/README.md">README</a> for more details.
+        default=0
+      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -1278,6 +1303,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRannotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://github.com/ImperialCardioGenetics/UTRannotator/blob/master/README.md">README</a> for more details.
+        default=0
+      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences


### PR DESCRIPTION
### Description

The VEP endpoint will have the external plugin UTRannotator available. This documentation is needed for the plugin.

### Use case

Plugin functionality available through REST.

### Benefits

The endpoint needs documentation to be displayed.

### Possible Drawbacks

None, the default behavior is the same.

### Testing

note to submitters and reviewers: documentation-only changes may reflect
changes in other repos that can result in new or different output from
REST endpoints. In turn, these may require new tests or changes to existing tests.

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
No regression was detected.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians
[/vep/:species/hgvs/] new plugin option added: UTRannotator
[/vep/:species/id/] new plugin option added: UTRannotator
[/vep/:species/region/] new plugin option added: UTRannotator
