### PR TITLE
Return structural variants by ID in Variation/VEP endpoints

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -185,6 +185,7 @@ jsonp=1
     
     variation_id=rs56116432
     variation_id_two=COSM476
+    sv_id=esv1815690
 
     variation_id_three=rs1042779
     variation_id_four=rs699

--- a/lib/EnsEMBL/REST/Model/Variation.pm
+++ b/lib/EnsEMBL/REST/Model/Variation.pm
@@ -90,7 +90,7 @@ sub fetch_variation_multiple {
 
   # check if remaining IDs are structural variants
   my %svs;
-  if (@$remaining_ids) {
+  if (defined $remaining_ids && @$remaining_ids) {
     my $sva = $c->model('Registry')->get_adaptor($species, 'Variation', 'StructuralVariation');
     %svs = map {$_->variation_name => $self->to_hash($_)} @{$sva->fetch_all_by_name_list($remaining_ids || [])};
     %return = (%return, %svs);

--- a/lib/EnsEMBL/REST/Model/Variation.pm
+++ b/lib/EnsEMBL/REST/Model/Variation.pm
@@ -22,7 +22,7 @@ package EnsEMBL::REST::Model::Variation;
 use Moose;
 use Catalyst::Exception qw(throw);
 use Scalar::Util qw/weaken/;
-use Bio::EnsEMBL::Variation::Utils::Constants qw(%OVERLAP_CONSEQUENCES %VARIATION_CLASSES);
+use Bio::EnsEMBL::Variation::Utils::Constants qw(%OVERLAP_CONSEQUENCES);
 extends 'Catalyst::Model';
 
 with 'Catalyst::Component::InstancePerContext';
@@ -59,7 +59,7 @@ sub fetch_variation {
     my $sva = $c->model('Registry')->get_adaptor($species, 'Variation', 'StructuralVariation');
     $variation = $sva->fetch_by_name($variation_id);
 
-    Catalyst::Exception->throw("$variation_id frankly not found for $species") unless $variation;
+    Catalyst::Exception->throw("$variation_id not found for $species") unless $variation;
   }
   return $self->to_hash($variation);
 }

--- a/root/documentation/variation.conf
+++ b/root/documentation/variation.conf
@@ -10,8 +10,9 @@
     <params>
       <id>
         type=String
-        description=Variant id
+        description=Variant identifier, including structural variant identifiers.
         example=__VAR(variation_id)__
+        example=__VAR(sv_id)__
         required=1
       </id>
       <species>
@@ -145,7 +146,7 @@
         path=/variation/__VAR(species)__
         accept=application/json
         content=application/json
-        body={ "ids" : ["__VAR(variation_id)__", "__VAR(variation_id_two)__" ] }
+        body={ "ids" : ["__VAR(variation_id)__", "__VAR(variation_id_two)__", "__VAR(sv_id)__" ] }
       </basic>
     </examples>
   </variation_post>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -626,9 +626,10 @@
      </species>
      <id>
        type=String
-       description=Query ID. Supports dbSNP, COSMIC and HGMD identifiers
+       description=Query ID. Supports dbSNP, COSMIC and HGMD identifiers, including structural variant idefentifiers.
        example=__VAR(variation_id)__
        example=__VAR(variation_id_two)__
+       example=__VAR(sv_id)__
        required=1
      </id>
       <hgvs>
@@ -1189,7 +1190,7 @@
         path=/vep/__VAR(species_common)__/id
         accept=application/json
         content=application/json
-        body={ "ids" : ["__VAR(variation_id)__", "__VAR(variation_id_two)__" ] }
+        body={ "ids" : ["__VAR(variation_id)__", "__VAR(variation_id_two)__", "__VAR(sv_id)__" ] }
       </basic>
     </examples>
   </vep_id_post>

--- a/t/variation.t
+++ b/t/variation.t
@@ -51,6 +51,55 @@ my $base = '/variation/homo_sapiens';
   my $phen_json = json_GET("$base/$id?phenotypes=1", "Phenotype info");
   cmp_deeply($phen_json, $expected_phenotype, "Returning phenotype information");
 
+#Get basic structural variation summary
+  my $id_sv = 'esv93078';
+  my $json_sv = json_GET("$base/$id_sv", 'Variation feature');
+  #is(scalar(@$json), 1, '1 variation feature returned');
+  my $expected_sv = {
+    source => 'Database of Genomic Variants Archive',
+    name => $id_sv,
+    alias => undef,
+    study => {
+      name => "estd59",
+      description => "1000 Genomes Project Consortium - Pilot Project. PMID:20981092 [remapped from build NCBI36]",
+      url => "ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd59_1000_Genomes_Consortium_Pilot_Project",
+    },
+    validation_status => "high quality",
+    var_class => "CNV",
+    mappings => [{
+      assembly_name => "GRCh37", 
+      location => "8:7803891-7825340",
+      strand => 1, 
+      start => 7803891, 
+      end => 7825340, 
+      seq_region_name => "8", 
+      coord_system => "chromosome",
+      genomic_size => 21450
+    }],
+    supporting_evidence => [{
+      alias => undef,
+      name => "essv194300",
+      mappings => [{
+        assembly_name => "GRCh37", 
+        location => "8:7803891-7825340",
+        strand => 1, 
+        start => 7803891, 
+        end => 7825340, 
+        seq_region_name => "8", 
+        coord_system => "chromosome",
+        genomic_size => 21450
+      }],
+      source => "Database of Genomic Variants Archive",
+      study => {
+        name => "estd59",
+        description => "1000 Genomes Project Consortium - Pilot Project. PMID:20981092 [remapped from build NCBI36]",
+        url => "ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd59_1000_Genomes_Consortium_Pilot_Project",
+      },
+      var_class => "loss"
+    }],
+  };
+  cmp_deeply($json_sv, $expected_sv, "Checking the result from the variation endpoint - SV");
+
 # Include genotyping chips information
   $id = 'rs7698608';
   my $expected_variation_3 = {source => 'Variants (including SNPs and indels) imported from dbSNP', name => $id, MAF => '0.448577', minor_allele => 'C', ambiguity => 'M', var_class => 'SNP', synonyms => bag(qw/rs60248177 rs17215092/), evidence => [], most_severe_consequence => '5_prime_UTR_variant', mappings => [{"assembly_name" => "GRCh37", "location"=>"4:103937974-103937974", "strand" => 1, "start" => 103937974, "end" => 103937974, "seq_region_name" => "4", "coord_system" => "chromosome","allele_string"=>"C/A","ancestral_allele" => undef}]};
@@ -100,8 +149,12 @@ my $base = '/variation/homo_sapiens';
    my $pop_genos_json = json_GET("$base/$id?population_genotypes=1", "Population_genotype info");
    cmp_deeply($pop_genos_json, $expected_pop_genos, "Returning population_genotype information");
 
-my $post_data = '{ "ids" : ["rs142276873","rs67521280"]}';
-my $expected_result = { rs142276873 => $expected_variation_1, rs67521280 => $expected_variation_2 };
+my $post_data = '{ "ids" : ["rs142276873","rs67521280","esv93078"]}';
+my $expected_result = {
+  rs142276873 => $expected_variation_1,
+  rs67521280 => $expected_variation_2,
+  esv93078 => $expected_sv
+};
 
 is_json_POST($base,$post_data,$expected_result,"Try to POST list of variations");
 

--- a/t/vep.t
+++ b/t/vep.t
@@ -294,7 +294,7 @@ lives_ok{$json = json_POST($vep_post,$vep_post_body_invalid,'POST a selection of
 
 # test vep/id
 my $vep_id_get = '/vep/homo_sapiens/id/rs186950277?content-type=application/json';
-$vep_output =
+my $rs186950277_output =
 [{
   allele_string => "G/A/T",
   colocated_variants =>
@@ -342,35 +342,59 @@ $vep_output =
   }];
 
 $json = json_GET($vep_id_get,'GET consequences for Variation ID');
-cmp_bag($json, $vep_output, 'VEP id GET');
+cmp_bag($json, $rs186950277_output, 'VEP id GET');
 
-
-my $vep_id_post = '/vep/homo_sapiens/id';
-my $vep_id_body = '{ "ids" : ["rs186950277", "rs17081232" ]}';
-$vep_output =
+# test vep/id for structural variants
+$vep_id_get = '/vep/homo_sapiens/id/esv93078?content-type=application/json';
+my $esv93078_output =
 [{
-  allele_string => "G/A/T",
-  colocated_variants =>
-  [{
-    'minor_allele_freq' => 0.0014,
-    'frequencies' => {
-      'A' => {
-        'amr' => 0.01,
-        'afr' => 0,
-        'eur' => 0.0013,
-        'asn' => 0
-      }
-    },
-    'end' => 60403074,
-    'strand' => 1,
-    'id' => 'rs186950277',
-    'allele_string' => 'G/A/T',
-    'minor_allele' => 'A',
-    'start' => 60403074
-  }],
-  end => 60403074,
-  id => 'rs186950277',
-  input => 'rs186950277',
+  allele_string => "copy_number_variation",
+  end => 7825340,
+  id => 'esv93078',
+  input => 'esv93078',
+  intergenic_consequences => [
+    {
+      consequence_terms => [
+        'intergenic_variant'
+      ],
+      impact => 'MODIFIER',
+      variant_allele => 'copy_number_variation'
+    }
+  ],
+  most_severe_consequence => 'intergenic_variant',
+  seq_region_name => '8',
+  assembly_name => 'GRCh37',
+  start => 7803891,
+  strand => 1
+  }];
+
+$json = json_GET($vep_id_get,'GET consequences for Variation ID');
+cmp_bag($json, $esv93078_output, 'VEP id GET');
+
+my $rs17081232_output = [{
+  allele_string => 'G/A',
+  colocated_variants => [
+    {
+      'minor_allele_freq' => 0.2443,
+      'frequencies' => {
+        'A' => {
+          'amr' => 0.25,
+          'afr' => 0.45,
+          'eur' => 0.11,
+          'asn' => 0.24
+        }
+      },
+      'end' => 32305409,
+      'strand' => 1,
+      'id' => 'rs17081232',
+      'allele_string' => 'G/A',
+      'minor_allele' => 'A',
+      'start' => 32305409
+    }
+  ],
+  end => 32305409,
+  id => 'rs17081232',
+  input => 'rs17081232',
   intergenic_consequences => [
     {
       consequence_terms => [
@@ -378,60 +402,19 @@ $vep_output =
       ],
       impact => 'MODIFIER',
       variant_allele => 'A'
-    },
-    {
-      consequence_terms => [
-        'intergenic_variant'
-      ],
-      impact => 'MODIFIER',
-      variant_allele => 'T'
     }
   ],
   most_severe_consequence => 'intergenic_variant',
-  seq_region_name => '8',
+  seq_region_name => '4',
   assembly_name => 'GRCh37',
-  start => 60403074,
-  strand => 1,
-  },
-  {
-    allele_string => 'G/A',
-    colocated_variants => [
-      {
-        'minor_allele_freq' => 0.2443,
-        'frequencies' => {
-          'A' => {
-            'amr' => 0.25,
-            'afr' => 0.45,
-            'eur' => 0.11,
-            'asn' => 0.24
-          }
-        },
-        'end' => 32305409,
-        'strand' => 1,
-        'id' => 'rs17081232',
-        'allele_string' => 'G/A',
-        'minor_allele' => 'A',
-        'start' => 32305409
-      }
-    ],
-    end => 32305409,
-    id => 'rs17081232',
-    input => 'rs17081232',
-    intergenic_consequences => [
-      {
-        consequence_terms => [
-          'intergenic_variant'
-        ],
-        impact => 'MODIFIER',
-        variant_allele => 'A'
-      }
-    ],
-    most_severe_consequence => 'intergenic_variant',
-    seq_region_name => '4',
-    assembly_name => 'GRCh37',
-    start => 32305409,
-    strand => 1
-  }];
+  start => 32305409,
+  strand => 1
+}];
+
+my $vep_id_post = '/vep/homo_sapiens/id';
+my $vep_id_body = '{ "ids" : ["rs186950277", "rs17081232", "esv93078" ]}';
+$vep_output =
+[$rs186950277_output->[0], $rs17081232_output->[0], $esv93078_output->[0]];
 
 
 $json = json_POST($vep_id_post,$vep_id_body,'VEP ID list POST');


### PR DESCRIPTION
### Description

[ENSVAR-5793](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5793): Return structural variants (SVs) by their ID when using Variation/VEP endpoints.

The information displayed for SVs is based on their Ensembl Variation page: for instance, [esv1815690](https://www.ensembl.org/Homo_sapiens/StructuralVariation/Mappings?db=core;sv=esv1815690)

Requires https://github.com/Ensembl/ensembl-variation/pull/1029.

### Use case

Users request that these endpoints return SVs (e.g., `esv1815690`). Currently, they only return non-SVs (e.g., `rs699`).

### Possible Drawbacks

If all IDs are non-SVs, the code will take the same time as before; otherwise, the code looks for the mismatched IDs in the SV table.

Also, some SVs may hit the memory limit, such as in the case of `nsv3901821`, and return an error message: `ERROR: Cannot allocate memory`.

### Testing

Unit tests added (but failing because they require https://github.com/Ensembl/ensembl-variation/pull/1029).

#### Some examples

- http://wp-np2-11.ebi.ac.uk:9300/vep/human/id/esv1815690
- http://wp-np2-11.ebi.ac.uk:9300/variation/human/esv1815690
```bash
# POST variation/human
curl -d '{ "ids" : ["esv1815690", "rs699", "cnvi0111251"] }' -H "Content-Type: application/json" http://wp-np2-11.ebi.ac.uk:9300/variation/human

# POST vep/human/id
curl -d '{ "ids" : ["esv1815690", "rs699", "cnvi0111251"] }' -H "Content-Type: application/json" http://wp-np2-11.ebi.ac.uk:9300/vep/human/id
```

#### Documentation changes

Check the following documentation updates in my sandbox:
- http://wp-np2-11.ebi.ac.uk:9300/documentation/info/variation_id
- http://wp-np2-11.ebi.ac.uk:9300/documentation/info/variation_post
- http://wp-np2-11.ebi.ac.uk:9300/documentation/info/vep_id_get
- http://wp-np2-11.ebi.ac.uk:9300/documentation/info/vep_id_post

### Changelog

[/variation/:species/id] Return structural variants by their ID
[/variation/:species] Return structural variants by their ID
[/vep/:species/id] Return structural variants by their ID
[/vep/:species] Return structural variants by their ID