### PR TITLE
Document `transcript_match` option for dbNSFP VEP plugin (e110)

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -150,7 +150,7 @@
       </Conservation>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
@@ -413,7 +413,7 @@
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
@@ -663,7 +663,7 @@
       </Conservation>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
@@ -908,7 +908,7 @@
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
@@ -1159,7 +1159,7 @@
       </Conservation>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
@@ -1418,7 +1418,7 @@
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>


### PR DESCRIPTION
@diegomscoelho 

### Description

Document the usage of an option to match Ensembl transcripts (`transcript_match`) in dbNSFP VEP plugin.

### Possible Drawbacks

None.

### Testing

The documentation update can be checked in my sandbox: http://wp-np2-11.ebi.ac.uk:9300/documentation/info/vep_hgvs_get

Also, the parameter is working as described, returning only dbNSFP fields related with the matched Ensembl transcript
- With `transcript_match=1`:  http://wp-np2-11.ebi.ac.uk:9300/vep/human/id/rs867018739?content-type=application/json&dbNSFP=MVP_score,some_invalid_dbNSFP_field,transcript_match=1,Ensembl_transcriptid
- Without `transcript_match`: http://wp-np2-11.ebi.ac.uk:9300/vep/human/id/rs867018739?content-type=application/json&dbNSFP=MVP_score,some_invalid_dbNSFP_field,Ensembl_transcriptid

### Changelog

/vep Documented use of `transcript_match` option for dbNSFP plugin
