### PR TITLE
Document OpenTargets plugin (e111)

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -185,38 +185,38 @@
       </pick_order>
       <AncestralAllele>
         type=Boolean
-        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
+        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AncestralAllele.pm">plugin details</a>)
         default=0
       </AncestralAllele>
       <Blosum62>
         type=Boolean
-        description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
+        description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Blosum62.pm">plugin details</a>)
         default=0
       </Blosum62>
       <Conservation>
         type=Boolean
-        description=Retrieves a conservation score from the Ensembl Compara databases for variant positions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Conservation.pm">plugin details</a>)
+        description=Retrieves a conservation score from the Ensembl Compara databases for variant positions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Conservation.pm">plugin details</a>)
         default=0
       </Conservation>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
       <dbscSNV>
         type=Boolean
-        description=Predictions for splicing variants from dbscSNV. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbscSNV.pm">plugin details</a>)
+        description=Predictions for splicing variants from dbscSNV. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/dbscSNV.pm">plugin details</a>)
         default=0
       </dbscSNV>
       <GeneSplicer>
         type=Boolean
-        description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/GeneSplicer.pm">plugin details</a>)
+        description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/GeneSplicer.pm">plugin details</a>)
         default=0
       </GeneSplicer>
       <IntAct>
         type=Boolean
-        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/IntAct.pm">plugin details</a>)
       </IntAct>
       <mutfunc>
         type=Boolean
@@ -225,17 +225,17 @@
       </mutfunc>
       <MaxEntScan>
         type=Boolean
-        description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
+        description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
       <NMD>
         type=Boolean
-        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/NMD.pm">plugin details</a>)
         default=0
       </NMD>
       <SpliceAI>
         type=Integer
-        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
         default=0
         example=2
       </SpliceAI>
@@ -266,32 +266,32 @@
       </transcript_id>
       <Phenotypes>
         type=Boolean
-        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
+        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
       <DisGeNET>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DisGeNET.pm">plugin details</a>)
         default=0
       </DisGeNET>
       <Mastermind>
         type=Boolean
-        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Mastermind.pm">plugin details</a>)
+        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
         default=0
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
         type=Boolean
-        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/OpenTargets.pm">plugin details</a>)
+        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/OpenTargets.pm">plugin details</a>)
         default=0
       </OpenTargets>
       <EVE>
         type=Boolean
-        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
+        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/EVE.pm">plugin details</a>)
         default=0
       </EVE>
       <GO>
@@ -508,33 +508,33 @@
       </pick_order>
       <AncestralAllele>
         type=Boolean
-        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
+        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AncestralAllele.pm">plugin details</a>)
         default=0
       </AncestralAllele>
       <Blosum62>
         type=Boolean
-        description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
+        description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Blosum62.pm">plugin details</a>)
         default=0
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
       <dbscSNV>
         type=Boolean
-        description=Predictions for splicing variants from dbscSNV. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbscSNV.pm">plugin details</a>)
+        description=Predictions for splicing variants from dbscSNV. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/dbscSNV.pm">plugin details</a>)
         default=0
       </dbscSNV>
       <GeneSplicer>
         type=Boolean
-        description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/GeneSplicer.pm">plugin details</a>)
+        description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/GeneSplicer.pm">plugin details</a>)
         default=0
       </GeneSplicer>
       <IntAct>
         type=Boolean
-        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/IntAct.pm">plugin details</a>)
       </IntAct>
       <mutfunc>
         type=Boolean
@@ -543,17 +543,17 @@
       </mutfunc>
       <MaxEntScan>
         type=Boolean
-        description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
+        description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
       <NMD>
         type=Boolean
-        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/NMD.pm">plugin details</a>)
         default=0
       </NMD>
       <SpliceAI>
         type=Integer
-        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
         default=0
         example=2
       </SpliceAI>
@@ -584,32 +584,32 @@
       </transcript_id>
       <Phenotypes>
         type=Boolean
-        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
+        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
       <DisGeNET>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DisGeNET.pm">plugin details</a>)
         default=0
       </DisGeNET>
       <Mastermind>
         type=Boolean
-        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Mastermind.pm">plugin details</a>)
+        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
         default=0
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
         type=Boolean
-        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/OpenTargets.pm">plugin details</a>)
+        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/OpenTargets.pm">plugin details</a>)
         default=0
       </OpenTargets>
       <EVE>
         type=Boolean
-        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
+        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/EVE.pm">plugin details</a>)
         default=0
       </EVE>
       <GO>
