### PR TITLE
Update flags and documentation of VEP and VR REST (110)

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -44,7 +44,6 @@ has valid_user_params => (
     gencode_basic
     refseq
     merged
-    all_refseq
 
     failed
     variant_class
@@ -52,7 +51,6 @@ has valid_user_params => (
     vcf_string
     transcript_version
 
-    everything
     appris
     canonical
     ccds

--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -50,6 +50,7 @@ has valid_user_params => (
     minimal
     vcf_string
     transcript_version
+    ambiguous_hgvs
 
     appris
     canonical

--- a/lib/EnsEMBL/REST/Controller/VariantRecoder.pm
+++ b/lib/EnsEMBL/REST/Controller/VariantRecoder.pm
@@ -40,7 +40,6 @@ has valid_user_params => (
   handles => { valid_user_param => 'exists' },
   default => sub { return { map {$_ => 1} (qw/
     gencode_basic
-    all_refseq
 
     failed
     minimal
@@ -48,12 +47,6 @@ has valid_user_params => (
 
     vcf_string
     var_synonyms
-
-    pick
-    pick_allele
-    per_gene
-    pick_allele_gene
-    pick_order
     /) }
   }
 );

--- a/root/documentation/variation.conf
+++ b/root/documentation/variation.conf
@@ -179,6 +179,21 @@
         description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic)
         default=id,hgvsg,hgvsc,hgvsp,spdi
       </fields>
+      <gencode_basic>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
+        default=0
+      </gencode_basic>
+      <failed>
+        type=Boolean
+        description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
+        default=0
+      </failed>
+      <minimal>
+        type=Boolean
+        description=Convert alleles to their most minimal representation before consequence calculation i.e. sequence that is identical between each pair of reference and alternate alleles is trimmed off from both ends, with coordinates adjusted accordingly. Note this may lead to discrepancies between input coordinates and coordinates reported by VEP relative to transcript sequences
+        default=0
+      </minimal>
       <vcf_string>
         type=Boolean(0,1)
         description=VCF represented in a string
@@ -228,6 +243,21 @@
         description=Comma-separated list of identifiers/notations to include from the following types: id (variant ID), hgvsg (HGVS genomic), hgvsc (HGVS coding), hgvsp (HGVS protein), spdi (SPDI genomic)
         default=id,hgvsg,hgvsc,hgvsp,spdi
       </fields>
+      <gencode_basic>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
+        default=0
+      </gencode_basic>
+      <failed>
+        type=Boolean
+        description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
+        default=0
+      </failed>
+      <minimal>
+        type=Boolean
+        description=Convert alleles to their most minimal representation before consequence calculation i.e. sequence that is identical between each pair of reference and alternate alleles is trimmed off from both ends, with coordinates adjusted accordingly. Note this may lead to discrepancies between input coordinates and coordinates reported by VEP relative to transcript sequences
+        default=0
+      </minimal>
       <vcf_string>
         type=Boolean(0,1)
         description=VCF represented in a string

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -107,7 +107,7 @@
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
-      </variant_class>
+      </failed>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -370,7 +370,7 @@
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
-      </variant_class>
+      </failed>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -610,7 +610,7 @@
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
-      </variant_class>
+      </failed>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -855,7 +855,7 @@
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
-      </variant_class>
+      </failed>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -1096,7 +1096,7 @@
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
-      </variant_class>
+      </failed>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant
@@ -1355,7 +1355,7 @@
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
         default=0
-      </variant_class>
+      </failed>
       <variant_class>
         type=Boolean
         description=Output the Sequence Ontology variant class for the input variant

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -32,7 +32,12 @@
         type=Boolean
         description=Include HGVS nomenclature based on Ensembl stable identifiers
         default=0
-      </hgvs> 
+      </hgvs>
+      <ambiguous_hgvs>
+        type=Boolean
+        description=Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected.
+        default=0
+      </ambiguous_hgvs>
       <ccds>
         type=Boolean
         description=Include CCDS transcript identifiers
@@ -340,7 +345,12 @@
         type=Boolean
         description=Include HGVS nomenclature based on Ensembl stable identifiers
         default=0
-      </hgvs> 
+      </hgvs>
+      <ambiguous_hgvs>
+        type=Boolean
+        description=Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected.
+        default=0
+      </ambiguous_hgvs>
       <ccds>
         type=Boolean
         description=Include CCDS transcript identifiers
@@ -625,7 +635,12 @@
         type=Boolean
         description=Include HGVS nomenclature based on Ensembl stable identifiers
         default=0
-      </hgvs> 
+      </hgvs>
+      <ambiguous_hgvs>
+        type=Boolean
+        description=Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected.
+        default=0
+      </ambiguous_hgvs>
       <ccds>
         type=Boolean
         description=Include CCDS transcript identifiers
@@ -915,7 +930,12 @@
         type=Boolean
         description=Include HGVS nomenclature based on Ensembl stable identifiers
         default=0
-      </hgvs> 
+      </hgvs>
+      <ambiguous_hgvs>
+        type=Boolean
+        description=Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected.
+        default=0
+      </ambiguous_hgvs>
       <ccds>
         type=Boolean
         description=Include CCDS transcript identifiers
@@ -1201,7 +1221,12 @@
         type=Boolean
         description=Include HGVS nomenclature based on Ensembl stable identifiers
         default=0
-      </hgvs> 
+      </hgvs>
+      <ambiguous_hgvs>
+        type=Boolean
+        description=Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected.
+        default=0
+      </ambiguous_hgvs>
       <ccds>
         type=Boolean
         description=Include CCDS transcript identifiers
@@ -1505,7 +1530,12 @@
         type=Boolean
         description=Include HGVS nomenclature based on Ensembl stable identifiers
         default=0
-      </hgvs> 
+      </hgvs>
+      <ambiguous_hgvs>
+        type=Boolean
+        description=Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected.
+        default=0
+      </ambiguous_hgvs>
       <ccds>
         type=Boolean
         description=Include CCDS transcript identifiers

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -170,8 +170,8 @@
       </flag_pick_allele_gene>
       <pick_order>
         type=String
-        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=mane,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane_select mane_clinical ].
+        default=mane_select,<wbr>mane_clinical,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -478,8 +478,8 @@
       </flag_pick_allele_gene>
       <pick_order>
         type=String
-        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=mane,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane_select mane_clinical ].
+        default=mane_select,<wbr>mane_clinical,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -763,8 +763,8 @@
       </flag_pick_allele_gene>
       <pick_order>
         type=String
-        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=mane,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane_select mane_clinical ].
+        default=mane_select,<wbr>mane_clinical,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -1053,8 +1053,8 @@
       </flag_pick_allele_gene>
       <pick_order>
         type=String
