### PR TITLE
Document VEP plugins REVEL and ClinPred (main)

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -305,6 +305,16 @@
         default=0
         example=snv_indels,<wbr>1
       </CADD>
+      <REVEL>
+        type=Boolean
+        description=<a rel="external" href="https://sites.google.com/site/revelgenomics">Rare Exome Variant Ensemble Learner (REVEL)</a> is an ensemble method for predicting the pathogenicity of missense variants based on a combination of scores from multiple individual tools. REVEL is only available for non-commercial use. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/REVEL.pm">plugin details</a>)
+        default=0
+      </REVEL>
+      <ClinPred>
+        type=Boolean
+        description=<a rel="external" href="https://sites.google.com/site/clinpred">ClinPred</a> is a prediction tool to identify disease-relevant nonsynonymous single nucleotide variants (only supported for human). The predictor incorporates existing pathogenicity scores and benefits from normal population allele frequencies. ClinPred is only available for non-commercial use. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/ClinPred.pm">plugin details</a>)
+        default=0
+      </ClinPred>
       <AlphaMissense>
         type=Boolean
         description=Annotates missense variants with the pre-computed <a target="_blank" href="https://www.science.org/doi/10.1126/science.adg7492">AlphaMissense</a> pathogenicity scores. AlphaMissense is a deep learning model developed by Google DeepMind that predicts the pathogenicity of single nucleotide missense variants. Data contained within the AlphaMissense Database is licensed under the Creative Commons Attribution 4.0 International License (CC-BY) (the "License"). You may obtain a copy of the License at: <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/legalcode">https://creativecommons.org/licenses/by/4.0/legalcode</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AlphaMissense.pm">plugin details</a>)
@@ -654,6 +664,16 @@
         default=0
         example=snv_indels,<wbr>1
       </CADD>
+      <REVEL>
+        type=Boolean
+        description=<a rel="external" href="https://sites.google.com/site/revelgenomics">Rare Exome Variant Ensemble Learner (REVEL)</a> is an ensemble method for predicting the pathogenicity of missense variants based on a combination of scores from multiple individual tools. REVEL is only available for non-commercial use. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/REVEL.pm">plugin details</a>)
+        default=0
+      </REVEL>
+      <ClinPred>
+        type=Boolean
+        description=<a rel="external" href="https://sites.google.com/site/clinpred">ClinPred</a> is a prediction tool to identify disease-relevant nonsynonymous single nucleotide variants (only supported for human). The predictor incorporates existing pathogenicity scores and benefits from normal population allele frequencies. ClinPred is only available for non-commercial use. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/ClinPred.pm">plugin details</a>)
+        default=0
+      </ClinPred>
       <AlphaMissense>
         type=Boolean
         description=Annotates missense variants with the pre-computed <a target="_blank" href="https://www.science.org/doi/10.1126/science.adg7492">AlphaMissense</a> pathogenicity scores. AlphaMissense is a deep learning model developed by Google DeepMind that predicts the pathogenicity of single nucleotide missense variants. Data contained within the AlphaMissense Database is licensed under the Creative Commons Attribution 4.0 International License (CC-BY) (the "License"). You may obtain a copy of the License at: <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/legalcode">https://creativecommons.org/licenses/by/4.0/legalcode</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AlphaMissense.pm">plugin details</a>)
@@ -991,6 +1011,16 @@
         default=0
         example=snv_indels,<wbr>1
       </CADD>
+      <REVEL>
+        type=Boolean
+        description=<a rel="external" href="https://sites.google.com/site/revelgenomics">Rare Exome Variant Ensemble Learner (REVEL)</a> is an ensemble method for predicting the pathogenicity of missense variants based on a combination of scores from multiple individual tools. REVEL is only available for non-commercial use. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/REVEL.pm">plugin details</a>)
+        default=0
+      </REVEL>
+      <ClinPred>
+        type=Boolean
+        description=<a rel="external" href="https://sites.google.com/site/clinpred">ClinPred</a> is a prediction tool to identify disease-relevant nonsynonymous single nucleotide variants (only supported for human). The predictor incorporates existing pathogenicity scores and benefits from normal population allele frequencies. ClinPred is only available for non-commercial use. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/ClinPred.pm">plugin details</a>)
+        default=0
+      </ClinPred>
       <AlphaMissense>
         type=Boolean
         description=Annotates missense variants with the pre-computed <a target="_blank" href="https://www.science.org/doi/10.1126/science.adg7492">AlphaMissense</a> pathogenicity scores. AlphaMissense is a deep learning model developed by Google DeepMind that predicts the pathogenicity of single nucleotide missense variants. Data contained within the AlphaMissense Database is licensed under the Creative Commons Attribution 4.0 International License (CC-BY) (the "License"). You may obtain a copy of the License at: <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/legalcode">https://creativecommons.org/licenses/by/4.0/legalcode</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AlphaMissense.pm">plugin details</a>)
@@ -1322,6 +1352,16 @@
         default=0
         example=snv_indels,<wbr>1
       </CADD>