@@ -808,38 +808,38 @@
       </pick_order>
       <AncestralAllele>
         type=Boolean
-        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
+        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AncestralAllele.pm">plugin details</a>)
         default=0
       </AncestralAllele>
       <Blosum62>
         type=Boolean
-        description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
+        description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Blosum62.pm">plugin details</a>)
         default=0
       </Blosum62>
       <Conservation>
         type=Boolean
-        description=Retrieves a conservation score from the Ensembl Compara databases for variant positions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Conservation.pm">plugin details</a>)
+        description=Retrieves a conservation score from the Ensembl Compara databases for variant positions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Conservation.pm">plugin details</a>)
         default=0
       </Conservation>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
       <dbscSNV>
         type=Boolean
-        description=Predictions for splicing variants from dbscSNV. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbscSNV.pm">plugin details</a>)
+        description=Predictions for splicing variants from dbscSNV. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/dbscSNV.pm">plugin details</a>)
         default=0
       </dbscSNV>
       <GeneSplicer>
         type=Boolean
-        description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/GeneSplicer.pm">plugin details</a>)
+        description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/GeneSplicer.pm">plugin details</a>)
         default=0
       </GeneSplicer>
       <IntAct>
         type=Boolean
-        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/IntAct.pm">plugin details</a>)
       </IntAct>
       <mutfunc>
         type=Boolean
@@ -848,17 +848,17 @@
       </mutfunc>
       <MaxEntScan>
         type=Boolean
-        description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
+        description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
       <NMD>
         type=Boolean
-        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/NMD.pm">plugin details</a>)
         default=0
       </NMD>
       <SpliceAI>
         type=Integer
-        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
         default=0
         example=2
       </SpliceAI>
@@ -889,32 +889,32 @@
       </transcript_id>
       <Phenotypes>
         type=Boolean
-        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
+        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
       <DisGeNET>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DisGeNET.pm">plugin details</a>)
         default=0
       </DisGeNET>
       <Mastermind>
         type=Boolean
-        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Mastermind.pm">plugin details</a>)
+        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
         default=0
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
         type=Boolean
-        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/OpenTargets.pm">plugin details</a>)
+        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/OpenTargets.pm">plugin details</a>)
         default=0
       </OpenTargets>
       <EVE>
         type=Boolean
-        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
+        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/EVE.pm">plugin details</a>)
         default=0
       </EVE>
       <GO>
@@ -1113,33 +1113,33 @@
       </pick_order>
       <AncestralAllele>
         type=Boolean
-        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
+        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AncestralAllele.pm">plugin details</a>)
         default=0
       </AncestralAllele>
       <Blosum62>
         type=Boolean
-        description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
+        description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Blosum62.pm">plugin details</a>)
         default=0
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
       <dbscSNV>
         type=Boolean
-        description=Predictions for splicing variants from dbscSNV. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbscSNV.pm">plugin details</a>)
+        description=Predictions for splicing variants from dbscSNV. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/dbscSNV.pm">plugin details</a>)
         default=0
       </dbscSNV>
       <GeneSplicer>
         type=Boolean
-        description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/GeneSplicer.pm">plugin details</a>)
+        description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/GeneSplicer.pm">plugin details</a>)
         default=0
       </GeneSplicer>
       <IntAct>
         type=Boolean
-        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/IntAct.pm">plugin details</a>)
       </IntAct>
       <mutfunc>
         type=Boolean
@@ -1148,17 +1148,17 @@
       </mutfunc>
       <MaxEntScan>
         type=Boolean
-        description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
+        description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
       <NMD>
         type=Boolean
-        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/NMD.pm">plugin details</a>)
         default=0
       </NMD>
       <SpliceAI>
         type=Integer
-        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
         default=0
         example=2
       </SpliceAI>
@@ -1189,32 +1189,32 @@
       </transcript_id>
       <Phenotypes>
         type=Boolean
-        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
+        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
       <DisGeNET>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DisGeNET.pm">plugin details</a>)
         default=0
       </DisGeNET>
       <Mastermind>
         type=Boolean
-        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Mastermind.pm">plugin details</a>)
+        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
         default=0
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
         type=Boolean
-        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/OpenTargets.pm">plugin details</a>)
+        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/OpenTargets.pm">plugin details</a>)
         default=0
       </OpenTargets>
       <EVE>
         type=Boolean
-        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
+        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/EVE.pm">plugin details</a>)
         default=0
       </EVE>
       <GO>
