### PR TITLE
Update ftp links to https

### DIFF
--- a/lib/EnsEMBL/REST/Model/ga4gh/references.pm
+++ b/lib/EnsEMBL/REST/Model/ga4gh/references.pm
@@ -153,7 +153,7 @@ sub format_sequence{
      $ens_ver  = 75         if $seq->{assembly} =~/GRCh37/; 
      $seq->{assembly} =~ s/\.p13// if $seq->{assembly} =~/GRCh37/;
      ## over-write stored ftp location with current for GRCh38 site
-     $ref{sourceURI} =  'ftp://ftp.ensembl.org/pub/release-'. $ens_ver .'/fasta/homo_sapiens/dna/Homo_sapiens.'. $seq->{assembly} .'.dna.chromosome.' . $ref{name} . '.fa.gz'; 
+     $ref{sourceURI} =  'https://ftp.ensembl.org/pub/release-'. $ens_ver .'/fasta/homo_sapiens/dna/Homo_sapiens.'. $seq->{assembly} .'.dna.chromosome.' . $ref{name} . '.fa.gz'; 
      
   }
 

--- a/t/gareferences.t
+++ b/t/gareferences.t
@@ -69,7 +69,7 @@ my $expected_data_single =  {
       length => 51304566,
       sourceDivergence => undef,
       isDerived => "true",
-      sourceURI => "ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.22.fa.gz",
+      sourceURI => "https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.22.fa.gz",
       id => "a718acaa6135fdca8357d5bfe94211dd",
     },
   ],
@@ -90,7 +90,7 @@ my $expected_data2 =  {
         'NC_000011.9'                                    
       ],                                                 
       sourceDivergence => undef,                            
-      sourceURI => 'ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.11.fa.gz'
+      sourceURI => 'https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.11.fa.gz'
     },                                                    
     {                                                     
       id => '2979a6085bfe28e3ad6f552f361ed74d',           
@@ -104,7 +104,7 @@ my $expected_data2 =  {
         'NC_000021.8'                                     
       ],                                                  
       sourceDivergence => undef,                             
-      sourceURI => 'ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.21.fa.gz'
+      sourceURI => 'https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.21.fa.gz'
     } 
   ]
 };
@@ -124,7 +124,7 @@ my $expected_data3 =  {
         'NC_000007.13'                                                                                                 
       ],                                                                                                               
       sourceDivergence => undef,                                          
-      sourceURI => 'ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.7.fa.gz'
+      sourceURI => 'https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.7.fa.gz'
     },                                                                                                                 
     {                                                                                                                  
       id => '1fa3474750af0948bdf97d5a0ee52e51',                                                                        
@@ -138,7 +138,7 @@ my $expected_data3 =  {
         'NC_000024.9'                                                                                                  
       ],                                                                                                               
       sourceDivergence => undef,                                                                                          
-      sourceURI => 'ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.Y.fa.gz'  
+      sourceURI => 'https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.Y.fa.gz'  
     }                                                                                                                  
   ] 
 };
@@ -181,7 +181,7 @@ my $expected_get_data =  {
       length => 51304566,
       sourceDivergence => undef,
       isDerived => "true",
-      sourceURI => "ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.22.fa.gz",
+      sourceURI => "https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.22.fa.gz",
       id => "a718acaa6135fdca8357d5bfe94211dd",
 } ; 
 

