### PR TITLE
Update Beacon response format

### DIFF
--- a/lib/EnsEMBL/REST/Model/ga4gh/Beacon.pm
+++ b/lib/EnsEMBL/REST/Model/ga4gh/Beacon.pm
@@ -1082,7 +1082,6 @@ sub get_vep_frequency {
             my ($gnomad_type, $pop) = $key =~ /(.*)_(.*)/;
             my $freq_obj;
             $freq_obj->{alleleFrequency} = $frequencies->{$key};
-            $freq_obj->{allele} = $allele;
 
             if($gnomad_type) {
               $pop = $gnomad_pop->{$pop} ? $gnomad_pop->{$pop} : $pop;
@@ -1111,7 +1110,7 @@ sub get_vep_frequency {
 sub get_vep_molecular_attribs {
   my $vep_consequences = shift;
 
-  my @gene_ontology;
+  my %gene_ontology;
   my %molecular_interactions;
   my @intact_data;
   my @phenotypes;
@@ -1132,13 +1131,11 @@ sub get_vep_molecular_attribs {
 
       # GO
       if($transcript_consequences->{'go'}) {
-        my @go_terms = split ',', $transcript_consequences->{'go'};
-        foreach my $go (@go_terms) {
-          my ($id, $term) = $go =~ /(.*):(.*)/;
+        foreach my $go (@{$transcript_consequences->{'go'}}) {
           my $cons;
-          $cons->{id} = $id;
-          $cons->{label} = $term;
-          push @gene_ontology, $cons;
+          $cons->{id} = $go->{'go_term'};
+          $cons->{label} = $go->{'description'};
+          $gene_ontology{$go->{'go_term'}} = $cons if !$gene_ontology{$go->{'go_term'}};
         }
       }
 
@@ -1182,8 +1179,10 @@ sub get_vep_molecular_attribs {
     }
   }
 
+  my @gene_ontology_list = values %gene_ontology;
+
   $results{molecular_interactions} = \%molecular_interactions;
-  $results{gene_ontology} = \@gene_ontology;
+  $results{gene_ontology} = \@gene_ontology_list;
   $results{disgenet} = \@disgenet_data;
   $results{cadd} = \@cadd_scores;
 


### PR DESCRIPTION
### Description

Release 113

Update the Beacon response:
- fix gene ontology output
- remove `allele` from the frequency output

### Use case

The gene ontology is not returning any data because the plugin output format was updated.

### Benefits

To include missing data in the output.

### Possible Drawbacks

None

### Testing

_Have you added/modified unit tests to test the changes?_
No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
No regression detected

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

[/ga4gh/beacon/query] Update output format