-        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=mane,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane_select mane_clinical ].
+        default=mane_select,<wbr>mane_clinical,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -1344,8 +1344,8 @@
       </flag_pick_allele_gene>
       <pick_order>
         type=String
-        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=mane,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane_select mane_clinical ].
+        default=mane_select,<wbr>mane_clinical,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -1653,8 +1653,8 @@
       </flag_pick_allele_gene>
       <pick_order>
         type=String
-        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=mane,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane_select mane_clinical ].
+        default=mane_select,<wbr>mane_clinical,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
       </pick_order>
       <AncestralAllele>
         type=Boolean

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -128,6 +128,51 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
+      <gencode_basic>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
+        default=0
+      </gencode_basic>
+      <pick>
+        type=Boolean
+        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
+        default=0
+      </pick>
+      <pick_allele>
+        type=Boolean
+        description=Like <b>pick</b>, but chooses one line or block of consequence data per variant allele. Will only differ in behaviour from <b>pick</b> when the input variant has multiple alternate alleles.
+        default=0
+      </pick_allele>
+      <per_gene>
+        type=Boolean
+        description=Output only the most severe consequence per gene. The transcript selected is arbitrary if more than one has the same predicted consequence. Uses the same ranking system as <b>pick</b>.
+        default=0
+      </per_gene>
+      <pick_allele_gene>
+        type=Boolean
+        description=Like <b>pick_allele</b>, but chooses one line or block of consequence data per variant allele and gene combination.
+        default=0
+      </pick_allele_gene>
+      <flag_pick>
+        type=Boolean
+        description=As per <b>pick</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick>
+      <flag_pick_allele>
+        type=Boolean
+        description=As per <b>pick_allele</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick_allele>
+      <flag_pick_allele_gene>
+        type=Boolean
+        description=As per <b>pick_allele_gene</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick_allele_gene>
+      <pick_order>
+        type=String
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
+        default=canonical,appris,tsl,biotype,ccds,rank,length,mane
+      </pick_order>
       <AncestralAllele>
         type=Boolean
         description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
