### PR TITLE
Drop use of non-human aliases in comparative config

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -143,7 +143,7 @@ jsonp=1
     taxon_nameish=Homo%25
     target_taxon=10090
     target_ancestral_taxon=9526
-    target_species=cow
+    target_species=bos_taurus
     
     ontology=GO
     ontology_term_id=GO:0005667


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

This PR removes configuration which depends on a non-human species alias. Specifically, it replaces the `cow` alias with `bos_taurus`.

Some non-human aliases remain in unit tests (e.g. [lines 273-274 of genomic_alignment.t](https://github.com/Ensembl/ensembl-rest/blob/eae4716521d2268f97e20437c905ba8c51693b59/t/genomic_alignment.t#L273-L274)), but those aliases are set and used within the unit test script itself.

### Use case

The use of species aliases is declining, so aside from `human`, it's considered safer to avoid relying on these being present.

### Benefits

Minimising use of species aliases will avoid failure of a REST example query which depends on such an alias.

### Possible Drawbacks

None anticipated.

### Testing

note to submitters and reviewers: documentation-only changes may reflect
changes in other repos that can result in new or different output from
REST endpoints. In turn, these may require new tests or changes to existing tests.

_Have you added/modified unit tests to test the changes?_

No unit tests have been added/modified.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Comparative unit tests pass.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians

N/A
