### PR TITLE
Add option ambiguous_hgvs to vep hgvs endpoint

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -51,6 +51,7 @@ has valid_user_params => (
     minimal
     vcf_string
     transcript_version
+    ambiguous_hgvs
 
     everything
     appris
@@ -489,4 +490,3 @@ sub _configure_plugins {
 }
 
 __PACKAGE__->meta->make_immutable;
-

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -1022,6 +1022,11 @@
         description=Include HGVS nomenclature based on Ensembl stable identifiers
         default=0
       </hgvs> 
+      <ambiguous_hgvs>
+        type=Boolean
+        description=Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected.
+        default=0
+      </ambiguous_hgvs>
       <ccds>
         type=Boolean
         description=Include CCDS transcript identifiers
@@ -1280,7 +1285,12 @@
         type=Boolean
         description=Include HGVS nomenclature based on Ensembl stable identifiers
         default=0
-      </hgvs> 
+      </hgvs>
+      <ambiguous_hgvs>
+        type=Boolean
+        description=Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected.
+        default=0
+      </ambiguous_hgvs>
       <ccds>
         type=Boolean
         description=Include CCDS transcript identifiers


### PR DESCRIPTION
### Requirements

### Description

Add option to VEP 'ambiguous_hgvs'

### Use case

Some users need to use the option ambiguous_hgvs when they input an hgvs on VEP REST. This PR adds the option to VEP.

### Benefits


### Possible Drawbacks

None

### Testing

_Have you added/modified unit tests to test the changes?_
No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
No regression detected.

### Changelog

[/vep/:species/hgvs/] new option 'ambiguous_hgvs' available
