### PR TITLE
Revert fetch_by_ensembl_gene to release/108 version

### DIFF
--- a/t/homology.t
+++ b/t/homology.t
@@ -57,12 +57,27 @@ my $condensed_ortho_ENSG00000139618_gorilla = {
     'method_link_type' => 'ENSEMBL_ORTHOLOGUES'
 };
 
+my $condensed_ortho_ENSECAG00000014890_gorilla = {
+    'taxonomy_level' => 'Boreoeutheria',
+    'protein_id' => 'ENSGGOP00000015446',
+    'type' => 'ortholog_one2one',
+    'id' => 'ENSGGOG00000015808',
+    'species' => 'gorilla_gorilla',
+    'method_link_type' => 'ENSEMBL_ORTHOLOGUES'
+};
+
 ## "condensed" homologies with target species
 
 is_json_GET(
     '/homology/id/ENSG00000139618?compara=homology;format=condensed;target_species=gorilla_gorilla;type=orthologues',
     _get_returned_json('ENSG00000139618', $condensed_ortho_ENSG00000139618_gorilla),
     '"condensed" homologies with a target species',
+);
+
+is_json_GET(
+    '/homology/id/ENSECAG00000014890?compara=homology;format=condensed;target_species=gorilla_gorilla;type=orthologues',
+    _get_returned_json('ENSECAG00000014890', $condensed_ortho_ENSECAG00000014890_gorilla),
+    'homologies of gene not found in stable_id_lookup',
 );
 
 is_json_GET(


### PR DESCRIPTION
### Description

This change reverts method `fetch_by_ensembl_gene` to its `release/108` version, and in doing that restores the ability to query the `homology/id/:id` endpoint by versioned gene stable ID.

### Use case

Until Ensembl 108, queries of the `homology/id` REST endpoint would return a result for a versioned gene stable ID, even if the initial stable_id_lookup failed, because of a fallback query of Compara databases to verify that the gene could indeed be accessed by the given versioned gene stable ID. As part of the process of deprecating Compara method `MemberAdaptor::fetch_by_stable_id`, that fallback query was removed, which effectively removed support for querying homologies by versioned gene stable ID.

For example, these queries return equivalent results via the Ensembl 108 REST API:
- https://rest.ensembl.org/homology/id/ENSG00000186092?content-type=application/json;compara=vertebrates;target_species=equus_caballus
- https://rest.ensembl.org/homology/id/ENSG00000186092.7?content-type=application/json;compara=vertebrates;target_species=equus_caballus

However, the latter query currently fails on the Ensembl 109 test REST site.

With the extension of the deprecation period of `MemberAdaptor::fetch_by_stable_id`, it is possible to reinstate the fallback query and thereby restore the ability to query homologies by versioned gene stable ID.

### Benefits

Users will be able to continue using the `homology/id/:id` endpoint to query homologies by versioned gene stable ID for at least one more Ensembl release. Development is in progress to replace this functionality in release 110.

### Possible Drawbacks

This solution is necessarily temporary, since `MemberAdaptor::fetch_by_stable_id` will be removed from the Compara Perl API in Ensembl 110. But in the worst case, support for querying homologies by versioned gene stable ID would end in Ensembl 110 rather than release 109.

### Testing

A unit test has been added to `homology.t` which queries the `homology/id/:id` endpoint with horse gene stable ID `ENSECAG00000014890`. This is not a versioned stable ID, but it can serve as a proxy for one, because it is present in the `homology` Compara unit-test database but not in the `stable_ids` test database used in stable_id_lookup.

All Compara-related unit tests passed locally.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

No change as such, only a partial reversion of the changes in PR #542 to restore functionality present in the Ensembl 108 REST API.