### PR TITLE
Update travis and coveralls badges to use main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ API used for our REST server, http://rest.ensembl.org
 
 
 
-[![Build Status](https://travis-ci.org/Ensembl/ensembl-rest.svg?branch=master)][travis]
-[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl-rest/badge.svg?branch=master)][coveralls]
+[![Build Status](https://travis-ci.org/Ensembl/ensembl-rest.svg?branch=main)][travis]
+[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl-rest/badge.svg?branch=main)][coveralls]
 
 [travis]: https://travis-ci.org/Ensembl/ensembl-rest
 [coveralls]: https://coveralls.io/github/Ensembl/ensembl-rest


### PR DESCRIPTION
### Description

Updating Travis and Coveralls badges to use the `main` branch, rather than the out-of-date `master` branch.

### Use case
N/A
### Benefits
Update badges

### Possible Drawbacks
None

### Testing
N/A

### Changelog
N/A