@@ -1419,38 +1419,38 @@
       </pick_order>
       <AncestralAllele>
         type=Boolean
-        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
+        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AncestralAllele.pm">plugin details</a>)
         default=0
       </AncestralAllele>
       <Blosum62>
         type=Boolean
-        description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
+        description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Blosum62.pm">plugin details</a>)
         default=0
       </Blosum62>
       <Conservation>
         type=Boolean
-        description=Retrieves a conservation score from the Ensembl Compara databases for variant positions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Conservation.pm">plugin details</a>)
+        description=Retrieves a conservation score from the Ensembl Compara databases for variant positions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Conservation.pm">plugin details</a>)
         default=0
       </Conservation>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
       <dbscSNV>
         type=Boolean
-        description=Predictions for splicing variants from dbscSNV. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbscSNV.pm">plugin details</a>)
+        description=Predictions for splicing variants from dbscSNV. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/dbscSNV.pm">plugin details</a>)
         default=0
       </dbscSNV>
       <GeneSplicer>
         type=Boolean
-        description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/GeneSplicer.pm">plugin details</a>)
+        description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/GeneSplicer.pm">plugin details</a>)
         default=0
       </GeneSplicer>
       <IntAct>
         type=Boolean
-        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/IntAct.pm">plugin details</a>)
       </IntAct>
       <mutfunc>
         type=Boolean
@@ -1459,17 +1459,17 @@
       </mutfunc>
       <MaxEntScan>
         type=Boolean
-        description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
+        description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
       <NMD>
         type=Boolean
-        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/NMD.pm">plugin details</a>)
         default=0
       </NMD>
       <SpliceAI>
         type=Integer
-        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
         default=0
         example=2
       </SpliceAI>
@@ -1500,32 +1500,32 @@
       </transcript_id>
       <Phenotypes>
         type=Boolean
-        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
+        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
       <DisGeNET>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DisGeNET.pm">plugin details</a>)
         default=0
       </DisGeNET>
       <Mastermind>
         type=Boolean
-        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Mastermind.pm">plugin details</a>)
+        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
         default=0
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
         type=Boolean
-        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/OpenTargets.pm">plugin details</a>)
+        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/OpenTargets.pm">plugin details</a>)
         default=0
       </OpenTargets>
       <EVE>
         type=Boolean
-        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
+        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/EVE.pm">plugin details</a>)
         default=0
       </EVE>
       <GO>
@@ -1743,33 +1743,33 @@
       </pick_order>
       <AncestralAllele>
         type=Boolean
