### PR TITLE
New VEP plugin mutfunc (e108)

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -163,6 +163,11 @@
         type=Boolean
         description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
+      <mutfunc>
+        type=Boolean
+        description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
+	default=0
+      </mutfunc>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -411,6 +416,11 @@
         type=Boolean
         description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
+      <mutfunc>
+        type=Boolean
+        description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
+        default=0
+      </mutfunc>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -646,6 +656,11 @@
         type=Boolean
         description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
+      <mutfunc>
+        type=Boolean
+        description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
+        default=0
+      </mutfunc>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -876,6 +891,11 @@
         type=Boolean
         description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
+      <mutfunc>
+        type=Boolean
+        description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
+        default=0
+      </mutfunc>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -1112,6 +1132,11 @@
         type=Boolean
         description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
+      <mutfunc>
+        type=Boolean
+        description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
+        default=0
+      </mutfunc>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -1356,6 +1381,11 @@
         type=Boolean
         description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
+      <mutfunc>
+        type=Boolean
+        description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
+        default=0
+      </mutfunc>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)


### PR DESCRIPTION
### Description

We are adding new plugin for VEP. This PR add the documentation for that.

### Use case

Plugin functionality available through REST.

### Benefits

The endpoint needs documentation to be displayed.

### Possible Drawbacks

None, the default behavior is the same.
Should only be merged if https://github.com/Ensembl/ensembl-rest_private/pull/119 is merged

### Testing

Tested on sanbox.

### Changelog

[/vep/:species/hgvs/] new plugin option added: mutfunc
[/vep/:species/id/] new plugin option added: mutfunc
[/vep/:species/region/] new plugin option added: mutfunc
