### PR TITLE
Document MaveDB plugin (111)

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -228,6 +228,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <MaveDB>
+        type=Boolean
+        description=Provides scores from Multiplexed Assays of Variant Effect for variants as reported by <a target="_blank" href="https://www.mavedb.org">MaveDB</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaveDB.pm">plugin details</a>)
+        default=0
+      </MaveDB>
       <NMD>
         type=Boolean
         description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
@@ -541,6 +546,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <MaveDB>
+        type=Boolean
+        description=Provides scores from Multiplexed Assays of Variant Effect for variants as reported by <a target="_blank" href="https://www.mavedb.org">MaveDB</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaveDB.pm">plugin details</a>)
+        default=0
+      </MaveDB>
       <NMD>
         type=Boolean
         description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
@@ -841,6 +851,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <MaveDB>
+        type=Boolean
+        description=Provides scores from Multiplexed Assays of Variant Effect for variants as reported by <a target="_blank" href="https://www.mavedb.org">MaveDB</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaveDB.pm">plugin details</a>)
+        default=0
+      </MaveDB>
       <NMD>
         type=Boolean
         description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
@@ -1136,6 +1151,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <MaveDB>
+        type=Boolean
+        description=Provides scores from Multiplexed Assays of Variant Effect for variants as reported by <a target="_blank" href="https://www.mavedb.org">MaveDB</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaveDB.pm">plugin details</a>)
+        default=0
+      </MaveDB>
       <NMD>
         type=Boolean
         description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
@@ -1442,6 +1462,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <MaveDB>
+        type=Boolean
+        description=Provides scores from Multiplexed Assays of Variant Effect for variants as reported by <a target="_blank" href="https://www.mavedb.org">MaveDB</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaveDB.pm">plugin details</a>)
+        default=0
+      </MaveDB>
       <NMD>
         type=Boolean
         description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
@@ -1756,6 +1781,11 @@
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
+      <MaveDB>
+        type=Boolean
+        description=Provides scores from Multiplexed Assays of Variant Effect for variants as reported by <a target="_blank" href="https://www.mavedb.org">MaveDB</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaveDB.pm">plugin details</a>)
+        default=0
+      </MaveDB>
       <NMD>
         type=Boolean
         description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)


### PR DESCRIPTION
### Description

[ENSVAR-5485](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5485): Add documentation for the MaveDB plugin.

### Possible Drawbacks

No drawbacks.

### Testing

Changes to documentation can be checked in http://hl-codon-06-01:3000/documentation/info/vep_region_get

### Changelog

[/vep] Documented MaveDB plugin