### PR TITLE
Adding new VEP plugin NMD

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -168,11 +168,6 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
 	default=0
       </mutfunc>
-      <SpliceRegion>
-        type=Boolean
-        description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
-        default=0
-      </SpliceRegion>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
@@ -426,11 +421,6 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
-      <SpliceRegion>
-        type=Boolean
-        description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
-        default=0
-      </SpliceRegion>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
@@ -671,11 +661,6 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
-      <SpliceRegion>
-        type=Boolean
-        description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
-        default=0
-      </SpliceRegion>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
@@ -911,11 +896,6 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
-      <SpliceRegion>
-        type=Boolean
-        description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
-        default=0
-      </SpliceRegion>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
@@ -1157,11 +1137,6 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
-      <SpliceRegion>
-        type=Boolean
-        description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
-        default=0
-      </SpliceRegion>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
@@ -1411,11 +1386,6 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
-      <SpliceRegion>
-        type=Boolean
-        description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
-        default=0
-      </SpliceRegion>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -163,6 +163,11 @@
         type=Boolean
         description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
+      <mutfunc>
+        type=Boolean
+        description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
+	default=0
+      </mutfunc>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -173,6 +178,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <NMD>
+        type=Boolean
+        description=Predicts if a stop_gained variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        default=0
+      </NMD>
       <SpliceAI>
         type=Integer
         description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
@@ -411,6 +421,11 @@
         type=Boolean
         description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
+      <mutfunc>
+        type=Boolean
+        description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
+        default=0
+      </mutfunc>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -421,6 +436,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <NMD>
+        type=Boolean
+        description=Predicts if a stop_gained variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        default=0
+      </NMD>
       <SpliceAI>
         type=Integer
         description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
@@ -646,6 +666,11 @@
         type=Boolean
         description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
+      <mutfunc>
+        type=Boolean
+        description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
+        default=0
+      </mutfunc>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -656,6 +681,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <NMD>
+        type=Boolean
+        description=Predicts if a stop_gained variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        default=0
+      </NMD>
       <SpliceAI>
         type=Integer
         description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
@@ -876,6 +906,11 @@
         type=Boolean
         description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
+      <mutfunc>
+        type=Boolean
+        description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
+        default=0
+      </mutfunc>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -886,6 +921,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <NMD>
+        type=Boolean
+        description=Predicts if a stop_gained variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        default=0
+      </NMD>
       <SpliceAI>
         type=Integer
         description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
@@ -1112,6 +1152,11 @@
         type=Boolean
         description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
+      <mutfunc>
+        type=Boolean
+        description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
+        default=0
+      </mutfunc>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -1122,6 +1167,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <NMD>
+        type=Boolean
+        description=Predicts if a stop_gained variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        default=0
+      </NMD>
       <SpliceAI>
         type=Integer
         description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
@@ -1356,6 +1406,11 @@
         type=Boolean
         description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
       </IntAct>
+      <mutfunc>
+        type=Boolean
+        description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
+        default=0
+      </mutfunc>
       <SpliceRegion>
         type=Boolean
         description=More granular predictions of splicing effects (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceRegion.pm">plugin details</a>)
@@ -1366,6 +1421,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <NMD>
+        type=Boolean
+        description=Predicts if a stop_gained variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        default=0
+      </NMD>
       <SpliceAI>
         type=Integer
         description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -175,7 +175,7 @@
       </MaxEntScan>
       <NMD>
         type=Boolean
-        description=Predicts if a stop_gained variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
         default=0
       </NMD>
       <SpliceAI>
@@ -428,7 +428,7 @@
       </MaxEntScan>
       <NMD>
         type=Boolean
-        description=Predicts if a stop_gained variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
         default=0
       </NMD>
       <SpliceAI>
@@ -668,7 +668,7 @@
       </MaxEntScan>
       <NMD>
         type=Boolean
-        description=Predicts if a stop_gained variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
         default=0
       </NMD>
       <SpliceAI>
@@ -903,7 +903,7 @@
       </MaxEntScan>
       <NMD>
         type=Boolean
-        description=Predicts if a stop_gained variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
         default=0
       </NMD>
       <SpliceAI>
@@ -1144,7 +1144,7 @@
       </MaxEntScan>
       <NMD>
         type=Boolean
-        description=Predicts if a stop_gained variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
         default=0
       </NMD>
       <SpliceAI>
@@ -1393,7 +1393,7 @@
       </MaxEntScan>
       <NMD>
         type=Boolean
-        description=Predicts if a stop_gained variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
         default=0
       </NMD>
       <SpliceAI>


### PR DESCRIPTION
### Description

We are adding new plugin for VEP. This PR add the documentation for that.
This is for **Ensembl release e!109**

Use case
Plugin functionality available through REST.

Benefits
The endpoint needs documentation to be displayed.

Possible Drawbacks
None, the default behavior is the same.
Should only be merged if https://github.com/Ensembl/ensembl-rest_private/pull/124 is merged (have related configuration changes)
Should be merged after  https://github.com/Ensembl/ensembl-rest/pull/546 and https://github.com/Ensembl/ensembl-rest/pull/551 (change the same file - so incorporated those changes to avoid a merge conflict)

Testing
Tested on sanbox.

Changelog
[/vep/:species/hgvs/] new plugin option added: NMD
[/vep/:species/id/] new plugin option added: NMD
[/vep/:species/region/] new plugin option added: NMD