### PR TITLE
Fix info test: new xref source

### DIFF
--- a/t/info.t
+++ b/t/info.t
@@ -173,7 +173,7 @@ is_json_GET(
 # /info/external_dbs/:species
 {
   my $external_dbs_json = json_GET('/info/external_dbs/homo_sapiens', 'Get the external dbs hash');
-  cmp_ok(scalar(@{$external_dbs_json}), '==', 510, 'Ensuring we have the right number of external_dbs available');
+  cmp_ok(scalar(@{$external_dbs_json}), '==', 511, 'Ensuring we have the right number of external_dbs available');
   my $expected = [{ name => 'GO', description => undef, release => undef, display_name => 'GO' }];
   is_json_GET('/info/external_dbs/homo_sapiens?filter=GO', $expected, 'Checking GO filtering works');
   my $xref_external_dbs_json = json_GET('info/external_dbs/homo_sapiens?feature=xref', 'Get the xref external dbs hash');


### PR DESCRIPTION
### Description

The `info.t` test counting the external DBs for Xref sources is failing, after updating the test DB for release 109.

### Use case

The number of DBs is hardcoded in `info.t` and it hasn't updated since the addition of a new DB source in Ensembl repo with PR#619.
As a result, the test suite is failing and likewise the automatic Travis build and related CI/CD pipeline.

Travis build for this PR is expected to fail, before test DBs are updated to 109.

### Benefits

Preserve full functionality of the test suite from release 109 on.

### Possible Drawbacks

None

### Testing

The only - and straightforward - modification is about the expected (hardcoded) number of external DBs in file `info.t`.
The test suite can now successfully run.

### Changelog

Public endpoints are not affected.
