### PR TITLE
Update to dbNSFP 4.5c (main)

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -160,7 +160,7 @@ jsonp=1
     compara_species_set_group=mammals
     compara_compact=1
 
-    dbnsfp_readme=https://drive.google.com/file/d/1VINShZQYN63HvigJA_SiuOYIk8TWl5Fh/view   
+    dbnsfp_readme=https://usf.app.box.com/s/jpg94a3t0qi529095v7wn4kpmr1at2aa
  
     genetree_stable_id=ENSGT00390000003602
     compara_gene_stable_id=ENSG00000173786

--- a/ensembl_rest_testing.conf
+++ b/ensembl_rest_testing.conf
@@ -58,7 +58,7 @@ jsonp=1
     compara_compact=1
     compara_gene_stable_id=ENSG00000173786
 
-    dbnsfp_readme=https://drive.google.com/file/d/1VINShZQYN63HvigJA_SiuOYIk8TWl5Fh/view
+    dbnsfp_readme=https://usf.app.box.com/s/jpg94a3t0qi529095v7wn4kpmr1at2aa
 
     genetree_stable_id=???
     


### PR DESCRIPTION
Duplicate of https://github.com/Ensembl/ensembl-rest/pull/624 to be merged with `main` branch

### Description

Update dbNSFP README URL to point to information on version 4.5c ([ENSVAR-6120](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6120)).

### Benefits

Required with the updated dbNSFP 4.5c data.

### Possible Drawbacks

No drawbacks.

### Changelog

[/vep] Update README URL for dbNSFP 4.5c
