### PR TITLE
Support VEP Gencode primary for REST (e113)

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -42,6 +42,7 @@ has valid_user_params => (
   default => sub { return {
     map {$_ => 1} (qw/
     gencode_basic
+    gencode_primary
     refseq
     merged
 

--- a/root/documentation/variation.conf
+++ b/root/documentation/variation.conf
@@ -185,6 +185,11 @@
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
+      <gencode_primary>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE primary set. 
+        default=0
+      </gencode_primary>
       <failed>
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants
@@ -254,6 +259,11 @@
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
+      <gencode_primary>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE primary set. 
+        default=0
+      </gencode_primary>
       <failed>
         type=Boolean
         description=When checking for co-located variants, by default variants flagged as failed by Ensembl's QC pipeline will be excluded. Set this flag to 1 to include such variants

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -143,6 +143,11 @@
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
+      <gencode_primary>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE primary set. 
+        default=0
+      </gencode_primary>
       <pick>
         type=Boolean
         description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
@@ -497,6 +502,11 @@
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
+      <gencode_primary>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE primary set. 
+        default=0
+      </gencode_primary>
       <pick>
         type=Boolean
         description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
@@ -829,6 +839,11 @@
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
+      <gencode_primary>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE primary set. 
+        default=0
+      </gencode_primary>
       <pick>
         type=Boolean
         description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
@@ -1165,6 +1180,11 @@
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
+      <gencode_primary>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE primary set. 
+        default=0
+      </gencode_primary>
       <pick>
         type=Boolean
         description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
@@ -1502,6 +1522,11 @@
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
+      <gencode_primary>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE primary set. 
+        default=0
+      </gencode_primary>
       <pick>
         type=Boolean
         description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.
@@ -1857,6 +1882,11 @@
         description=Limit your analysis to transcripts belonging to the GENCODE basic set. This set has fragmented or problematic transcripts removed.
         default=0
       </gencode_basic>
+      <gencode_primary>
+        type=Boolean(0,1)
+        description=Limit your analysis to transcripts belonging to the GENCODE primary set. 
+        default=0
+      </gencode_primary>
       <pick>
         type=Boolean
         description=Pick one line or block of consequence data per variant, including transcript-specific columns. Consequences are chosen according to the criteria described <a target="_blank" href="http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html\#pick">here</a>, and the order the criteria are applied may be customised with <b>pick_order</b>. This is the best method to use if you are interested only in one consequence per variant.


### PR DESCRIPTION
### Description

Support gencode_primary flag for VEP REST

### Use case
VEP and variation endpoints can now discover GENCODE Primary transcripts 

### Testing
`curl 'http://wp-np2-25.ebi.ac.uk:3000/vep/human/id/rs699?gencode_primary=1' -H 'Content-type:application/json'`

### Dependency
https://github.com/Ensembl/ensembl-vep/pull/1699

### Changelog
Additional flag `gencode_primary` in VEP/variation endpoints
