### PR TITLE
Update ga4gh ftp fasta

### DIFF
--- a/lib/EnsEMBL/REST/Model/ga4gh/references.pm
+++ b/lib/EnsEMBL/REST/Model/ga4gh/references.pm
@@ -105,7 +105,7 @@ sub extract_data{
     next if defined $post_data->{md5checksum} && $post_data->{md5checksum} ne '' 
                                               && $post_data->{md5checksum} ne $refseq->{md5};
 
-    next if defined $post_data->{accession}   && $post_data->{accession}   ne '' 
+    next if defined $post_data->{accession}   && $post_data->{accession}   ne ''
                                               && $post_data->{accession}   ne $refseq->{sourceAccessions}->[0]; 
 
     ## rough paging
@@ -150,11 +150,16 @@ sub format_sequence{
      $ref{sourceURI} = "https://github.com/ga4gh/compliance/blob/master/test-data/";
   }
   else{
-     $ens_ver  = 75         if $seq->{assembly} =~/GRCh37/; 
+     $ens_ver = 75 if $seq->{assembly} =~/GRCh37/;
      $seq->{assembly} =~ s/\.p13// if $seq->{assembly} =~/GRCh37/;
      ## over-write stored ftp location with current for GRCh38 site
-     $ref{sourceURI} =  'ftp://ftp.ensembl.org/pub/release-'. $ens_ver .'/fasta/homo_sapiens/dna/Homo_sapiens.'. $seq->{assembly} .'.dna.chromosome.' . $ref{name} . '.fa.gz'; 
-     
+     $ref{sourceURI} = 'https://ftp.ensembl.org/pub/release-'. $ens_ver .'/fasta/homo_sapiens/dna/Homo_sapiens.'. $seq->{assembly};
+      if($seq->{assembly} =~/GRCh37/) {
+        $ref{sourceURI} .= '.75.dna.chromosome.' . $ref{name} . '.fa.gz';
+      }
+      else {
+        $ref{sourceURI} .= '.dna.chromosome.' . $ref{name} . '.fa.gz';
+      }
   }
 
   return \%ref;

--- a/t/gareferences.t
+++ b/t/gareferences.t
@@ -69,7 +69,7 @@ my $expected_data_single =  {
       length => 51304566,
       sourceDivergence => undef,
       isDerived => "true",
-      sourceURI => "ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.22.fa.gz",
+      sourceURI => "https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.75.dna.chromosome.22.fa.gz",
       id => "a718acaa6135fdca8357d5bfe94211dd",
     },
   ],
@@ -90,7 +90,7 @@ my $expected_data2 =  {
         'NC_000011.9'                                    
       ],                                                 
       sourceDivergence => undef,                            
-      sourceURI => 'ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.11.fa.gz'
+      sourceURI => 'https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.75.dna.chromosome.11.fa.gz'
     },                                                    
     {                                                     
       id => '2979a6085bfe28e3ad6f552f361ed74d',           
@@ -104,7 +104,7 @@ my $expected_data2 =  {
         'NC_000021.8'                                     
       ],                                                  
       sourceDivergence => undef,                             
-      sourceURI => 'ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.21.fa.gz'
+      sourceURI => 'https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.75.dna.chromosome.21.fa.gz'
     } 
   ]
 };
@@ -124,7 +124,7 @@ my $expected_data3 =  {
         'NC_000007.13'                                                                                                 
       ],                                                                                                               
       sourceDivergence => undef,                                          
-      sourceURI => 'ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.7.fa.gz'
+      sourceURI => 'https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.75.dna.chromosome.7.fa.gz'
     },                                                                                                                 
     {                                                                                                                  
       id => '1fa3474750af0948bdf97d5a0ee52e51',                                                                        
@@ -138,7 +138,7 @@ my $expected_data3 =  {
         'NC_000024.9'                                                                                                  
       ],                                                                                                               
       sourceDivergence => undef,                                                                                          
-      sourceURI => 'ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.Y.fa.gz'  
+      sourceURI => 'https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.75.dna.chromosome.Y.fa.gz'
     }                                                                                                                  
   ] 
 };
@@ -181,7 +181,7 @@ my $expected_get_data =  {
       length => 51304566,
       sourceDivergence => undef,
       isDerived => "true",
-      sourceURI => "ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.22.fa.gz",
+      sourceURI => "https://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.75.dna.chromosome.22.fa.gz",
       id => "a718acaa6135fdca8357d5bfe94211dd",
 } ; 
 
@@ -203,4 +203,3 @@ eq_or_diff($json_seq_get, $expected_get_seq_data, "Checking the get bases result
 
 
 done_testing();
-


### PR DESCRIPTION
### Description

Update the ga4gh references endpoint to return the correct fasta file name and FTP location for GRCh37.


### Possible Drawbacks

None

### Testing

_Have you added/modified unit tests to test the changes?_
Yes

_If so, do the tests pass/fail?_
No

_Have you run the entire test suite and no regression was detected?_

### Changelog

[/ga4gh/references] Updated the sourceURI for human GRCh37
