### PR TITLE
Update docs pointer to latest REST version (Release 110)

### DIFF
--- a/lib/EnsEMBL/REST.pm
+++ b/lib/EnsEMBL/REST.pm
@@ -64,7 +64,7 @@ use Catalyst qw/
 /;
 
 
-our $VERSION = '15.4';
+our $VERSION = '15.6';
 
 # Configure the application.
 #


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

Update docs pointer to latest version (REST version 15.6, for Release 110). Refers to task A5 in the Infrastructure Release Tasks: https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?spaceKey=ENSCORE&title=Core+release+coordination#CoreReleaseCoordination-RESTserver-A5.

Please note that there were two sets of changes for Release 109, reflected in REST versions 15.4 and 15.5. Therefore, here the REST version is updated to 15.6.

### Use case

### Benefits

### Possible Drawbacks

### Testing

note to submitters and reviewers: documentation-only changes may reflect
changes in other repos that can result in new or different output from
REST endpoints. In turn, these may require new tests or changes to existing tests.

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians
