### PR TITLE
Remove VEP plugin UTRannotator

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -189,11 +189,6 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
-      <UTRannotator>
-        type=Boolean
-        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://github.com/ImperialCardioGenetics/UTRannotator/blob/master/README.md">README</a> for more details.
-        default=0
-      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -442,11 +437,6 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
-      <UTRannotator>
-        type=Boolean
-        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://github.com/ImperialCardioGenetics/UTRannotator/blob/master/README.md">README</a> for more details.
-        default=0
-      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -682,11 +672,6 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
-      <UTRannotator>
-        type=Boolean
-        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://github.com/ImperialCardioGenetics/UTRannotator/blob/master/README.md">README</a> for more details.
-        default=0
-      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -917,11 +902,6 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
-      <UTRannotator>
-        type=Boolean
-        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://github.com/ImperialCardioGenetics/UTRannotator/blob/master/README.md">README</a> for more details.
-        default=0
-      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -1158,11 +1138,6 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
-      <UTRannotator>
-        type=Boolean
-        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://github.com/ImperialCardioGenetics/UTRannotator/blob/master/README.md">README</a> for more details.
-        default=0
-      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -1407,11 +1382,6 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
-      <UTRannotator>
-        type=Boolean
-        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://github.com/ImperialCardioGenetics/UTRannotator/blob/master/README.md">README</a> for more details.
-        default=0
-      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences


### PR DESCRIPTION
### Description

The VEP endpoint will not have the external plugin UTRannotator available.
This PR removes docs added in https://github.com/Ensembl/ensembl-rest/pull/517 

### Use case

Plugin functionality won't be available through REST.

### Benefits



### Possible Drawbacks

None

### Testing

note to submitters and reviewers: documentation-only changes may reflect
changes in other repos that can result in new or different output from
REST endpoints. In turn, these may require new tests or changes to existing tests.

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

Revert the functionality of: 
[/vep/:species/hgvs/] 
[/vep/:species/id/] 
[/vep/:species/region/] 
