### PR TITLE
Document SV ID support in Variation/VEP

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -185,6 +185,7 @@ jsonp=1
     
     variation_id=rs56116432
     variation_id_two=COSM476
+    sv_id=esv1815690
 
     variation_id_three=rs1042779
     variation_id_four=rs699

--- a/root/documentation/variation.conf
+++ b/root/documentation/variation.conf
@@ -10,8 +10,9 @@
     <params>
       <id>
         type=String
-        description=Variant id
+        description=Variant identifier, including structural variant identifiers.
         example=__VAR(variation_id)__
+        example=__VAR(sv_id)__
         required=1
       </id>
       <species>
@@ -145,7 +146,7 @@
         path=/variation/__VAR(species)__
         accept=application/json
         content=application/json
-        body={ "ids" : ["__VAR(variation_id)__", "__VAR(variation_id_two)__" ] }
+        body={ "ids" : ["__VAR(variation_id)__", "__VAR(variation_id_two)__", "__VAR(sv_id)__" ] }
       </basic>
     </examples>
   </variation_post>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -626,9 +626,10 @@
      </species>
      <id>
        type=String
-       description=Query ID. Supports dbSNP, COSMIC and HGMD identifiers
+       description=Query ID. Supports dbSNP, COSMIC and HGMD identifiers, including structural variant idefentifiers.
        example=__VAR(variation_id)__
        example=__VAR(variation_id_two)__
+       example=__VAR(sv_id)__
        required=1
      </id>
       <hgvs>
@@ -1189,7 +1190,7 @@
         path=/vep/__VAR(species_common)__/id
         accept=application/json
         content=application/json
-        body={ "ids" : ["__VAR(variation_id)__", "__VAR(variation_id_two)__" ] }
+        body={ "ids" : ["__VAR(variation_id)__", "__VAR(variation_id_two)__", "__VAR(sv_id)__" ] }
       </basic>
     </examples>
   </vep_id_post>


### PR DESCRIPTION
### Possible Drawbacks

No drawbacks.

### Testing

Check the following documentation pages affected in my sandbox:
- http://wp-np2-11.ebi.ac.uk:9300/documentation/info/variation_id
- http://wp-np2-11.ebi.ac.uk:9300/documentation/info/variation_post
- http://wp-np2-11.ebi.ac.uk:9300/documentation/info/vep_id_get
- http://wp-np2-11.ebi.ac.uk:9300/documentation/info/vep_id_post

### Changelog

[/variation/:species/id] Added the ability to look up structural variants by their ID
[/variation/:species] Added the ability to look up structural variants by their ID
[/vep/:species/id] Added the ability to look up structural variants by their ID
[/vep/:species] Added the ability to look up structural variants by their ID
