### PR TITLE
Improve CADD: add SV and pig CADD support (e112)

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -441,7 +441,7 @@ sub _configure_plugins {
           push @params, $param;
         }
         # CADD - check if species is pig and provide appropriate file based on that
-        elsif(lc $module eq 'CADD' && $c->stash->{species} eq "sus_scrofa"){
+        elsif(lc $module eq 'cadd' && $c->stash->{species} eq "sus_scrofa"){
           next unless $param =~ /^snv_pig=/;
 
           my $param_aux = $param;

--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -442,13 +442,13 @@ sub _configure_plugins {
         }
         # CADD - check if species is pig and provide appropriate file based on that
         elsif(lc $module eq 'CADD' && $c->stash->{species} eq "sus_scrofa"){
-          next unless $param_clone =~ /^snv_pig=/;
+          next unless $param =~ /^snv_pig=/;
 
           my $param_aux = $param;
           $param_aux =~ s/snv_pig=//;
-          $param_clone = 'snv=' . $param_aux;
+          $param = 'snv=' . $param_aux;
 
-          push @params, $param_clone;
+          push @params, $param;
         }
         # other params, such as file paths, get passed from the config
         else {

--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -450,6 +450,22 @@ sub _configure_plugins {
 
           push @params, $param;
         }
+        elsif(lc $module eq 'cadd' && ($user_config->{$module} eq "snv_indels" || $user_config->{$module} eq "1")){
+          next unless ($param =~ /^snv=/ || $param =~ /^indels=/);
+          push @params, $param;
+        }
+        elsif(lc $module eq 'cadd' && $user_config->{$module} eq "snv"){
+          next unless ($param =~ /^snv=/);
+          push @params, $param;
+        }
+        elsif(lc $module eq 'cadd' && $user_config->{$module} eq "indels"){
+          next unless ($param =~ /^indels=/);
+          push @params, $param;
+        }
+        elsif(lc $module eq 'cadd' && $user_config->{$module} eq "sv"){
+          next unless ($param =~ /^sv=/);
+          push @params, $param;
+        }
         # other params, such as file paths, get passed from the config
         else {
           push @params, $param;

--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -440,6 +440,16 @@ sub _configure_plugins {
           }
           push @params, $param;
         }
+        # CADD - check if species is pig and provide appropriate file based on that
+        elsif(lc $module eq 'CADD' && $c->stash->{species} eq "sus_scrofa"){
+          next unless $param_clone =~ /^snv_pig=/;
+
+          my $param_aux = $param;
+          $param_aux =~ s/snv_pig=//;
+          $param_clone = 'snv=' . $param_aux;
+
+          push @params, $param_clone;
+        }
         # other params, such as file paths, get passed from the config
         else {
           push @params, $param;

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -291,7 +291,7 @@
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
@@ -619,7 +619,7 @@
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
@@ -935,7 +935,7 @@
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
@@ -1245,7 +1245,7 @@
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
@@ -1566,7 +1566,7 @@
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
@@ -1895,7 +1895,7 @@
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -293,6 +293,7 @@
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
+        example=snv_indels,<wbr>1
       </CADD>
       <OpenTargets>
         type=Boolean
@@ -621,6 +622,7 @@
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
+        example=snv_indels,<wbr>1
       </CADD>
       <OpenTargets>
         type=Boolean
@@ -937,6 +939,7 @@
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
+        example=snv_indels,<wbr>1
       </CADD>
       <OpenTargets>
         type=Boolean
@@ -1247,6 +1250,7 @@
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
+        example=snv_indels,<wbr>1
       </CADD>
       <OpenTargets>
         type=Boolean
@@ -1568,6 +1572,7 @@
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
+        example=snv_indels,<wbr>1
       </CADD>
       <OpenTargets>
         type=Boolean
@@ -1897,6 +1902,7 @@
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
+        example=snv_indels,<wbr>1
       </CADD>
       <OpenTargets>
         type=Boolean

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -291,7 +291,7 @@
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
@@ -619,7 +619,7 @@
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
@@ -935,7 +935,7 @@
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
@@ -1245,7 +1245,7 @@
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
@@ -1566,7 +1566,7 @@
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>
@@ -1895,7 +1895,7 @@
       </Mastermind>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
       </CADD>
       <OpenTargets>


### PR DESCRIPTION
### Description
- ADD options to allow CADD-SV and pCADD annotation using CADD option in Ensembl VEP rest endpoints.
- Update docs to reflect these change. 

### Use case
User trying to annotate CADD for structural variant input for human or SNV for pig

### Benefits
New feature

### Possible Drawbacks
N/A

### Testing
Tested in sandbox; see
https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5782
https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6099

### Changelog
[/vep/:species/hgvs/] new option values allowed for: CADD
[/vep/:species/id/] new option values allowed for: CADD
[/vep/:species/region/] new option values allowed for: CADD
