### PR TITLE
UTRAnnotator VEP plugin

### DIFF
--- a/lib/EnsEMBL/REST.pm
+++ b/lib/EnsEMBL/REST.pm
@@ -64,7 +64,7 @@ use Catalyst qw/
 /;
 
 
-our $VERSION = '15.4';
+our $VERSION = '15.5';
 
 # Configure the application.
 #

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -194,6 +194,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRAnnotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
+        default=0
+      </UTRAnnotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -447,6 +452,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRAnnotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
+        default=0
+      </UTRAnnotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -687,6 +697,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRAnnotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
+        default=0
+      </UTRAnnotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -922,6 +937,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRAnnotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
+        default=0
+      </UTRAnnotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -1163,6 +1183,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRAnnotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
+        default=0
+      </UTRAnnotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences
@@ -1412,6 +1437,11 @@
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
         default=0
       </LoF>
+      <UTRAnnotator>
+        type=Boolean
+        description=Annotates high-impact five prime UTR variants either creating new upstream ORFs or disrupting existing upstream ORFs (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/UTRAnnotator.pm">plugin details</a>)
+        default=0
+      </UTRAnnotator>
       <distance>
         type=Integer
         description=Change the distance to transcript for which VEP assigns upstream and downstream consequences


### PR DESCRIPTION
### Description

A new plugin was added to VEP_Plugins, UTRAnnotator for Release 109.
Should be merged after https://github.com/Ensembl/ensembl-rest_private/pull/126 is merged.

This PR is sister to #559 

### Benefits

Provide docs for new VEP plugin 

### Possible Drawbacks

None

### Testing

Test are successful

### Changelog

[/vep/:species/hgvs/] new plugin option added: UTRAnnotator
[/vep/:species/id/] new plugin option added: UTRAnnotator
[/vep/:species/region/] new plugin option added: UTRAnnotator