@@ -391,6 +436,51 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
+            <gencode_basic>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
+        default=0
+      </gencode_basic>
+      <pick>
+        type=Boolean
+        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
+        default=0
+      </pick>
+      <pick_allele>
+        type=Boolean
+        description=Like <b>pick</b>, but chooses one line or block of consequence data per variant allele. Will only differ in behaviour from <b>pick</b> when the input variant has multiple alternate alleles.
+        default=0
+      </pick_allele>
+      <per_gene>
+        type=Boolean
+        description=Output only the most severe consequence per gene. The transcript selected is arbitrary if more than one has the same predicted consequence. Uses the same ranking system as <b>pick</b>.
+        default=0
+      </per_gene>
+      <pick_allele_gene>
+        type=Boolean
+        description=Like <b>pick_allele</b>, but chooses one line or block of consequence data per variant allele and gene combination.
+        default=0
+      </pick_allele_gene>
+      <flag_pick>
+        type=Boolean
+        description=As per <b>pick</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick>
+      <flag_pick_allele>
+        type=Boolean
+        description=As per <b>pick_allele</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick_allele>
+      <flag_pick_allele_gene>
+        type=Boolean
+        description=As per <b>pick_allele_gene</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick_allele_gene>
+      <pick_order>
+        type=String
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
+        default=canonical,appris,tsl,biotype,ccds,rank,length,mane
+      </pick_order>
       <AncestralAllele>
         type=Boolean
         description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
@@ -631,6 +721,51 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
+            <gencode_basic>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
+        default=0
+      </gencode_basic>
+      <pick>
+        type=Boolean
+        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
+        default=0
+      </pick>
+      <pick_allele>
+        type=Boolean
+        description=Like <b>pick</b>, but chooses one line or block of consequence data per variant allele. Will only differ in behaviour from <b>pick</b> when the input variant has multiple alternate alleles.
+        default=0
+      </pick_allele>
+      <per_gene>
+        type=Boolean
+        description=Output only the most severe consequence per gene. The transcript selected is arbitrary if more than one has the same predicted consequence. Uses the same ranking system as <b>pick</b>.
+        default=0
+      </per_gene>
+      <pick_allele_gene>
+        type=Boolean
+        description=Like <b>pick_allele</b>, but chooses one line or block of consequence data per variant allele and gene combination.
+        default=0
+      </pick_allele_gene>
+      <flag_pick>
+        type=Boolean
+        description=As per <b>pick</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick>
+      <flag_pick_allele>
+        type=Boolean
+        description=As per <b>pick_allele</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick_allele>
+      <flag_pick_allele_gene>
+        type=Boolean
+        description=As per <b>pick_allele_gene</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick_allele_gene>
+      <pick_order>
+        type=String
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
+        default=canonical,appris,tsl,biotype,ccds,rank,length,mane
+      </pick_order>
       <AncestralAllele>
         type=Boolean
         description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
@@ -876,6 +1011,51 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
+            <gencode_basic>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
+        default=0
+      </gencode_basic>
+      <pick>
+        type=Boolean
+        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
+        default=0
+      </pick>
+      <pick_allele>
+        type=Boolean
+        description=Like <b>pick</b>, but chooses one line or block of consequence data per variant allele. Will only differ in behaviour from <b>pick</b> when the input variant has multiple alternate alleles.
+        default=0
+      </pick_allele>
+      <per_gene>
+        type=Boolean
+        description=Output only the most severe consequence per gene. The transcript selected is arbitrary if more than one has the same predicted consequence. Uses the same ranking system as <b>pick</b>.
+        default=0
+      </per_gene>
+      <pick_allele_gene>
+        type=Boolean
+        description=Like <b>pick_allele</b>, but chooses one line or block of consequence data per variant allele and gene combination.
+        default=0
+      </pick_allele_gene>
+      <flag_pick>
+        type=Boolean
+        description=As per <b>pick</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick>
+      <flag_pick_allele>
+        type=Boolean
+        description=As per <b>pick_allele</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick_allele>
+      <flag_pick_allele_gene>
+        type=Boolean
+        description=As per <b>pick_allele_gene</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick_allele_gene>
+      <pick_order>
+        type=String
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
+        default=canonical,appris,tsl,biotype,ccds,rank,length,mane
+      </pick_order>
       <AncestralAllele>
         type=Boolean
         description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
