### PR TITLE
VEP plugins: Update to dbNSFP 4.7c data (e113)

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -160,7 +160,7 @@ jsonp=1
     compara_species_set_group=mammals
     compara_compact=1
 
-    dbnsfp_readme=https://usf.box.com/s/azp443vfh3zlpep4bt0oap0k3c3afzgj
+    dbnsfp_readme=https://usf.box.com/s/h9mqovab0on1r3hpopwypcjr9i9mf0s3
  
     genetree_stable_id=ENSGT00390000003602
     compara_gene_stable_id=ENSG00000173786

--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -160,7 +160,7 @@ jsonp=1
     compara_species_set_group=mammals
     compara_compact=1
 
-    dbnsfp_readme=https://usf.app.box.com/s/jpg94a3t0qi529095v7wn4kpmr1at2aa
+    dbnsfp_readme=https://usf.box.com/s/azp443vfh3zlpep4bt0oap0k3c3afzgj
  
     genetree_stable_id=ENSGT00390000003602
     compara_gene_stable_id=ENSG00000173786

--- a/ensembl_rest_testing.conf
+++ b/ensembl_rest_testing.conf
@@ -58,7 +58,7 @@ jsonp=1
     compara_compact=1
     compara_gene_stable_id=ENSG00000173786
 
-    dbnsfp_readme=https://usf.box.com/s/azp443vfh3zlpep4bt0oap0k3c3afzgj
+    dbnsfp_readme=https://usf.box.com/s/h9mqovab0on1r3hpopwypcjr9i9mf0s3
 
     genetree_stable_id=???
     

--- a/ensembl_rest_testing.conf
+++ b/ensembl_rest_testing.conf
@@ -58,7 +58,7 @@ jsonp=1
     compara_compact=1
     compara_gene_stable_id=ENSG00000173786
 
-    dbnsfp_readme=https://usf.app.box.com/s/jpg94a3t0qi529095v7wn4kpmr1at2aa
+    dbnsfp_readme=https://usf.box.com/s/azp443vfh3zlpep4bt0oap0k3c3afzgj
 
     genetree_stable_id=???
     


### PR DESCRIPTION
### Description

[ENSVAR-6245](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6245): Update dbNSFP README URL to 4.7c data

### Testing

@dglemos 

### Changelog

[/vep] Update dbNSFP data to 4.7c