### PR TITLE
updated default config file

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -21,11 +21,11 @@ jsonp=1
   port = 3306
   user = anonymous
   
-  # host = mysql.ebi.ac.uk
+  # host = mysql-eg-publicsql.ebi.ac.uk
   # port = 4157
   # user = anonymous
  
-  version = 88
+  version = 110
   verbose = 0
   
   ###### Registry file settings


### PR DESCRIPTION
### Description

Minor changes to the `ensembl_rest.conf.default` default config file

### Use case

Update outdated Ensembl version 88 and amended outdated (and non-working) `mysql.ebi.ac.uk`

### Benefits

Reduced annoyance on my side

### Possible Drawbacks

Complaints from the wistful ones

### Testing

Successfully performed (manually)

### Changelog

N/A