@@ -1117,6 +1297,51 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
+            <gencode_basic>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
+        default=0
+      </gencode_basic>
+      <pick>
+        type=Boolean
+        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
+        default=0
+      </pick>
+      <pick_allele>
+        type=Boolean
+        description=Like <b>pick</b>, but chooses one line or block of consequence data per variant allele. Will only differ in behaviour from <b>pick</b> when the input variant has multiple alternate alleles.
+        default=0
+      </pick_allele>
+      <per_gene>
+        type=Boolean
+        description=Output only the most severe consequence per gene. The transcript selected is arbitrary if more than one has the same predicted consequence. Uses the same ranking system as <b>pick</b>.
+        default=0
+      </per_gene>
+      <pick_allele_gene>
+        type=Boolean
+        description=Like <b>pick_allele</b>, but chooses one line or block of consequence data per variant allele and gene combination.
+        default=0
+      </pick_allele_gene>
+      <flag_pick>
+        type=Boolean
+        description=As per <b>pick</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick>
+      <flag_pick_allele>
+        type=Boolean
+        description=As per <b>pick_allele</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick_allele>
+      <flag_pick_allele_gene>
+        type=Boolean
+        description=As per <b>pick_allele_gene</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick_allele_gene>
+      <pick_order>
+        type=String
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
+        default=canonical,appris,tsl,biotype,ccds,rank,length,mane
+      </pick_order>
       <AncestralAllele>
         type=Boolean
         description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
@@ -1376,6 +1601,51 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
+            <gencode_basic>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
+        default=0
+      </gencode_basic>
+      <pick>
+        type=Boolean
+        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
+        default=0
+      </pick>
+      <pick_allele>
+        type=Boolean
+        description=Like <b>pick</b>, but chooses one line or block of consequence data per variant allele. Will only differ in behaviour from <b>pick</b> when the input variant has multiple alternate alleles.
+        default=0
+      </pick_allele>
+      <per_gene>
+        type=Boolean
+        description=Output only the most severe consequence per gene. The transcript selected is arbitrary if more than one has the same predicted consequence. Uses the same ranking system as <b>pick</b>.
+        default=0
+      </per_gene>
+      <pick_allele_gene>
+        type=Boolean
+        description=Like <b>pick_allele</b>, but chooses one line or block of consequence data per variant allele and gene combination.
+        default=0
+      </pick_allele_gene>
+      <flag_pick>
+        type=Boolean
+        description=As per <b>pick</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick>
+      <flag_pick_allele>
+        type=Boolean
+        description=As per <b>pick_allele</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick_allele>
+      <flag_pick_allele_gene>
+        type=Boolean
+        description=As per <b>pick_allele_gene</b>, but adds the PICK flag to the chosen block of consequence data and retains others.
+        default=0
+      </flag_pick_allele_gene>
+      <pick_order>
+        type=String
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
+        default=canonical,appris,tsl,biotype,ccds,rank,length,mane
+      </pick_order>
       <AncestralAllele>
         type=Boolean
         description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -171,7 +171,7 @@
       <pick_order>
         type=String
         description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length,<wbr>mane
+        default=mane,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -479,7 +479,7 @@
       <pick_order>
         type=String
         description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length,<wbr>mane
+        default=mane,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -764,7 +764,7 @@
       <pick_order>
         type=String
         description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length,<wbr>mane
+        default=mane,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -1054,7 +1054,7 @@
       <pick_order>
         type=String
         description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length,<wbr>mane
+        default=mane,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -1345,7 +1345,7 @@
       <pick_order>
         type=String
         description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length,<wbr>mane
+        default=mane,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -1654,7 +1654,7 @@
       <pick_order>
         type=String
         description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length,<wbr>mane
+        default=mane,<wbr>canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length
       </pick_order>
       <AncestralAllele>
         type=Boolean

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -129,13 +129,13 @@
         default=0
       </merged>
       <gencode_basic>
-        type=Boolean(0,1)
+        type=Boolean
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
       <pick>
         type=Boolean
-        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
+        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
         default=0
       </pick>
       <pick_allele>
@@ -170,8 +170,8 @@
       </flag_pick_allele_gene>
       <pick_order>
         type=String
-        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=canonical,appris,tsl,biotype,ccds,rank,length,mane
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
+        default=canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length,<wbr>mane
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -436,14 +436,14 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
-            <gencode_basic>
-        type=Boolean(0,1)
+      <gencode_basic>
+        type=Boolean
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
       <pick>
         type=Boolean
-        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
+        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
         default=0
       </pick>
       <pick_allele>
@@ -478,8 +478,8 @@
       </flag_pick_allele_gene>
       <pick_order>
         type=String
-        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=canonical,appris,tsl,biotype,ccds,rank,length,mane
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
+        default=canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length,<wbr>mane
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -721,14 +721,14 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
-            <gencode_basic>
-        type=Boolean(0,1)
+      <gencode_basic>
+        type=Boolean
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
       <pick>
         type=Boolean
-        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
+        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
         default=0
       </pick>
       <pick_allele>
@@ -763,8 +763,8 @@
       </flag_pick_allele_gene>
       <pick_order>
         type=String
