### PR TITLE
Include exons of length 1 at the boundary

### DIFF
--- a/lib/EnsEMBL/REST/Model/Overlap.pm
+++ b/lib/EnsEMBL/REST/Model/Overlap.pm
@@ -239,7 +239,7 @@ sub exon {
   my @exons;
   foreach my $transcript (@$transcripts) {
     foreach my $exon (@{ $transcript->get_all_ExonTranscripts}) {
-      if (($slice->start < $exon->seq_region_start && $exon->seq_region_start < $slice->end) || ($slice->start < $exon->seq_region_end && $exon->seq_region_end < $slice->end) ||($slice->start >= $exon->seq_region_start && $slice->end <= $exon->seq_region_end) ) {
+      if (($slice->start <= $exon->seq_region_start && $exon->seq_region_start < $slice->end) || ($slice->start < $exon->seq_region_end && $exon->seq_region_end <= $slice->end) ||($slice->start >= $exon->seq_region_start && $slice->end <= $exon->seq_region_end) ) {
         push (@exons, $exon);
       }
     }


### PR DESCRIPTION
### Description

Sister to PR #612 - this applied to main branch 
Fix issue #588 

### Use case

Exons of length 1 at the boundary of the given region were not returned by the /overlap endpoint.

### Benefits

Return the exons of length 1 sitting at the region boundary. 

### Possible Drawbacks

Downstream pipelines can be affected.

### Testing

Test suite runs fine

### Changelog

N/A
