### PR TITLE
Improve Beacon v2 (e111)

### DIFF
--- a/lib/EnsEMBL/REST/Model/ga4gh/Beacon.pm
+++ b/lib/EnsEMBL/REST/Model/ga4gh/Beacon.pm
@@ -1151,7 +1151,8 @@ sub get_vep_molecular_attribs {
             $disgenet_obj->{annotatedWith}->{toolName} = 'DisGeNET';
             $disgenet_obj->{annotatedWith}->{version} = 'v7';
             $disgenet_obj->{conditionId} = $disgenet->{diseaseName};
-            $disgenet_obj->{evidenceType} = 'PMID:' . $disgenet->{pmid};
+            $disgenet_obj->{evidenceType}->{id} = "isDefinedBy";
+            $disgenet_obj->{evidenceType}->{label} = 'PMID:' . $disgenet->{pmid};
             $disgenet_obj->{score} = $disgenet->{score};
             push @disgenet_data, $disgenet_obj;
             $unique_disgenet{$key} = 1;

--- a/lib/EnsEMBL/REST/Model/ga4gh/Beacon.pm
+++ b/lib/EnsEMBL/REST/Model/ga4gh/Beacon.pm
@@ -924,12 +924,12 @@ sub get_dataset_allele_response {
     my @genes; # geneIds (part of MolecularAttributes)
     my @molecular_effects; # molecularEffects (part of MolecularAttributes)
     my $molecular_interactions; # molecularInteractions (part of MolecularAttributes)
-    my $gene_ontology;
+    my $gene_ontology = [];
     my @clinical; # clinicalInterpretations (part of variantLevelData)
     my %unique_phenotypes;
     my $var;
-    my $disgenet;
-    my $frequency;
+    my $disgenet = [];
+    my $frequency = [];
 
     if($sv == 1) {
       $var = $variation_feature->structural_variation();
@@ -1039,7 +1039,7 @@ sub get_dataset_allele_response {
     my @unique_molecular_effects = uniq @molecular_effects;
     $result_details->{MolecularAttributes}->{molecularEffects} = \@unique_molecular_effects if (scalar @unique_molecular_effects > 0);
 
-    $result_details->{MolecularAttributes}->{molecularInteractions} = $molecular_interactions;
+    $result_details->{MolecularAttributes}->{molecularInteractions} = $molecular_interactions if (scalar keys %{$molecular_interactions} > 0);
 
     $result_details->{variantLevelData}->{clinicalInterpretations} = \@clinical if (scalar @clinical > 0);
 


### PR DESCRIPTION
### Description

Update Beacon endpoint to run VEP.
The idea is to return output for the following:
-  IntAct
-  Mastermind
- GO
- Phenotypes
- DisGeNET
- EVE
- SpliceAI
-  frequency data from gnomAD

The Beacon schema does not specify all types of data we want to return so in this PR we return data for the following:
- IntAct
- GO
- Phenotypes
- DisGeNET
- CADD
- frequency data from gnomAD


This change should also be included in release 110.

Some results are not included in the Beacon schema yet (example: pathogenicityPredictions). I created a ticket in the Beacon repo for that: https://github.com/ga4gh-beacon/beacon-v2/issues/76

### Use case


### Benefits

Return vep data through Beacon, this way users can integrate VEP in Beacon.

### Possible Drawbacks

None

### Testing

note to submitters and reviewers: documentation-only changes may reflect
changes in other repos that can result in new or different output from
REST endpoints. In turn, these may require new tests or changes to existing tests.

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_
Tests pass.

_Have you run the entire test suite and no regression was detected?_
No regression detected.

### Changelog

[/ga4gh/beacon/query] Return VEP data in Beacon output
