### PR TITLE
New VEP plugin IntAct (e107)

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -156,7 +156,7 @@
       </GeneSplicer>
       <IntAct>
         type=Boolean
-        description=Provides molecular interaction data for variants as reprted by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
       <SpliceRegion>
         type=Boolean
@@ -394,7 +394,7 @@
       </GeneSplicer>
       <IntAct>
         type=Boolean
-        description=Provides molecular interaction data for variants as reprted by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
       <SpliceRegion>
         type=Boolean
@@ -619,7 +619,7 @@
       </GeneSplicer>
       <IntAct>
         type=Boolean
-        description=Provides molecular interaction data for variants as reprted by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
       <SpliceRegion>
         type=Boolean
@@ -839,7 +839,7 @@
       </GeneSplicer>
       <IntAct>
         type=Boolean
-        description=Provides molecular interaction data for variants as reprted by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
       <SpliceRegion>
         type=Boolean
@@ -1065,7 +1065,7 @@
       </GeneSplicer>
       <IntAct>
         type=Boolean
-        description=Provides molecular interaction data for variants as reprted by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
       <SpliceRegion>
         type=Boolean
@@ -1299,7 +1299,7 @@
       </GeneSplicer>
       <IntAct>
         type=Boolean
-        description=Provides molecular interaction data for variants as reprted by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
       <SpliceRegion>
         type=Boolean

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -154,6 +154,10 @@
         description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/GeneSplicer.pm">plugin details</a>)
         default=0
       </GeneSplicer>
+      <IntAct>
+        type=Boolean
+        description=Provides molecular interaction data for variants as reprted by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+      </IntAct>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -388,6 +392,10 @@
         description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/GeneSplicer.pm">plugin details</a>)
         default=0
       </GeneSplicer>
+      <IntAct>
+        type=Boolean
+        description=Provides molecular interaction data for variants as reprted by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+      </IntAct>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -609,6 +617,10 @@
         description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/GeneSplicer.pm">plugin details</a>)
         default=0
       </GeneSplicer>
+      <IntAct>
+        type=Boolean
+        description=Provides molecular interaction data for variants as reprted by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+      </IntAct>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -825,6 +837,10 @@
         description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/GeneSplicer.pm">plugin details</a>)
         default=0
       </GeneSplicer>
+      <IntAct>
+        type=Boolean
+        description=Provides molecular interaction data for variants as reprted by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+      </IntAct>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -1047,6 +1063,10 @@
         description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/GeneSplicer.pm">plugin details</a>)
         default=0
       </GeneSplicer>
+      <IntAct>
+        type=Boolean
+        description=Provides molecular interaction data for variants as reprted by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+      </IntAct>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -1277,6 +1297,10 @@
         description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/GeneSplicer.pm">plugin details</a>)
         default=0
       </GeneSplicer>
+      <IntAct>
+        type=Boolean
+        description=Provides molecular interaction data for variants as reprted by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+      </IntAct>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)


### PR DESCRIPTION
### Description

The VEP endpoint will have the external plugin IntAct available. This documentation is needed for the plugin.

### Use case

Plugin functionality available through REST.

### Benefits

The endpoint needs documentation to be displayed.

### Possible Drawbacks

None, the default behavior is the same.

### Testing

note to submitters and reviewers: documentation-only changes may reflect
changes in other repos that can result in new or different output from
REST endpoints. In turn, these may require new tests or changes to existing tests.

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians
[/vep/:species/hgvs/] new plugin option added: IntAct
[/vep/:species/id/] new plugin option added: IntAct
[/vep/:species/region/] new plugin option added: IntAct