### PR TITLE
Add support for `--ga4gh_vrs` flag in VEP and VR (110)

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -72,6 +72,8 @@ has valid_user_params => (
     shift_3prime
     shift_genomic
 
+    ga4gh_vrs
+
     pick
     pick_allele
     per_gene

--- a/lib/EnsEMBL/REST/Controller/VariantRecoder.pm
+++ b/lib/EnsEMBL/REST/Controller/VariantRecoder.pm
@@ -49,6 +49,8 @@ has valid_user_params => (
     vcf_string
     var_synonyms
 
+    ga4gh_vrs
+
     pick
     pick_allele
     per_gene

--- a/root/documentation/variation.conf
+++ b/root/documentation/variation.conf
@@ -191,7 +191,7 @@
       </var_synonyms>
       <ga4gh_vrs>
         type=Boolean
-        description=Adds the GA4GH VRS allele object
+        description=Add GA4GH Variation Representation Specification (VRS) notation
         default=0
       </ga4gh_vrs>
     </params>
@@ -245,7 +245,7 @@
       </var_synonyms>
       <ga4gh_vrs>
         type=Boolean
-        description=Adds the GA4GH VRS allele object
+        description=Add GA4GH Variation Representation Specification (VRS) notation
         default=0
       </ga4gh_vrs>
     </params>

--- a/root/documentation/variation.conf
+++ b/root/documentation/variation.conf
@@ -189,6 +189,11 @@
         description=Known variation synonyms and their sources
         default=0
       </var_synonyms>
+      <ga4gh_vrs>
+        type=Boolean
+        description=Adds the GA4GH VRS allele object
+        default=0
+      </ga4gh_vrs>
     </params>
 
     <examples>
@@ -238,6 +243,11 @@
         description=Known variation synonyms and their sources
         default=0
       </var_synonyms>
+      <ga4gh_vrs>
+        type=Boolean
+        description=Adds the GA4GH VRS allele object
+        default=0
+      </ga4gh_vrs>
     </params>
 
     postformat={ "ids": array }

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -107,7 +107,7 @@
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
-      </variant_class>
+      </failed>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -370,7 +370,7 @@
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
-      </variant_class>
+      </failed>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -610,7 +610,7 @@
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
-      </variant_class>
+      </failed>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -855,7 +855,7 @@
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
-      </variant_class>
+      </failed>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -1096,7 +1096,7 @@
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
-      </variant_class>
+      </failed>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -1355,7 +1355,7 @@
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
-      </variant_class>
+      </failed>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -110,7 +110,7 @@
       </failed>
       <ga4gh_vrs>
         type=Boolean
-        description=Adds the GA4GH VRS allele object
+        description=Add GA4GH Variation Representation Specification (VRS) notation
         default=0
       </ga4gh_vrs>
       <variant_class>
@@ -378,7 +378,7 @@
       </failed>
       <ga4gh_vrs>
         type=Boolean
-        description=Adds the GA4GH VRS allele object
+        description=Add GA4GH Variation Representation Specification (VRS) notation
         default=0
       </ga4gh_vrs>
       <variant_class>
@@ -623,7 +623,7 @@
       </failed>
       <ga4gh_vrs>
         type=Boolean
-        description=Adds the GA4GH VRS allele object
+        description=Add GA4GH Variation Representation Specification (VRS) notation
         default=0
       </ga4gh_vrs>
       <variant_class>
@@ -873,7 +873,7 @@
       </failed>
       <ga4gh_vrs>
         type=Boolean
-        description=Adds the GA4GH VRS allele object
+        description=Add GA4GH Variation Representation Specification (VRS) notation
         default=0
       </ga4gh_vrs>
       <variant_class>
@@ -1119,7 +1119,7 @@
       </failed>
       <ga4gh_vrs>
         type=Boolean
-        description=Adds the GA4GH VRS allele object
+        description=Add GA4GH Variation Representation Specification (VRS) notation
         default=0
       </ga4gh_vrs>
       <variant_class>
@@ -1383,7 +1383,7 @@
       </failed>
       <ga4gh_vrs>
         type=Boolean
-        description=Adds the GA4GH VRS allele object
+        description=Add GA4GH Variation Representation Specification (VRS) notation
         default=0
       </ga4gh_vrs>
       <variant_class>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -108,6 +108,11 @@
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
       </failed>
+      <ga4gh_vrs>
+        type=Boolean
+        description=Adds the GA4GH VRS allele object
+        default=0
+      </ga4gh_vrs>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -371,6 +376,11 @@
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
       </failed>
+      <ga4gh_vrs>
+        type=Boolean
+        description=Adds the GA4GH VRS allele object
+        default=0
+      </ga4gh_vrs>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -611,6 +621,11 @@
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
       </failed>
+      <ga4gh_vrs>
+        type=Boolean
+        description=Adds the GA4GH VRS allele object
+        default=0
+      </ga4gh_vrs>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -856,6 +871,11 @@
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
       </failed>
+      <ga4gh_vrs>
+        type=Boolean
+        description=Adds the GA4GH VRS allele object
+        default=0
+      </ga4gh_vrs>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -1097,6 +1117,11 @@
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
       </failed>
+      <ga4gh_vrs>
+        type=Boolean
+        description=Adds the GA4GH VRS allele object
+        default=0
+      </ga4gh_vrs>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -1356,6 +1381,11 @@
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
       </failed>
+      <ga4gh_vrs>
+        type=Boolean
+        description=Adds the GA4GH VRS allele object
+        default=0
+      </ga4gh_vrs>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant


### PR DESCRIPTION
### Description

[ENSVAR-5274](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5274): Adds support to output the [GA4GH Variation Representation Specification (VRS)](https://vrs.ga4gh.org) standard in VEP and VR.

Requires https://github.com/Ensembl/ensembl-vep/pull/1311

### Possible Drawbacks

No drawbacks.

### Testing

Check that `ga4gh_vrs` is returned when enabling the `ga4gh_vrs` flag:
- VEP: http://wp-np2-11.ebi.ac.uk:9303/vep/human/id/rs1210229297?content-type=application/json&ga4gh_vrs=1
- VR: http://wp-np2-11.ebi.ac.uk:9303/variant_recoder/human/rs1210229297?content-type=application/json&ga4gh_vrs=1

### Changelog

[/vep]: Allow to output the GA4GH Variation Representation Specification (VRS) standard
[/variant_recoder]: Allow to output the GA4GH Variation Representation Specification (VRS) standard
