### PR TITLE
Mention ALL keyword in dbNSFP plugin docs (110)

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -150,7 +150,7 @@
       </Conservation>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code> — this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
@@ -413,7 +413,7 @@
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code> — this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
@@ -663,7 +663,7 @@
       </Conservation>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code> — this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
@@ -908,7 +908,7 @@
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code> — this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
@@ -1159,7 +1159,7 @@
       </Conservation>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code> — this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
@@ -1418,7 +1418,7 @@
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code> — this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -150,9 +150,9 @@
       </Conservation>
       <dbNSFP>
         type=String
-        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code> — this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
-        example=LRT_pred,MutationTaster_pred
+        example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
       <dbscSNV>
         type=Boolean
@@ -413,9 +413,9 @@
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code> — this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
-        example=LRT_pred,MutationTaster_pred
+        example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
       <dbscSNV>
         type=Boolean
@@ -663,9 +663,9 @@
       </Conservation>
       <dbNSFP>
         type=String
-        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code> — this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
-        example=LRT_pred,MutationTaster_pred
+        example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
       <dbscSNV>
         type=Boolean
@@ -908,9 +908,9 @@
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code> — this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
-        example=LRT_pred,MutationTaster_pred
+        example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
       <dbscSNV>
         type=Boolean
@@ -1159,9 +1159,9 @@
       </Conservation>
       <dbNSFP>
         type=String
-        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code> — this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
-        example=LRT_pred,MutationTaster_pred
+        example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
       <dbscSNV>
         type=Boolean
@@ -1418,9 +1418,9 @@
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Include fields from dbNSFP, a database of pathogenicity predictions for missense variants. Multiple fields should be separated by commas. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code> — this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
-        example=LRT_pred,MutationTaster_pred
+        example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
       <dbscSNV>
         type=Boolean


### PR DESCRIPTION
### Description

Clarify usage of `ALL` keyword in the documentation of dbNSFP plugin, based on #544. Also added line break tag (`wbr`) to default list in order to visually improve the table layout.

### Possible Drawbacks

No drawbacks.

### Testing

Check changes in my [sandbox](http://wp-np2-11.ebi.ac.uk:9304/documentation/info/vep_id_get).

### Changelog

[/vep] Mention `ALL` keyword in documentation of dbNSFP plugin for VEP