+      <REVEL>
+        type=Boolean
+        description=<a rel="external" href="https://sites.google.com/site/revelgenomics">Rare Exome Variant Ensemble Learner (REVEL)</a> is an ensemble method for predicting the pathogenicity of missense variants based on a combination of scores from multiple individual tools. REVEL is only available for non-commercial use. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/REVEL.pm">plugin details</a>)
+        default=0
+      </REVEL>
+      <ClinPred>
+        type=Boolean
+        description=<a rel="external" href="https://sites.google.com/site/clinpred">ClinPred</a> is a prediction tool to identify disease-relevant nonsynonymous single nucleotide variants (only supported for human). The predictor incorporates existing pathogenicity scores and benefits from normal population allele frequencies. ClinPred is only available for non-commercial use. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/ClinPred.pm">plugin details</a>)
+        default=0
+      </ClinPred>
       <AlphaMissense>
         type=Boolean
         description=Annotates missense variants with the pre-computed <a target="_blank" href="https://www.science.org/doi/10.1126/science.adg7492">AlphaMissense</a> pathogenicity scores. AlphaMissense is a deep learning model developed by Google DeepMind that predicts the pathogenicity of single nucleotide missense variants. Data contained within the AlphaMissense Database is licensed under the Creative Commons Attribution 4.0 International License (CC-BY) (the "License"). You may obtain a copy of the License at: <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/legalcode">https://creativecommons.org/licenses/by/4.0/legalcode</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AlphaMissense.pm">plugin details</a>)
@@ -1664,6 +1704,16 @@
         default=0
         example=snv_indels,<wbr>1
       </CADD>
+      <REVEL>
+        type=Boolean
+        description=<a rel="external" href="https://sites.google.com/site/revelgenomics">Rare Exome Variant Ensemble Learner (REVEL)</a> is an ensemble method for predicting the pathogenicity of missense variants based on a combination of scores from multiple individual tools. REVEL is only available for non-commercial use. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/REVEL.pm">plugin details</a>)
+        default=0
+      </REVEL>
+      <ClinPred>
+        type=Boolean
+        description=<a rel="external" href="https://sites.google.com/site/clinpred">ClinPred</a> is a prediction tool to identify disease-relevant nonsynonymous single nucleotide variants (only supported for human). The predictor incorporates existing pathogenicity scores and benefits from normal population allele frequencies. ClinPred is only available for non-commercial use. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/ClinPred.pm">plugin details</a>)
+        default=0
+      </ClinPred>
       <AlphaMissense>
         type=Boolean
         description=Annotates missense variants with the pre-computed <a target="_blank" href="https://www.science.org/doi/10.1126/science.adg7492">AlphaMissense</a> pathogenicity scores. AlphaMissense is a deep learning model developed by Google DeepMind that predicts the pathogenicity of single nucleotide missense variants. Data contained within the AlphaMissense Database is licensed under the Creative Commons Attribution 4.0 International License (CC-BY) (the "License"). You may obtain a copy of the License at: <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/legalcode">https://creativecommons.org/licenses/by/4.0/legalcode</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AlphaMissense.pm">plugin details</a>)
@@ -2014,6 +2064,16 @@
         default=0
         example=snv_indels,<wbr>1
       </CADD>
+      <REVEL>
+        type=Boolean
+        description=<a rel="external" href="https://sites.google.com/site/revelgenomics">Rare Exome Variant Ensemble Learner (REVEL)</a> is an ensemble method for predicting the pathogenicity of missense variants based on a combination of scores from multiple individual tools. REVEL is only available for non-commercial use. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/REVEL.pm">plugin details</a>)
+        default=0
+      </REVEL>
+      <ClinPred>
+        type=Boolean
+        description=<a rel="external" href="https://sites.google.com/site/clinpred">ClinPred</a> is a prediction tool to identify disease-relevant nonsynonymous single nucleotide variants (only supported for human). The predictor incorporates existing pathogenicity scores and benefits from normal population allele frequencies. ClinPred is only available for non-commercial use. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/ClinPred.pm">plugin details</a>)
+        default=0
+      </ClinPred>
       <AlphaMissense>
         type=Boolean
         description=Annotates missense variants with the pre-computed <a target="_blank" href="https://www.science.org/doi/10.1126/science.adg7492">AlphaMissense</a> pathogenicity scores. AlphaMissense is a deep learning model developed by Google DeepMind that predicts the pathogenicity of single nucleotide missense variants. Data contained within the AlphaMissense Database is licensed under the Creative Commons Attribution 4.0 International License (CC-BY) (the "License"). You may obtain a copy of the License at: <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/legalcode">https://creativecommons.org/licenses/by/4.0/legalcode</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/AlphaMissense.pm">plugin details</a>)


### PR DESCRIPTION
### Description

Document VEP plugins REVEL and ClinPred

[ENSVAR-6395](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6395): add ClinPred plugin to web VEP + REST
[ENSVAR-6396](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6396): add REVEL plugin to web VEP + REST

### Testing

Check documentation changes in http://hl-codon-09-02.ebi.ac.uk:3000

### Changelog

[/vep] Added VEP plugins REVEL and ClinPred
