### PR TITLE
Add AncestralAllele docs

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -128,6 +128,11 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
+      <AncestralAllele>
+        type=Boolean
+        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
+        default=0
+      </AncestralAllele>
       <Blosum62>
         type=Boolean
         description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
@@ -371,6 +376,11 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
+      <AncestralAllele>
+        type=Boolean
+        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
+        default=0
+      </AncestralAllele>
       <Blosum62>
         type=Boolean
         description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
@@ -591,6 +601,11 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
+      <AncestralAllele>
+        type=Boolean
+        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
+        default=0
+      </AncestralAllele>
       <Blosum62>
         type=Boolean
         description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
@@ -816,6 +831,11 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
+      <AncestralAllele>
+        type=Boolean
+        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
+        default=0
+      </AncestralAllele>
       <Blosum62>
         type=Boolean
         description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
@@ -1037,6 +1057,11 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
+      <AncestralAllele>
+        type=Boolean
+        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
+        default=0
+      </AncestralAllele>
       <Blosum62>
         type=Boolean
         description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
@@ -1276,6 +1301,11 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
+      <AncestralAllele>
+        type=Boolean
+        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
+        default=0
+      </AncestralAllele>
       <Blosum62>
         type=Boolean
         description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)


### PR DESCRIPTION
### Description

The VEP endpoint uses the external plugin AncestralAllele that is already available in REST. This documentation is needed for the plugin. @dglemos

### Use case

Documentation of VEP plugin available through REST.

### Benefits

The endpoint needs documentation to be displayed.

### Possible Drawbacks

None, the default behavior is the same.

### Testing

Tested by running [ensembl_rest_server.pl](https://github.com/Ensembl/ensembl-rest/blob/release/105/script/ensembl_rest_server.pl). Documentation shows as expected.

### Changelog

[/vep/:species/hgvs/] plugin option available: AncestralAllele
[/vep/:species/id/] plugin option available: AncestralAllele
[/vep/:species/region/] plugin option available: AncestralAllele