### PR TITLE
VEP P/U miRNA deprecation

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -71,6 +71,7 @@ has valid_user_params => (
     mane
     shift_3prime
     shift_genomic
+    mirna
 
     pick
     pick_allele

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -184,11 +184,11 @@
         default=0
         example=2
       </SpliceAI>
-      <miRNA>
+      <mirna>
         type=Boolean
-        description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
+        description=Determines where in the secondary structure of a miRNA a variant falls
         default=0
-      </miRNA>
+      </mirna>
       <LoF>
         type=Boolean
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
@@ -442,11 +442,11 @@
         default=0
         example=2
       </SpliceAI>
-      <miRNA>
+      <mirna>
         type=Boolean
-        description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
+        description=Determines where in the secondary structure of a miRNA a variant falls
         default=0
-      </miRNA>
+      </mirna>
       <LoF>
         type=Boolean
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
@@ -687,11 +687,11 @@
         default=0
         example=2
       </SpliceAI>
-      <miRNA>
+      <mirna>
         type=Boolean
-        description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
+        description=Determines where in the secondary structure of a miRNA a variant falls
         default=0
-      </miRNA>
+      </mirna>
       <LoF>
         type=Boolean
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
@@ -927,11 +927,11 @@
         default=0
         example=2
       </SpliceAI>
-      <miRNA>
+      <mirna>
         type=Boolean
-        description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
+        description=Determines where in the secondary structure of a miRNA a variant falls
         default=0
-      </miRNA>
+      </mirna>
       <LoF>
         type=Boolean
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
@@ -1173,11 +1173,11 @@
         default=0
         example=2
       </SpliceAI>
-      <miRNA>
+      <mirna>
         type=Boolean
-        description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
+        description=Determines where in the secondary structure of a miRNA a variant falls
         default=0
-      </miRNA>
+      </mirna>
       <LoF>
         type=Boolean
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.
@@ -1427,11 +1427,11 @@
         default=0
         example=2
       </SpliceAI>
-      <miRNA>
+      <mirna>
         type=Boolean
-        description=Determines where in the secondary structure of a miRNA a variant falls (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/miRNA.pm">plugin details</a>)
+        description=Determines where in the secondary structure of a miRNA a variant falls
         default=0
-      </miRNA>
+      </mirna>
       <LoF>
         type=Boolean
         description=LOFTEE identifies LoF (loss-of-function) variation. See <a target="_blank" href="https://github.com/konradjk/loftee/blob/master/README.md">README</a> for more details.


### PR DESCRIPTION
### Description

Sister PR to #568 . This one for `main`.

[ENSVAR-5227](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5227): The miRNA plugin is being deprecated, as that logic was integrated into VEP via the `--mirna` flag. This PR updates REST to conform to VEP's usage.

Note that in REST, `miRNA` should now be `mirna` (lowercase) to properly enable the argument in VEP.

### Use case

Example: `/vep/human/id/rs569478349?content-type=application/json&mirna=1`

### Benefits

Updates miRNA usage to reflect changes in VEP.

### Possible Drawbacks

No drawbacks.

### Testing

The existing unit tests were run and work as expected. No new unit tests were added (I tried adding a test for miRNA flag in rs569478349).

You can test REST in my sandbox, for instance, [rs569478349](http://wp-np2-11.ebi.ac.uk:9301/vep/human/id/rs569478349?content-type=application/json&mirna=1) should show a `miRNA_stem` structure as a consequence in miRNA ENST00000577608:

```
        "mirna": [
          "miRNA_stem"
        ],
```

### Changelog

[/vep] Deprecated miRNA plugin in favour of the flag in VEP. Please note that the argument must now be set in lowercase (`mirna`).