--- a/t/gavariantset.t
+++ b/t/gavariantset.t
@@ -143,7 +143,7 @@ my $expected_data2 = {
          type => 'Integer'                                                               
        },                                                                                
        { info => {},                                                                     
-         description => 'Ancestral Allele, ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/pilot_data/technical/reference/ancestral_alignments/README',
+         description => 'Ancestral Allele, https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/pilot_data/technical/reference/ancestral_alignments/README',
          id => 'AA',                                                                     
          key => 'INFO',                                                                  
          number => '1',                                                                  
@@ -340,7 +340,7 @@ my $expected_get_data =  {
          type => 'Integer'                                                               
        },                                                                                
        { info => {},                                                                     
-         description => 'Ancestral Allele, ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/pilot_data/technical/reference/ancestral_alignments/README',
+         description => 'Ancestral Allele, https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/pilot_data/technical/reference/ancestral_alignments/README',
          id => 'AA',                                                                     
          key => 'INFO',                                                                  
          number => '1',                                                                  

--- a/t/test-genome-DBs/homo_sapiens/variation/study.txt
+++ b/t/test-genome-DBs/homo_sapiens/variation/study.txt
@@ -1,7 +1,7 @@
-4237	11	estd1	Redon 2006 "Global variation in copy number in the human genome." PMID:17122850 [remapped from build NCBI35]	ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd1_Redon_et_al_2006	pubmed/17122850	Control Set
-4246	11	estd55	Pinto 2007 "Copy-number variation in control population cohorts." PMID:17911159 [remapped from build NCBI35]	ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd55_Pinto_et_al_2007	pubmed/17911159	Control Set
-4247	11	estd59	1000 Genomes Project Consortium - Pilot Project. PMID:20981092 [remapped from build NCBI36]	ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd59_1000_Genomes_Consortium_Pilot_Project	pubmed/20981092	\N
-4478	11	estd194	Bentley 2008 "Accurate whole human genome sequencing using reversible terminator chemistry" PMID:18987734 [remapped from build NCBI36]	ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd194_Bentley_et_al_2008	pubmed/18987734	Control Set
-4479	11	estd195	Altshuler 2010 "Integrating common and rare genetic variation in diverse human populations" PMID:20811451 [remapped from build NCBI36]	ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd195_Altshuler_et_al_2010	pubmed/20811451	Control Set
+4237	11	estd1	Redon 2006 "Global variation in copy number in the human genome." PMID:17122850 [remapped from build NCBI35]	https://ftp.ebi.ac.uk/pub/databases/dgva/estd1_Redon_et_al_2006	pubmed/17122850	Control Set
+4246	11	estd55	Pinto 2007 "Copy-number variation in control population cohorts." PMID:17911159 [remapped from build NCBI35]	https://ftp.ebi.ac.uk/pub/databases/dgva/estd55_Pinto_et_al_2007	pubmed/17911159	Control Set
+4247	11	estd59	1000 Genomes Project Consortium - Pilot Project. PMID:20981092 [remapped from build NCBI36]	https://ftp.ebi.ac.uk/pub/databases/dgva/estd59_1000_Genomes_Consortium_Pilot_Project	pubmed/20981092	\N
+4478	11	estd194	Bentley 2008 "Accurate whole human genome sequencing using reversible terminator chemistry" PMID:18987734 [remapped from build NCBI36]	https://ftp.ebi.ac.uk/pub/databases/dgva/estd194_Bentley_et_al_2008	pubmed/18987734	Control Set
+4479	11	estd195	Altshuler 2010 "Integrating common and rare genetic variation in diverse human populations" PMID:20811451 [remapped from build NCBI36]	https://ftp.ebi.ac.uk/pub/databases/dgva/estd195_Altshuler_et_al_2010	pubmed/20811451	Control Set
 4480	52	NULL	NULL	NULL	PMID:8626802	NULL
-4465	11	estd192	Catalogue of Somatic Mutations in Cancer (COSMIC) version 61	ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd192_COSMIC http://cancer.sanger.ac.uk/cancergenome/projects/cosmic/	Somatic	\N
+4465	11	estd192	Catalogue of Somatic Mutations in Cancer (COSMIC) version 61	https://ftp.ebi.ac.uk/pub/databases/dgva/estd192_COSMIC http://cancer.sanger.ac.uk/cancergenome/projects/cosmic/	Somatic	\N

--- a/t/test-genome-DBs/multi/ontology/synonym.txt
+++ b/t/test-genome-DBs/multi/ontology/synonym.txt
@@ -2327,7 +2327,7 @@
 2327	1457	"codon_variant" []	\N
 2328	1458	"initiatior codon variant" []	\N
 2329	1458	"initiator codon change" []	\N
-2330	1459	"missense" [ftp://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
+2330	1459	"missense" [https://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
 2331	1459	"missense codon" []	\N
 2332	1459	"non synonymous codon" []	\N
 2333	1459	"non synonymous variant" []	\N
@@ -2338,12 +2338,12 @@
 2338	1460	"quiet missense codon" []	\N
 2339	1461	"non conservative missense codon" []	\N
 2340	1461	"non conservative missense variant" []	\N
-2341	1462	"nonsense" [ftp://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
+2341	1462	"nonsense" [https://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
 2342	1462	"nonsense codon" []	\N
 2343	1462	"stop codon gained" []	\N
 2344	1462	"stop gained" [http://ensembl.org/info/docs/variation/index.html]	\N
 2345	1463	"frameshift variant" []	\N
-2346	1463	"frameshift_" [ftp://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
+2346	1463	"frameshift_" [https://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
 2347	1463	"frameshift_coding" [http://ensembl.org/info/docs/variation/index.html]	\N
 2348	1464	"terminal codon variant" []	\N
 2349	1464	"terminal_codon_variant" []	\N
@@ -2392,15 +2392,15 @@
 2392	1497	"5'UTR variant" []	\N
 2393	1497	"5PRIME_UTR" [http://ensembl.org/info/docs/variation/index.html]	\N
 2394	1497	"five prime UTR variant" []	\N
-2395	1497	"untranslated-5" [ftp://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
+2395	1497	"untranslated-5" [https://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
 2396	1498	"3'UTR variant" []	\N
 2397	1498	"3PRIME_UTR" [http://ensembl.org/info/docs/variation/index.html]	\N
 2398	1498	"three prime UTR variant" []	\N
-2399	1498	"untranslated-3" [ftp://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
+2399	1498	"untranslated-3" [https://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
 2400	1499	"incomplete terminal codon variant" []	\N
 2401	1499	"partial_codon" [http://ensembl.org/info/docs/variation/index.html]	\N
 2402	1500	"intron variant" []	\N
-2403	1500	"intron_" [ftp://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
+2403	1500	"intron_" [https://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
 2404	1500	"intronic" [http://ensembl.org/info/docs/variation/index.html]	\N
 2405	1501	"intergenic" [http://ensembl.org/info/docs/variation/index.html]	\N
 2406	1501	"intergenic variant" []	\N
@@ -2413,11 +2413,11 @@
 2413	1506	"downstream" [http://ensembl.org/info/docs/variation/index.html]	\N
 2414	1506	"within 5KB downstream" []	\N
 2415	1507	"500B downstream variant" []	\N
-2416	1507	"near-gene-3" [ftp://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
+2416	1507	"near-gene-3" [https://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
 2417	1508	"5kb upstream variant" []	\N
 2418	1508	"upstream" [http://ensembl.org/info/docs/variation/index.html]	\N
 2419	1509	"2KB upstream variant" []	\N
-2420	1509	"near-gene-5" [ftp://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
+2420	1509	"near-gene-5" [https://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
 2421	1510	"rRNA gene" []	\N
 2422	1511	"piRNA gene" []	\N
 2423	1512	"RNase P RNA gene" []	\N
@@ -2649,7 +2649,7 @@
 2649	1684	"coding variant quality" []	\N
 2650	1686	"non synonymous" []	\N
 2651	1688	"protein altering variant" []	\N
-2652	1689	"coding-synon" [ftp://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
+2652	1689	"coding-synon" [https://ftp.ncbi.nih.gov/snp/specs/docsum_3.1.xsd]	\N
 2653	1689	"silent mutation" []	\N
 2654	1689	"silent substitution" []	\N
 2655	1689	"silent_mutation" []	\N

--- a/t/test-genome-DBs/testdata/ga_data/ga_references.json
+++ b/t/test-genome-DBs/testdata/ga_data/ga_references.json
@@ -4,7 +4,7 @@
       "name": "GRCh37",
       "md5":  "3812377a7767211e8f30e096f1615583",
       "sourceAccessions":["GCA_000001405.14"],
-      "sourceUri": "ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/",
+      "sourceUri": "https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/",
       "ncbiTaxonId": "9606",
       "isDerived":   "true",
       "sequences":[


### PR DESCRIPTION
This PR updates all ftp URLs to use https (to be compatible with web browsers).
The affected hostnames have been tested working with https.
Similar PRs in other repos are listed in the JIRA ticket.

Webteam JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6632
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680