### PR TITLE
feat: add plugin UTRAnnotator to vep.conf (release 109)

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -196,7 +196,7 @@
       </LoF>
       <UTRannotator>
         type=Boolean
-        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">README</a> for more details.
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
         default=0
       </UTRannotator>
       <distance>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -1185,7 +1185,7 @@
       </LoF>
       <UTRannotator>
         type=Boolean
-        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">README</a> for more details.
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
         default=0
       </UTRannotator>
       <distance>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -454,7 +454,7 @@
       </LoF>
       <UTRannotator>
         type=Boolean
-        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">README</a> for more details.
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
         default=0
       </UTRannotator>
       <distance>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -194,11 +194,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
-      <UTRannotator>
+      <UTRAnnotator>
         type=Boolean
         description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
         default=0
-      </UTRannotator>
+      </UTRAnnotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -452,11 +452,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
-      <UTRannotator>
+      <UTRAnnotator>
         type=Boolean
         description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
         default=0
-      </UTRannotator>
+      </UTRAnnotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -697,11 +697,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
-      <UTRannotator>
+      <UTRAnnotator>
         type=Boolean
         description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
         default=0
-      </UTRannotator>
+      </UTRAnnotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -937,11 +937,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
-      <UTRannotator>
+      <UTRAnnotator>
         type=Boolean
         description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
         default=0
-      </UTRannotator>
+      </UTRAnnotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -1183,11 +1183,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
-      <UTRannotator>
+      <UTRAnnotator>
         type=Boolean
         description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
         default=0
-      </UTRannotator>
+      </UTRAnnotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -1437,11 +1437,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
-      <UTRannotator>
+      <UTRAnnotator>
         type=Boolean
         description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
         default=0
-      </UTRannotator>
+      </UTRAnnotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -939,7 +939,7 @@
       </LoF>
       <UTRannotator>
         type=Boolean
-        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">README</a> for more details.
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
         default=0
       </UTRannotator>
       <distance>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -1439,7 +1439,7 @@
       </LoF>
       <UTRannotator>
         type=Boolean
-        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">README</a> for more details.
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
         default=0
       </UTRannotator>
       <distance>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -194,6 +194,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRannotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">README</a> for more details.
+        default=0
+      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -447,6 +452,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRannotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">README</a> for more details.
+        default=0
+      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -687,6 +697,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRannotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">README</a> for more details.
+        default=0
+      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -922,6 +937,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRannotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">README</a> for more details.
+        default=0
+      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -1163,6 +1183,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRannotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">README</a> for more details.
+        default=0
+      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -1412,6 +1437,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRannotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">README</a> for more details.
+        default=0
+      </UTRannotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -699,7 +699,7 @@
       </LoF>
       <UTRannotator>
         type=Boolean
-        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs. See <a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">README</a> for more details.
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
         default=0
       </UTRannotator>
       <distance>


### PR DESCRIPTION
## Requirements
### Description

A new plugin was added to VEP_Plugins, UTRAnnotator. This is for Ensembl release e!109
Should be merged after https://github.com/Ensembl/ensembl-rest_private/pull/126 is merged.

### Use case
Plugin functionality available through REST.

### Benefits
None

### Possible Drawbacks
None

### Testing
Have you added/modified unit tests to test the changes?
Yes, I updated an old test.

If so, do the tests pass/fail?
Tests pass

Have you run the entire test suite and no regression was detected?
None detected

### Changelog
[/vep/:species/hgvs/] new plugin option added: UTRAnnotator
[/vep/:species/id/] new plugin option added: UTRAnnotator
[/vep/:species/region/] new plugin option added: UTRAnnotator