### PR TITLE
Hotfix/enscoresw 4269 e111

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
     - git clone --depth 1 https://github.com/Ensembl/ensembl-git-tools.git
     - export PATH=$PWD/ensembl-git-tools/bin:$PATH
     - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
-    - export ENSEMBL_BRANCH='main'
+    - export ENSEMBL_BRANCH='release/111'
     - export SECONDARY_BRANCH='main'
     - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; export SECONDARY_BRANCH=$TRAVIS_BRANCH; fi
     - echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"

--- a/lib/EnsEMBL/REST/Model/Overlap.pm
+++ b/lib/EnsEMBL/REST/Model/Overlap.pm
@@ -239,7 +239,7 @@ sub exon {
   my @exons;
   foreach my $transcript (@$transcripts) {
     foreach my $exon (@{ $transcript->get_all_ExonTranscripts}) {
-      if (($slice->start < $exon->seq_region_start && $exon->seq_region_start < $slice->end) || ($slice->start < $exon->seq_region_end && $exon->seq_region_end < $slice->end) ||($slice->start >= $exon->seq_region_start && $slice->end <= $exon->seq_region_end) ) {
+      if (($slice->start <= $exon->seq_region_start && $exon->seq_region_start < $slice->end) || ($slice->start < $exon->seq_region_end && $exon->seq_region_end <= $slice->end) ||($slice->start >= $exon->seq_region_start && $slice->end <= $exon->seq_region_end) ) {
         push (@exons, $exon);
       }
     }


### PR DESCRIPTION
### Description

Fix issue #588 

### Use case

Exons of length 1 at the boundary of the given region were not returned by the /overlap endpoint.

### Benefits

Return the exons of length 1 sitting at the region boundary. 

### Possible Drawbacks

Downstream pipelines can be affected.

### Testing

Test suite runs fine

### Changelog

N/A
