### PR TITLE
Fixed invalid species bug when no compara division is specified

### DIFF
--- a/lib/EnsEMBL/REST/Controller/Homology.pm
+++ b/lib/EnsEMBL/REST/Controller/Homology.pm
@@ -72,7 +72,7 @@ sub fetch_by_ensembl_gene : Chained("/") PathPart("homology/id") Args(1)  {
   my ( $self, $c, $id ) = @_;
   my $lookup = $c->model('Lookup');
   my $species;
-  $species = $lookup->find_object_location($id);
+  ($species) = $lookup->find_object_location($id);
 
   if ( !$species ) {
     $c->go('ReturnError', 'from_ensembl', [qq{$_}]) if $_ =~ /STACK/;

--- a/t/homology.t
+++ b/t/homology.t
@@ -66,8 +66,7 @@ is_json_GET(
 );
 
 is_json_GET(
-    '/homology/id/ENSG00000139618?format=condensed;target_species=gorilla_gorilla;type=orthologues',
-    {data => []},
+    '/homology/id/ENSG00000139618?format=condensed;target_species=gorilla_gorilla;type=orthologues', {data => []},
     'homologies without compara division specified',
 );
 

--- a/t/homology.t
+++ b/t/homology.t
@@ -68,7 +68,7 @@ is_json_GET(
 is_json_GET(
     '/homology/id/ENSG00000139618?format=condensed;target_species=gorilla_gorilla;type=orthologues',
     {data => []},
-    '"homologies without compara specified',
+    'homologies without compara division specified',
 );
 
 is_json_GET(

--- a/t/homology.t
+++ b/t/homology.t
@@ -66,6 +66,12 @@ is_json_GET(
 );
 
 is_json_GET(
+    '/homology/id/ENSG00000139618?format=condensed;target_species=gorilla_gorilla;type=orthologues',
+    {data => []},
+    '"homologies without compara specified',
+);
+
+is_json_GET(
     '/homology/id/ENSG00000139618?compara=homology;format=condensed;target_taxon=9595;type=orthologues',
     _get_returned_json('ENSG00000139618', $condensed_ortho_ENSG00000139618_gorilla),
     '"condensed" homologies with a target single-species taxon',


### PR DESCRIPTION
### Requirements

### Description

On [line 75 of the Ensembl REST Homology controller module in release/109](https://github.com/Ensembl/ensembl-rest/blob/cf8457163df365ddb9a1a5259183773495da65e6/lib/EnsEMBL/REST/Controller/Homology.pm#L75), there is a method call to $lookup->find_object_location($id), where $id contains the Ensembl gene stable_id for which homologies are sought. The return value of this method call is an array — ($species, $object_type, $db_type) — where $species is the relevant species name. On [the corresponding line in release/108](https://github.com/Ensembl/ensembl-rest/blob/1cd1ae1a54c1de3a7e038f4d6b8813ad7fea7c63/lib/EnsEMBL/REST/Controller/Homology.pm#L74), the variable $species was in parentheses, which had the result that the variable was assigned the first value of the array returned by find_object_location. (i.e. $species). Without the parentheses, the return value will the length of the returned array and the query eventually fails with complaining about an invalid species.

This PR fixes this issue described in more detail in [this ticket](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6048).

### Use case

Bug fix.

### Testing

_Have you added/modified unit tests to test the changes?_

Added a unit test.

_If so, do the tests pass/fail?_

It did pass.

_Have you run the entire test suite and no regression was detected?_

No.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

Not changing functionality of endpoints.
