### PR TITLE
Perl documentation fix

### DIFF
--- a/root/documentation/examples/perl.tt
+++ b/root/documentation/examples/perl.tt
@@ -54,7 +54,7 @@ if(length $response->{content}) {
   print "\n";
 }
 [% ELSE %]
-print "$response->{status} $response->{reason}\n";
+print "$response->{content}\n";
 [% END -%]
 [% END %]
 </pre>


### PR DESCRIPTION
When printing out non-JSON content with perl, the example REST documentation is currently suggesting to use the response status and reason attributes. This PR updates the perl example to print out the response content instead.