### PR TITLE
Removing documentation spliceregion rest

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -168,11 +168,6 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
 	default=0
       </mutfunc>
-      <SpliceRegion>
-        type=Boolean
-        description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
-        default=0
-      </SpliceRegion>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
@@ -421,11 +416,6 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
-      <SpliceRegion>
-        type=Boolean
-        description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
-        default=0
-      </SpliceRegion>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
@@ -661,11 +651,6 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
-      <SpliceRegion>
-        type=Boolean
-        description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
-        default=0
-      </SpliceRegion>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
@@ -896,11 +881,6 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
-      <SpliceRegion>
-        type=Boolean
-        description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
-        default=0
-      </SpliceRegion>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
@@ -1137,11 +1117,6 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
-      <SpliceRegion>
-        type=Boolean
-        description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
-        default=0
-      </SpliceRegion>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
@@ -1386,11 +1361,6 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
-      <SpliceRegion>
-        type=Boolean
-        description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
-        default=0
-      </SpliceRegion>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)


### PR DESCRIPTION
## Description
Removing SpliceRegion VEP plugin from ensembl rest. As Splice region consequences is calculated by VEP by default
[ENSVAR-4922](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4922)
