### PR TITLE
New plugin: DosageSensitivity (e112)

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -223,6 +223,11 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
 	default=0
       </mutfunc>
+      <DosageSensitivity>
+        type=Boolean
+        description=Retrieves haploinsufficiency and triplosensitivity probability scores for affected genes from a published <a target="_blank" href="https://www.sciencedirect.com/science/article/pii/S0092867422007887">dosage sensitivity catalogue</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DosageSensitivity.pm">plugin details</a>)
+        default=0
+      </DosageSensitivity>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaxEntScan.pm">plugin details</a>)
@@ -551,6 +556,11 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
+      <DosageSensitivity>
+        type=Boolean
+        description=Retrieves haploinsufficiency and triplosensitivity probability scores for affected genes from a published <a target="_blank" href="https://www.sciencedirect.com/science/article/pii/S0092867422007887">dosage sensitivity catalogue</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DosageSensitivity.pm">plugin details</a>)
+        default=0
+      </DosageSensitivity>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaxEntScan.pm">plugin details</a>)
@@ -867,6 +877,11 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
+      <DosageSensitivity>
+        type=Boolean
+        description=Retrieves haploinsufficiency and triplosensitivity probability scores for affected genes from a published <a target="_blank" href="https://www.sciencedirect.com/science/article/pii/S0092867422007887">dosage sensitivity catalogue</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DosageSensitivity.pm">plugin details</a>)
+        default=0
+      </DosageSensitivity>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaxEntScan.pm">plugin details</a>)
@@ -1177,6 +1192,11 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
+      <DosageSensitivity>
+        type=Boolean
+        description=Retrieves haploinsufficiency and triplosensitivity probability scores for affected genes from a published <a target="_blank" href="https://www.sciencedirect.com/science/article/pii/S0092867422007887">dosage sensitivity catalogue</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DosageSensitivity.pm">plugin details</a>)
+        default=0
+      </DosageSensitivity>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaxEntScan.pm">plugin details</a>)
@@ -1498,6 +1518,11 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
+      <DosageSensitivity>
+        type=Boolean
+        description=Retrieves haploinsufficiency and triplosensitivity probability scores for affected genes from a published <a target="_blank" href="https://www.sciencedirect.com/science/article/pii/S0092867422007887">dosage sensitivity catalogue</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DosageSensitivity.pm">plugin details</a>)
+        default=0
+      </DosageSensitivity>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaxEntScan.pm">plugin details</a>)
@@ -1827,6 +1852,11 @@
         description=Predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant as reported by <a target="_blank" href="http://www.mutfunc.com/">mutfunc</a> database. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/mutfunc.pm">plugin details</a>)
         default=0
       </mutfunc>
+      <DosageSensitivity>
+        type=Boolean
+        description=Retrieves haploinsufficiency and triplosensitivity probability scores for affected genes from a published <a target="_blank" href="https://www.sciencedirect.com/science/article/pii/S0092867422007887">dosage sensitivity catalogue</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DosageSensitivity.pm">plugin details</a>)
+        default=0
+      </DosageSensitivity>
       <MaxEntScan>
         type=Boolean
         description=Sequence motif and maximum entropy based splice site consensus predictions (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/MaxEntScan.pm">plugin details</a>)


### PR DESCRIPTION
### Description
Added documentation for new VEP plugin.

### Use case
Provide information to user about new option available in `vep` rest endpoint.

### Possible Drawbacks
No drawbacks.

### Testing
Checked in sandbox - http://wp-np2-11.ebi.ac.uk:7075

### Changelog
[/vep/:species/hgvs/] new plugin option added: DosageSensitivity
[/vep/:species/id/] new plugin option added: DosageSensitivity
[/vep/:species/region/] new plugin option added: DosageSensitivity
