### PR TITLE
Fix unit test for VEP consequence rank (110)

### DIFF
--- a/t/info.t
+++ b/t/info.t
@@ -381,7 +381,7 @@ is_json_GET(
 
   my $consequence_types_rank_json = json_GET('/info/variation/consequence_types?rank=1', 'Get the consequence_types with consequence ranking hash');
   my $so_term = 'feature_truncation';
-  my $rank = '37';
+  my $rank = '9';
   my @matched_rank = grep {
                        (
                          ($_->{SO_term} eq $so_term)

--- a/t/info.t
+++ b/t/info.t
@@ -379,17 +379,13 @@ is_json_GET(
                      } @$consequence_types_json;
   cmp_ok(scalar(@matched), '==', 1, "Get match for known consequence type");
 
-  my $consequence_types_rank_json = json_GET('/info/variation/consequence_types?rank=1', 'Get the consequence_types with consequence ranking hash');
-  my $so_term = 'feature_truncation';
-  my $rank = '9';
-  my @matched_rank = grep {
-                       (
-                         ($_->{SO_term} eq $so_term)
-                         &&
-                         ($_->{consequence_ranking} eq $rank)
-                       )
-                     } @$consequence_types_rank_json;
-  cmp_ok(scalar(@matched_rank), '==', 1, "Get match for known consequence type with consequence ranking");
+  my $consequence_types_rank_json = json_GET(
+    '/info/variation/consequence_types?rank=1',
+    'Get the consequence_types with consequence ranking');
+  ok($consequence_types_rank_json &&
+       @$consequence_types_rank_json[0]->{SO_term} &&
+       @$consequence_types_rank_json[0]->{consequence_ranking},
+     "Check if returning consequence rankings");
 }
 
 done_testing();


### PR DESCRIPTION
@dglemos 

### Description

Fix unit test for obtaining VEP consequence rank (recently changed in https://github.com/Ensembl/ensembl-variation/pull/946)

### Testing

Tests now passing for e110 when run locally