-        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=canonical,appris,tsl,biotype,ccds,rank,length,mane
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
+        default=canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length,<wbr>mane
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -1011,14 +1011,14 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
-            <gencode_basic>
-        type=Boolean(0,1)
+      <gencode_basic>
+        type=Boolean
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
       <pick>
         type=Boolean
-        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
+        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
         default=0
       </pick>
       <pick_allele>
@@ -1053,8 +1053,8 @@
       </flag_pick_allele_gene>
       <pick_order>
         type=String
-        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=canonical,appris,tsl,biotype,ccds,rank,length,mane
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
+        default=canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length,<wbr>mane
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -1302,14 +1302,14 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
-            <gencode_basic>
-        type=Boolean(0,1)
+      <gencode_basic>
+        type=Boolean
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
       <pick>
         type=Boolean
-        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
+        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
         default=0
       </pick>
       <pick_allele>
@@ -1344,8 +1344,8 @@
       </flag_pick_allele_gene>
       <pick_order>
         type=String
-        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=canonical,appris,tsl,biotype,ccds,rank,length,mane
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
+        default=canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length,<wbr>mane
       </pick_order>
       <AncestralAllele>
         type=Boolean
@@ -1611,14 +1611,14 @@
         description=Use merged Ensembl and RefSeq transcript set to report consequences (human only)
         default=0
       </merged>
-            <gencode_basic>
-        type=Boolean(0,1)
+      <gencode_basic>
+        type=Boolean
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
       <pick>
         type=Boolean
-        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
+        description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
         default=0
       </pick>
       <pick_allele>
@@ -1653,8 +1653,8 @@
       </flag_pick_allele_gene>
       <pick_order>
         type=String
-        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
-        default=canonical,appris,tsl,biotype,ccds,rank,length,mane
+        description=Comma-separated list with order of criteria (and the list of criteria) applied when choosing a block of annotation data with one of the following options: <b>pick</b>, <b>pick_allele</b>, <b>per_gene</b>, <b>pick_allele_gene</b>, <b>flag_pick</b>, <b>flag_pick_allele</b>, <b>flag_pick_allele_gene</b>. See <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick_options">this page</a> for the default order. Valid criteria are: [ canonical appris tsl biotype ccds rank length mane ].
+        default=canonical,<wbr>appris,<wbr>tsl,<wbr>biotype,<wbr>ccds,<wbr>rank,<wbr>length,<wbr>mane
       </pick_order>
       <AncestralAllele>
         type=Boolean

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -33,11 +33,6 @@
         description=Include HGVS nomenclature based on Ensembl stable identifiers
         default=0
       </hgvs>
-      <ambiguous_hgvs>
-        type=Boolean
-        description=Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected.
-        default=0
-      </ambiguous_hgvs>
       <ccds>
         type=Boolean
         description=Include CCDS transcript identifiers
@@ -346,11 +341,6 @@
         description=Include HGVS nomenclature based on Ensembl stable identifiers
         default=0
       </hgvs>
-      <ambiguous_hgvs>
-        type=Boolean
-        description=Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected.
-        default=0
-      </ambiguous_hgvs>
       <ccds>
         type=Boolean
         description=Include CCDS transcript identifiers
@@ -636,11 +626,6 @@
         description=Include HGVS nomenclature based on Ensembl stable identifiers
         default=0
       </hgvs>
-      <ambiguous_hgvs>
-        type=Boolean
-        description=Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected.
-        default=0
-      </ambiguous_hgvs>
       <ccds>
         type=Boolean
         description=Include CCDS transcript identifiers
@@ -931,11 +916,6 @@
         description=Include HGVS nomenclature based on Ensembl stable identifiers
         default=0
       </hgvs>
-      <ambiguous_hgvs>
-        type=Boolean
-        description=Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected.
-        default=0
-      </ambiguous_hgvs>
       <ccds>
         type=Boolean
         description=Include CCDS transcript identifiers


### PR DESCRIPTION
### Description

[ENSVAR-5301](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5301) – this PR intends to:
- Disable VEP/VR flags in REST we don't want users to access
- Document VEP/VR REST flags with no documentation
- Add and document `--ambiguous_hgvs` as a valid VEP flag

### Use case

Avoid users using undocumented flags. We decided which flags should be documented and which should be unavailable to users via the REST interface.

### Benefits

Proper documentation to all valid VEP/VR flags in REST.

### Possible Drawbacks

None.

### Testing

Mostly changes to docs. Changes to valid flags for VEP/VR should not affect unit tests.

Test in my [sandbox](http://wp-np2-11.ebi.ac.uk:9300).

### Changelog

[vep/] Documented all valid flags in VEP REST
[variant_recoder/] Documented all valid flags in VR REST
