### PR TITLE
feat: Add VEP Plugin - EVE

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -224,6 +224,11 @@
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
         default=0
       </CADD>
+      <EVE>
+        type=Boolean
+        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
+        default=0
+      </EVE>
     </params>
     <examples>
       <a>
@@ -467,6 +472,11 @@
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
         default=0
       </CADD>
+      <EVE>
+        type=Boolean
+        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
+        default=0
+      </EVE>
     </params>
     postformat={ "variants": array }
     <examples>
@@ -697,6 +707,11 @@
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
         default=0
       </CADD>
+      <EVE>
+        type=Boolean
+        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
+        default=0
+      </EVE>
     </params>
    <examples>
      <one>
@@ -922,6 +937,11 @@
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
         default=0
       </CADD>
+      <EVE>
+        type=Boolean
+        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
+        default=0
+      </EVE>
     </params>
     postformat={ "ids": array }
     <examples>
@@ -1153,6 +1173,11 @@
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
         default=0
       </CADD>
+      <EVE>
+        type=Boolean
+        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
+        default=0
+      </EVE>
     </params>
    <examples>
      <one>
@@ -1392,6 +1417,11 @@
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
         default=0
       </CADD>
+      <EVE>
+        type=Boolean
+        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
+        default=0
+      </EVE>
     </params>
     postformat={ "hgvs_notations": array }
     <examples>


### PR DESCRIPTION
### Description

The VEP endpoint will have the external plugin EVE available. This documentation is needed for the plugin.

### Use case

Plugin functionality available through REST.

### Benefits

The endpoint needs documentation to be displayed.

### Possible Drawbacks

None, the default behavior is the same.

### Testing

Documentation check only.

### Changelog

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians
[/vep/:species/hgvs/] new plugin option added: EVE
[/vep/:species/id/] new plugin option added: EVE
[/vep/:species/region/] new plugin option added: EVE