-        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/AncestralAllele.pm">plugin details</a>)
+        description=Retrieves the ancestral allele for variants inferred from the Ensembl Compara Enredo-Pecan-Ortheus (EPO) pipeline (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AncestralAllele.pm">plugin details</a>)
         default=0
       </AncestralAllele>
       <Blosum62>
         type=Boolean
-        description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Blosum62.pm">plugin details</a>)
+        description=Include BLOSUM62 amino acid conservation score (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Blosum62.pm">plugin details</a>)
         default=0
       </Blosum62>
       <dbNSFP>
         type=String
-        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbNSFP.pm">plugin details</a>)
+        description=Comma-separated list of fields from dbNSFP, a database of pathogenicity predictions for missense variants. See <a target="_blank" href="__VAR(dbnsfp_readme)__">dbNSFP README</a> for field list or include all fields with <code>ALL</code>; this fetches a large amount of data per variant! By default, some fields contain values for all Ensembl transcripts; add <code>transcript_match=1</code> to only return values for the matched Ensembl transcript. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/dbNSFP.pm">plugin details</a>)
         default=Not used
         example=LRT_pred,<wbr>MutationTaster_pred
       </dbNSFP>
       <dbscSNV>
         type=Boolean
-        description=Predictions for splicing variants from dbscSNV. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/dbscSNV.pm">plugin details</a>)
+        description=Predictions for splicing variants from dbscSNV. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/dbscSNV.pm">plugin details</a>)
         default=0
       </dbscSNV>
       <GeneSplicer>
         type=Boolean
-        description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/GeneSplicer.pm">plugin details</a>)
+        description=Detects splice sites in genomic DNA (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/GeneSplicer.pm">plugin details</a>)
         default=0
       </GeneSplicer>
       <IntAct>
         type=Boolean
-        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/IntAct.pm">plugin details</a>)
+        description=Provides molecular interaction data for variants as reported by <a target="_blank" href="https://www.ebi.ac.uk/intact/home">IntAct</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/IntAct.pm">plugin details</a>)
       </IntAct>
       <mutfunc>
         type=Boolean
@@ -1778,17 +1778,17 @@
       </mutfunc>
       <MaxEntScan>
         type=Boolean
-        description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/MaxEntScan.pm">plugin details</a>)
+        description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaxEntScan.pm">plugin details</a>)
         default=0
       </MaxEntScan>
       <NMD>
         type=Boolean
-        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/NMD.pm">plugin details</a>)
+        description=Predicts if a variant allows the transcript escape nonsense-mediated mRNA decay. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/NMD.pm">plugin details</a>)
         default=0
       </NMD>
       <SpliceAI>
         type=Integer
-        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
+        description=Retrieves pre-calculated annotations from SpliceAI a deep neural network, developed by Illumina, Inc that predicts splice junctions from an arbitrary pre-mRNA transcript sequence. Used for non-commercial purposes. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/SpliceAI.pm">plugin details</a>) <br>The pre-calculated annotations for all possible single nucleotide substitutions can be retrieved from: value <b>1</b>) Ensembl/GENCODE v24 canonical transcripts (masked scores); value <b>2</b>) Ensembl/GENCODE v37 MANE transcripts (raw scores). <br>Note: The pre-calculated annotations for 1 base insertions, and 1-4 base deletions are only available for Ensembl/GENCODE v24 canonical transcripts.
         default=0
         example=2
       </SpliceAI>
@@ -1819,32 +1819,32 @@
       </transcript_id>
       <Phenotypes>
         type=Boolean
-        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Phenotypes.pm">plugin details</a>)
+        description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
       <DisGeNET>
         type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/DisGeNET.pm">plugin details</a>)
+        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DisGeNET.pm">plugin details</a>)
         default=0
       </DisGeNET>
       <Mastermind>
         type=Boolean
-        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/Mastermind.pm">plugin details</a>)
+        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
         default=0
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
         type=Boolean
-        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/OpenTargets.pm">plugin details</a>)
+        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/OpenTargets.pm">plugin details</a>)
         default=0
       </OpenTargets>
       <EVE>
         type=Boolean
-        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
+        description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/EVE.pm">plugin details</a>)
         default=0
       </EVE>
       <GO>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -284,6 +284,11 @@
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
         default=0
       </CADD>
+      <OpenTargets>
+        type=Boolean
+        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/OpenTargets.pm">plugin details</a>)
+        default=0
+      </OpenTargets>
       <EVE>
         type=Boolean
         description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
@@ -597,6 +602,11 @@
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
         default=0
       </CADD>
+      <OpenTargets>
+        type=Boolean
+        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/OpenTargets.pm">plugin details</a>)
+        default=0
+      </OpenTargets>
       <EVE>
         type=Boolean
         description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
@@ -897,6 +907,11 @@
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
         default=0
       </CADD>
+      <OpenTargets>
+        type=Boolean
+        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/OpenTargets.pm">plugin details</a>)
+        default=0
+      </OpenTargets>
       <EVE>
         type=Boolean
         description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
@@ -1192,6 +1207,11 @@
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
         default=0
       </CADD>
+      <OpenTargets>
+        type=Boolean
+        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/OpenTargets.pm">plugin details</a>)
+        default=0
+      </OpenTargets>
       <EVE>
         type=Boolean
         description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
@@ -1498,6 +1518,11 @@
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
         default=0
       </CADD>
+      <OpenTargets>
+        type=Boolean
+        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/OpenTargets.pm">plugin details</a>)
+        default=0
+      </OpenTargets>
       <EVE>
         type=Boolean
         description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)
@@ -1812,6 +1837,11 @@
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/CADD.pm">plugin details</a>)
         default=0
       </CADD>
+      <OpenTargets>
+        type=Boolean
+        description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/OpenTargets.pm">plugin details</a>)
+        default=0
+      </OpenTargets>
       <EVE>
         type=Boolean
         description=EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences. See <a target="_blank" href="https://evemodel.org/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/master/EVE.pm">plugin details</a>)


### PR DESCRIPTION
### Description

[ENSVAR-5840](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5840): Add documentation for the new VEP plugin OpenTargets (configured in https://github.com/Ensembl/ensembl-rest_private/pull/134).

Also, update links pointing to VEP_plugin github repo: branch is now `main`.

### Possible Drawbacks

No drawbacks.

### Testing

Changes in documentation can be tested in http://hl-codon-21-03.ebi.ac.uk:3000

### Changelog

[/vep] Documented OpenTargets plugin
