### PR TITLE
Add long-lookup capability to Compara endpoints

### DIFF
--- a/lib/EnsEMBL/REST/Controller/Homology.pm
+++ b/lib/EnsEMBL/REST/Controller/Homology.pm
@@ -73,7 +73,7 @@ sub fetch_by_ensembl_gene : Chained("/") PathPart("homology/id") Args(1)  {
   my $lookup = $c->model('Lookup');
   my $species;
 
-  my $capture_sets = $lookup->find_all_object_locations_for_compara($id, 'Gene', 'core');
+  my $capture_sets = $lookup->find_all_core_object_locations_for_compara($id, 'Gene');
   if (scalar(@{$capture_sets}) == 1) {
     $species = $capture_sets->[0][0];
   } else {

--- a/lib/EnsEMBL/REST/Model/DatabaseIDLookup.pm
+++ b/lib/EnsEMBL/REST/Model/DatabaseIDLookup.pm
@@ -19,7 +19,6 @@ limitations under the License.
 
 package EnsEMBL::REST::Model::DatabaseIDLookup;
 
-use DBI qw(:sql_types);
 use Moose;
 use Scalar::Util qw/weaken/;
 use namespace::autoclean;
@@ -67,48 +66,14 @@ sub find_prediction_transcript {
   return ($species, $object_type, $db_type);
 }
 
-sub find_all_object_locations_for_compara {
-  # Adapted from method Bio::EnsEMBL::Registry::stable_id_lookup, the main difference
-  # being that this is intended to return all results for a given stable_id.
-  my ($self, $id, $object_type, $db_type, $species) = @_;
+sub find_all_core_object_locations_for_compara {
+  my ($self, $id, $object_type, $species) = @_;
   my $reg = $self->context->model('Registry');
 
-  my $stable_ids_dba = $reg->get_DBAdaptor('multi', 'stable_ids', 1);
+  my $force_long_lookup = $self->long_lookup();
 
-  my $statement = 'SELECT name, object_type, db_type FROM stable_id_lookup join species using(species_id) WHERE stable_id = ?';
-
-  if ($species) {
-    $statement .= ' AND name = ?';
-  }
-  if ($db_type) {
-    $statement .= ' AND db_type = ?';
-  }
-  if ($object_type) {
-    $statement .= ' AND object_type = ?';
-  }
-
-  my $sth = $stable_ids_dba->dbc()->prepare($statement);
-  my $param_count = 1;
-  $sth->bind_param($param_count, $id, SQL_VARCHAR);
-  if ($species) {
-    $species = $reg->get_alias($species);
-    $param_count++;
-    $sth->bind_param($param_count, $species, SQL_VARCHAR);
-  }
-  if ($db_type) {
-    $param_count++;
-    $sth->bind_param($param_count, $db_type, SQL_VARCHAR);
-  }
-  if ($object_type) {
-    $param_count++;
-    $sth->bind_param($param_count, $object_type, SQL_VARCHAR);
-  }
-
-  $sth->execute();
-  my $capture_sets = $sth->fetchall_arrayref();
-  $sth->finish();
-
-  return $capture_sets;
+  $self->context->log->debug(sprintf('Looking for %s with %s in %s', $id, ($object_type || q{?}), ($species || q{?})));
+  return $reg->get_all_core_species_and_object_types($id, $object_type, $species, $force_long_lookup);
 }
 
 1;

--- a/lib/EnsEMBL/REST/Model/Registry.pm
+++ b/lib/EnsEMBL/REST/Model/Registry.pm
@@ -24,6 +24,7 @@ use namespace::autoclean;
 require EnsEMBL::REST;
 use feature 'switch';
 use CHI;
+use DBI qw(:sql_types);
 use Try::Tiny;
 use Bio::EnsEMBL::Utils::Exception qw/throw/;
 use EnsEMBL::REST::RegistryHelper;
@@ -300,6 +301,152 @@ sub get_alias {
     return $reg->get_alias($alias);
   }
   return;
+}
+
+sub get_all_core_species_and_object_types {
+  # Adapted from method 'Bio::EnsEMBL::Registry::get_species_and_object_type'.
+  my ($self, $stable_id, $known_type, $known_species, $force_long_lookup) = @_;
+
+  my $stable_ids_dba = $self->get_DBAdaptor('multi', 'stable_ids', 1);
+
+  my $capture_sets;
+  if ($stable_ids_dba && ! $force_long_lookup) {
+    $capture_sets = $self->stable_id_lookup_all_core($stable_id, $known_type, $known_species);
+  }
+  else {
+    my @dbas =
+      sort { $a->dbc->host cmp $b->dbc->host || $a->dbc->port <=> $b->dbc->port }
+      grep { $_->dbc->dbname !~ m{ \A ensembl_metadata | ncbi_taxonomy }msx }
+      @{$self->get_all_DBAdaptors('core', $known_species)};
+
+    foreach my $dba (@dbas) {
+      my $db_capture_sets = $self->_core_get_all_species_and_object_types($stable_id, $known_type, $dba);
+      push(@{$capture_sets}, @{$db_capture_sets});
+    }
+  }
+
+  return $capture_sets;
+}
+
+sub _core_get_all_species_and_object_types {
+  # Adapted from method 'Bio::EnsEMBL::Registry::_core_get_species_and_object_type'.
+  my ($self, $stable_id, $known_type, $dba) = @_;
+
+  # Try looking up the species with the stable_id, as-is.
+  my $capture_sets = $self->_core_get_all_species_and_object_types_worker($stable_id, $known_type, $dba);
+
+  # If stable_id appears to be versioned, try also looking up the species with the unversioned stable_id.
+  my $vindex = rindex($stable_id, '.');
+  if ($vindex > 0) {  # skip if no dot (unversioned stable_id) or string starts with dot (empty stable_id)
+    my $version = substr($stable_id, ($vindex + 1));
+    if ($version =~ /^\d+$/) {
+      my $unversioned_id = substr($stable_id, 0, $vindex);
+      push(@{$capture_sets}, @{$self->_core_get_all_species_and_object_types_worker($unversioned_id, $known_type, $dba)});
+    }
+  }
+
+  return $capture_sets;
+}
+
+sub _core_get_all_species_and_object_types_worker {
+  # Adapted from method 'Bio::EnsEMBL::Registry::_core_get_species_and_object_type_worker'.
+  my ($self, $stable_id, $known_type, $dba) = @_;
+
+  my %stable_id_stmts = (
+    gene => 'SELECT m.meta_value, "Gene" '
+      . 'FROM %1$s.gene '
+      . 'JOIN %1$s.seq_region USING (seq_region_id) '
+      . 'JOIN %1$s.coord_system USING (coord_system_id) '
+      . 'JOIN %1$s.meta m USING (species_id) '
+      . 'WHERE stable_id = ? '
+      . 'AND m.meta_key = "species.production_name"',
+    transcript => 'SELECT m.meta_value, "Transcript" '
+      . 'FROM %1$s.transcript '
+      . 'JOIN %1$s.seq_region USING (seq_region_id) '
+      . 'JOIN %1$s.coord_system USING (coord_system_id) '
+      . 'JOIN %1$s.meta m USING (species_id) '
+      . 'WHERE stable_id = ? '
+      . 'AND m.meta_key = "species.production_name"',
+    exon => 'SELECT m.meta_value, "Exon" '
+      . 'FROM %1$s.exon '
+      . 'JOIN %1$s.seq_region USING (seq_region_id) '
+      . 'JOIN %1$s.coord_system USING (coord_system_id) '
+      . 'JOIN %1$s.meta m USING (species_id) '
+      . 'WHERE stable_id = ? '
+      . 'AND m.meta_key = "species.production_name"',
+    translation => 'SELECT m.meta_value, "Translation" '
+      . 'FROM %1$s.translation tl '
+      . 'JOIN %1$s.transcript USING (transcript_id) '
+      . 'JOIN %1$s.seq_region USING (seq_region_id) '
+      . 'JOIN %1$s.coord_system USING (coord_system_id) '
+      . 'JOIN %1$s.meta m USING (species_id) '
+      . 'WHERE tl.stable_id = ? '
+      . 'AND m.meta_key = "species.production_name"',
+  );
+
+  my @lc_object_types;
+  if (defined $known_type) {
+    my $lc_known_type = lc $known_type;
+
+    if (!exists $stable_id_stmts{$lc_known_type}) {
+      throw("Cannot fetch $known_type object for ID $stable_id");
+    }
+
+    @lc_object_types = ($lc_known_type);
+  } else {
+    @lc_object_types = ('gene', 'transcript', 'translation', 'exon');
+  }
+
+  my $capture_sets;
+  foreach my $lc_object_type (@lc_object_types) {
+    my $statement = sprintf $stable_id_stmts{$lc_object_type}, $dba->dbc->dbname;
+    my $sth = $dba->dbc()->prepare($statement);
+    $sth->bind_param(1, $stable_id, SQL_VARCHAR);
+
+    $sth->execute;
+    my $object_type_capture_sets = $sth->fetchall_arrayref();
+    $sth->finish;
+
+    push(@{$capture_sets}, @{$object_type_capture_sets});
+  }
+  $dba->dbc->disconnect_if_idle();  # always disconnect after lookup
+  return $capture_sets;
+}
+
+sub stable_id_lookup_all_core {
+  # Adapted from method Bio::EnsEMBL::Registry::stable_id_lookup, the main difference
+  # being that this is intended to return all core objects matching a given stable_id.
+  my ($self, $stable_id, $known_type, $known_species) = @_;
+
+  my $stable_ids_dba = $self->get_DBAdaptor('multi', 'stable_ids', 1);
+
+  my $statement = 'SELECT name, object_type FROM stable_id_lookup join species using(species_id) WHERE db_type = "core" AND stable_id = ?';
+
+  if ($known_species) {
+    $statement .= ' AND name = ?';
+  }
+  if ($known_type) {
+    $statement .= ' AND object_type = ?';
+  }
+
+  my $sth = $stable_ids_dba->dbc()->prepare($statement);
+  my $param_count = 1;
+  $sth->bind_param($param_count, $stable_id, SQL_VARCHAR);
+  if ($known_species) {
+    $known_species = $self->get_alias($known_species);
+    $param_count++;
+    $sth->bind_param($param_count, $known_species, SQL_VARCHAR);
+  }
+  if ($known_type) {
+    $param_count++;
+    $sth->bind_param($param_count, $known_type, SQL_VARCHAR);
+  }
+
+  $sth->execute();
+  my $capture_sets = $sth->fetchall_arrayref();
+  $sth->finish();
+
+  return $capture_sets;
 }
 
 after 'BUILD' => sub {

--- a/t/homology.t
+++ b/t/homology.t
@@ -72,7 +72,7 @@ is_json_GET(
 );
 
 is_json_GET(
-    '/homology/id/ENSG00000139618?format=condensed;target_species=gorilla_gorilla;type=orthologues', {data => []},
+    '/homology/id/ENSG00000176515?format=condensed;target_species=gorilla_gorilla;type=orthologues', {data => []},
     'homologies without compara division specified',
 );
 


### PR DESCRIPTION
### Description

[Ensembl REST PR #583](https://github.com/Ensembl/ensembl-rest/pull/583) deprecated Compara REST endpoints supporting queries by gene/sequence object stable ID, and introduced replacement endpoints supporting queries by species name and object stable ID. (See [ENSINT-1416](https://www.ebi.ac.uk/panda/jira/browse/ENSINT-1416) for more info.)

One of the potential drawbacks highlighted in PR #583 was the fact that the code being used to fetch all objects matching a given stable ID depended on the presence of a `stable_ids` database. This has been realised in the case of the Ensembl REST staging server: in the absence of a `stable_ids` database, stable ID lookup fails for many of the deprecated/replacement Compara endpoints.

**NB:** [Ensembl REST PR #587](https://github.com/Ensembl/ensembl-rest/pull/587) applied these changes to the `release/110` branch, and this PR replicates those changes on the `main` branch.

### Use case

This PR allows the recently deprecated Compara endpoints to function in the absence of a `stable_ids` database, by adapting existing long-lookup code to look up supported objects (i.e. `Gene`, `Transcript`, `Translation` or `Exon`) in a way that allows for duplicate stable IDs.

### Benefits

The affected Compara endpoints will function even in the absence of a `stable_ids` database.

### Possible Drawbacks

No drawbacks are envisaged.

### Testing

All Compara unit tests pass locally, whether with or without the `multi/stable_ids` test database.

### Notes

No PR has been submitted to `ensembl-rest_private`, as no changes have been made to the documentation.

The stable ID used in the `homologies without compara division specified` unit test has been changed to one that is present in the`homo_sapiens/core` test database.
