### PR TITLE
Remove peak feature from overlap endpoints

### DIFF
--- a/lib/EnsEMBL/REST/Model/Overlap.pm
+++ b/lib/EnsEMBL/REST/Model/Overlap.pm
@@ -34,7 +34,7 @@ use Bio::EnsEMBL::Utils::Scalar qw/wrap_array/;
 
 has 'allowed_features' => ( isa => 'HashRef', is => 'ro', lazy => 1, default => sub {
   return {
-    map { $_ => 1 } qw/gene transcript cds exon repeat simple misc variation somatic_variation structural_variation somatic_structural_variation constrained regulatory  motif peak array_probe other_regulatory band mane/
+    map { $_ => 1 } qw/gene transcript cds exon repeat simple misc variation somatic_variation structural_variation somatic_structural_variation constrained regulatory motif array_probe other_regulatory band mane/
   };
 });
 
@@ -408,14 +408,6 @@ sub regulatory {
   my $c          = $self->context();
   my $species    = $c->stash->{species};
   my $adaptor = $c->model('Registry')->get_adaptor($species, 'funcgen', 'RegulatoryFeature');
-  return $adaptor->fetch_all_by_Slice($slice);
-}
-
-sub peak {
-  my ($self, $slice) = @_;
-  my $c       = $self->context();
-  my $species = $c->stash->{species};
-  my $adaptor = $c->model('Registry')->get_adaptor($species, 'funcgen', 'Peak');
   return $adaptor->fetch_all_by_Slice($slice);
 }
 

--- a/root/documentation/overlap.conf
+++ b/root/documentation/overlap.conf
@@ -31,7 +31,7 @@
         default=core
       </db_type>
       <feature>
-        type=Enum(band, gene, transcript, cds, exon, repeat, simple, misc, variation, somatic_variation, structural_variation, somatic_structural_variation, constrained, regulatory, motif, peak, other_regulatory, array_probe, mane)
+        type=Enum(band, gene, transcript, cds, exon, repeat, simple, misc, variation, somatic_variation, structural_variation, somatic_structural_variation, constrained, regulatory, motif, other_regulatory, array_probe, mane)
         description=The type of feature to retrieve. Multiple values are accepted.
         default=none
         required=1
@@ -136,7 +136,7 @@
         example=core
       </db_type>
       <feature>
-        type=Enum(band, gene, transcript, cds, exon, repeat, simple, misc, variation, somatic_variation, structural_variation, somatic_structural_variation, constrained, regulatory,  motif, chipseq, array_probe, mane)
+        type=Enum(band, gene, transcript, cds, exon, repeat, simple, misc, variation, somatic_variation, structural_variation, somatic_structural_variation, constrained, regulatory, motif, other_regulatory, array_probe, mane)
         description=The type of feature to retrieve. Multiple values are accepted.
         default=none
         required=1

--- a/t/test-genome-DBs/homo_sapiens/funcgen/meta_coord.txt
+++ b/t/test-genome-DBs/homo_sapiens/funcgen/meta_coord.txt
@@ -1,5 +1,3 @@
-peak	2	160421
-peak	4	160421
 external_feature	2	8062
 external_feature	4	8062
 mirna_target_feature	2	29


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

In Regulation we are removing peaks from the funcgen DB from releas 108. The overlap/ and overlap/region endpoints accepted 'peak' as featureType parameter. In this PR we have removed all references to peaks in these endpoints. We have also update the documentation and the test files.

### Use case

From release 108 'peak' shouldn't be accepted as FeatureType parameter in the overlap/ and overlap/region endpoints.

### Benefits

---

### Possible Drawbacks

---

### Testing

Changes have been successfully tested locally.

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_


_Have you run the entire test suite and no regression was detected?_


### Changelog

As explained before.
From release 108 'peak' shouldn't be accepted as FeatureType parameter in the overlap/ and overlap/region endpoints.