### PR TITLE
Patch test databases for Release 112 (round 2 before branching)

### DIFF
--- a/t/test-genome-DBs/homo_sapiens/funcgen/meta.txt
+++ b/t/test-genome-DBs/homo_sapiens/funcgen/meta.txt
@@ -212,3 +212,4 @@
 787	\N	patch	patch_110_111_a.sql|schema_version
 788	\N	patch	patch_111_112_a.sql|schema_version
 789	\N	patch	patch_111_112_b.sql|fix data_file_id length
+790	\N	patch	patch_111_112_c.sql|set data_file_id to not null auto increment

--- a/t/test-genome-DBs/homo_sapiens/funcgen/table.sql
+++ b/t/test-genome-DBs/homo_sapiens/funcgen/table.sql
@@ -192,7 +192,7 @@ CREATE TABLE `chance` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `data_file` (
-  `data_file_id` int(10) unsigned NOT NULL,
+  `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `table_id` int(10) unsigned NOT NULL,
   `table_name` varchar(32) NOT NULL,
   `path` varchar(255) NOT NULL,
@@ -221,7 +221,7 @@ CREATE TABLE `epigenome_track` (
   `epigenome_track_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `epigenome_id` int(10) unsigned NOT NULL,
   `feature_type_id` int(10) unsigned NOT NULL,
-  `data_file_id` int(10) unsigned DEFAULT NULL,
+  `data_file_id` int(10) unsigned NOT NULL,
   `track_type` varchar(50) DEFAULT NULL,
   PRIMARY KEY (`epigenome_track_id`),
   KEY `et_index` (`epigenome_id`,`feature_type_id`)
@@ -401,7 +401,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=790 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=791 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,


### PR DESCRIPTION
### Description

PR to incorporate updates to test databases before branching for Release 112.

Patch relates to `funcgen` data: setting `data_file_id` to `NOT NULL` and enabling auto increment.

Build is now passing.

### Use case

### Benefits

Up-to-date test databases.

### Possible Drawbacks

### Testing

note to submitters and reviewers: documentation-only changes may reflect
changes in other repos that can result in new or different output from
REST endpoints. In turn, these may require new tests or changes to existing tests.

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians
