### PR TITLE
Remove spurious "0" from info/data releases array response

### DIFF
--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -245,7 +245,9 @@ sub get_unique_schema_versions {
   my %hash;
   my $species_info = $self->_species_info();
   foreach my $species (@{$species_info}) {
-    $hash{$species->{release}} = 1;
+    if(defined $species->{release}) {
+      $hash{$species->{release}} = 1;
+    }
   }
   return [map { $_ *1 } keys %hash];
 }


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

Remove spurious "0" from info/data releases array response.

### Use case

info/data endpoint is returning "0" as part of the response because of duplication of meta table in two different bacteria dbs. Perl API modifies the species name by suffixing original name with a number but, other attributes such as release is undefined due to which rest server is considering the undefined release and returning "0" as part of releases array response.

### Benefits

info/data returns the correct response

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

### Testing

note to submitters and reviewers: documentation-only changes may reflect
changes in other repos that can result in new or different output from
REST endpoints. In turn, these may require new tests or changes to existing tests.

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

eg. [/info/data] Remove spurious "0" from info/data releases array response.
