### PR TITLE
Patch test-dbs for compara case insensitive stable_id schema alteration

### DIFF
--- a/t/test-genome-DBs/homology/compara/meta.txt
+++ b/t/test-genome-DBs/homology/compara/meta.txt
@@ -77,3 +77,4 @@
 103	\N	patch	patch_105_106_a.sql|schema_version
 105	\N	patch	patch_106_107_a.sql|schema_version
 106	\N	patch	patch_105_106_b.sql|clusterset_id_varchar50
+107	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id

--- a/t/test-genome-DBs/homology/compara/table.sql
+++ b/t/test-genome-DBs/homology/compara/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -176,7 +176,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) NOT NULL,
+  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -436,7 +436,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=107 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=108 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -540,7 +540,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,

--- a/t/test-genome-DBs/multi/compara/meta.txt
+++ b/t/test-genome-DBs/multi/compara/meta.txt
@@ -121,3 +121,4 @@
 148	\N	patch	patch_105_106_a.sql|schema_version
 150	\N	patch	patch_106_107_a.sql|schema_version
 151	\N	patch	patch_105_106_b.sql|clusterset_id_varchar50
+152	\N	patch	patch_106_107_b.sql|case_sensitive_stable_id

--- a/t/test-genome-DBs/multi/compara/table.sql
+++ b/t/test-genome-DBs/multi/compara/table.sql
@@ -138,7 +138,7 @@ CREATE TABLE `gene_align_member` (
 
 CREATE TABLE `gene_member` (
   `gene_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLGENE','EXTERNALGENE') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,
@@ -176,7 +176,7 @@ CREATE TABLE `gene_member_hom_stats` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_member_qc` (
-  `gene_member_stable_id` varchar(128) NOT NULL,
+  `gene_member_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `genome_db_id` int(10) unsigned NOT NULL,
   `seq_member_id` int(10) unsigned DEFAULT NULL,
   `n_species` int(11) DEFAULT NULL,
@@ -436,7 +436,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=152 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=153 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -540,7 +540,7 @@ CREATE TABLE `peptide_align_feature` (
 
 CREATE TABLE `seq_member` (
   `seq_member_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `stable_id` varchar(128) NOT NULL,
+  `stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `version` int(10) unsigned DEFAULT '0',
   `source_name` enum('ENSEMBLPEP','ENSEMBLTRANS','Uniprot/SPTREMBL','Uniprot/SWISSPROT','EXTERNALPEP','EXTERNALTRANS','EXTERNALCDS') NOT NULL,
   `taxon_id` int(10) unsigned NOT NULL,


### PR DESCRIPTION
### Description

_In e107 Metazoa compara revealed an issue in that the schema expected entirely `UNIQUE` `stable_id` across all genomes. This cannot be the case because divisions such as Metazoa have external annotations and `UNIQUE` `stable_id` is not enforced, not expected._

### Use case

_The compara schema and API is too tied in with a `UNIQUE` enforcement and may require a larger change later on. For now, changing the case sensitivity is a passable compromise to get compara through e107. (The conflicting `stable-ids` remain unique when case is taken into account)._

### Benefits

_This small change allows the compara schema and API to remain largely unchanged, whilst allowing through the current e107 dataset._

### Possible Drawbacks

_There are no consequences, bar the fact that future conflicts may require a larger and more complex change. This is enough for now._

### Testing

note to submitters and reviewers: documentation-only changes may reflect
changes in other repos that can result in new or different output from
REST endpoints. In turn, these may require new tests or changes to existing tests.

_Have you added/modified unit tests to test the changes?_ NA

_If so, do the tests pass/fail?_ NA

_Have you run the entire test suite and no regression was detected?_  :heavy_check_mark:

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

NA
