### PR TITLE
Add AlphaMissense plugin to VEP REST (e112)

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -300,6 +300,11 @@
         default=0
         example=snv_indels,<wbr>1
       </CADD>
+      <AlphaMissense>
+        type=Boolean
+        description=Annotates missense variants with the pre-computed <a target="_blank" href="https://www.science.org/doi/10.1126/science.adg7492">AlphaMissense</a> pathogenicity scores. AlphaMissense is a deep learning model developed by Google DeepMind that predicts the pathogenicity of single nucleotide missense variants. Data contained within the AlphaMissense Database is licensed under the Creative Commons Attribution 4.0 International License (CC-BY) (the "License"). You may obtain a copy of the License at: <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/legalcode">https://creativecommons.org/licenses/by/4.0/legalcode</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AlphaMissense.pm">plugin details</a>)
+        default=0
+      </AlphaMissense>
       <OpenTargets>
         type=Boolean
         description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/OpenTargets.pm">plugin details</a>)
@@ -634,6 +639,11 @@
         default=0
         example=snv_indels,<wbr>1
       </CADD>
+      <AlphaMissense>
+        type=Boolean
+        description=Annotates missense variants with the pre-computed <a target="_blank" href="https://www.science.org/doi/10.1126/science.adg7492">AlphaMissense</a> pathogenicity scores. AlphaMissense is a deep learning model developed by Google DeepMind that predicts the pathogenicity of single nucleotide missense variants. Data contained within the AlphaMissense Database is licensed under the Creative Commons Attribution 4.0 International License (CC-BY) (the "License"). You may obtain a copy of the License at: <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/legalcode">https://creativecommons.org/licenses/by/4.0/legalcode</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AlphaMissense.pm">plugin details</a>)
+        default=0
+      </AlphaMissense>
       <OpenTargets>
         type=Boolean
         description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/OpenTargets.pm">plugin details</a>)
@@ -956,6 +966,11 @@
         default=0
         example=snv_indels,<wbr>1
       </CADD>
+      <AlphaMissense>
+        type=Boolean
+        description=Annotates missense variants with the pre-computed <a target="_blank" href="https://www.science.org/doi/10.1126/science.adg7492">AlphaMissense</a> pathogenicity scores. AlphaMissense is a deep learning model developed by Google DeepMind that predicts the pathogenicity of single nucleotide missense variants. Data contained within the AlphaMissense Database is licensed under the Creative Commons Attribution 4.0 International License (CC-BY) (the "License"). You may obtain a copy of the License at: <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/legalcode">https://creativecommons.org/licenses/by/4.0/legalcode</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AlphaMissense.pm">plugin details</a>)
+        default=0
+      </AlphaMissense>
       <OpenTargets>
         type=Boolean
         description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/OpenTargets.pm">plugin details</a>)
@@ -1272,6 +1287,11 @@
         default=0
         example=snv_indels,<wbr>1
       </CADD>
+      <AlphaMissense>
+        type=Boolean
+        description=Annotates missense variants with the pre-computed <a target="_blank" href="https://www.science.org/doi/10.1126/science.adg7492">AlphaMissense</a> pathogenicity scores. AlphaMissense is a deep learning model developed by Google DeepMind that predicts the pathogenicity of single nucleotide missense variants. Data contained within the AlphaMissense Database is licensed under the Creative Commons Attribution 4.0 International License (CC-BY) (the "License"). You may obtain a copy of the License at: <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/legalcode">https://creativecommons.org/licenses/by/4.0/legalcode</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AlphaMissense.pm">plugin details</a>)
+        default=0
+      </AlphaMissense>
       <OpenTargets>
         type=Boolean
         description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/OpenTargets.pm">plugin details</a>)
@@ -1599,6 +1619,11 @@
         default=0
         example=snv_indels,<wbr>1
       </CADD>
+      <AlphaMissense>
+        type=Boolean
+        description=Annotates missense variants with the pre-computed <a target="_blank" href="https://www.science.org/doi/10.1126/science.adg7492">AlphaMissense</a> pathogenicity scores. AlphaMissense is a deep learning model developed by Google DeepMind that predicts the pathogenicity of single nucleotide missense variants. Data contained within the AlphaMissense Database is licensed under the Creative Commons Attribution 4.0 International License (CC-BY) (the "License"). You may obtain a copy of the License at: <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/legalcode">https://creativecommons.org/licenses/by/4.0/legalcode</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AlphaMissense.pm">plugin details</a>)
+        default=0
+      </AlphaMissense>
       <OpenTargets>
         type=Boolean
         description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/OpenTargets.pm">plugin details</a>)
@@ -1934,6 +1959,11 @@
         default=0
         example=snv_indels,<wbr>1
       </CADD>
+      <AlphaMissense>
+        type=Boolean
+        description=Annotates missense variants with the pre-computed <a target="_blank" href="https://www.science.org/doi/10.1126/science.adg7492">AlphaMissense</a> pathogenicity scores. AlphaMissense is a deep learning model developed by Google DeepMind that predicts the pathogenicity of single nucleotide missense variants. Data contained within the AlphaMissense Database is licensed under the Creative Commons Attribution 4.0 International License (CC-BY) (the "License"). You may obtain a copy of the License at: <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/legalcode">https://creativecommons.org/licenses/by/4.0/legalcode</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AlphaMissense.pm">plugin details</a>)
+        default=0
+      </AlphaMissense>
       <OpenTargets>
         type=Boolean
         description=Reports locus-to-gene (L2G) scores to predict causal genes at GWAS loci from <a target="_blank" href="https://genetics.opentargets.org">Open Targets Genetics</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/OpenTargets.pm">plugin details</a>)


### PR DESCRIPTION
### Description

Add AlphaMissense plugin to VEP REST ([ENSVAR-6262](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6262))

### Testing

Check documentation changes in my sandbox: http://hl-codon-36-01.ebi.ac.uk:3000/documentation/info/vep_region_get

### Changelog

[/vep] Added AlphaMissense plugin
