### PR TITLE
Add CACTUS_DB to genomic alignment method list

### DIFF
--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -595,7 +595,7 @@
 	example=mus_musculus
       </species_set>
       <method>
-        type=Enum(EPO, EPO_EXTENDED, PECAN, LASTZ_NET, BLASTZ_NET, TRANSLATED_BLAT_NET, CACTUS_HAL, CACTUS_HAL_PW)
+        type=Enum(EPO, EPO_EXTENDED, PECAN, LASTZ_NET, BLASTZ_NET, TRANSLATED_BLAT_NET, CACTUS_HAL, CACTUS_HAL_PW, CACTUS_DB)
 	description=The alignment method
 	default=__VAR(compara_method)__
 	example=PECAN


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing
    - if you're adding/updating documentation of an endpoint, make sure you add/update the necessary parameters to the (template) configuration files in the ensembl-rest_private repo

### Description

This PR adds `CACTUS_DB` (Cactus alignment via database) to the list of genomic alignment methods in the documentation.

### Use case

Several Ensembl divisions will have `CACTUS_DB` data in release 113 and subsequent releases.

### Benefits

This will help make users aware of the availability of `CACTUS_DB` data.

### Possible Drawbacks

None anticipated.

### Testing

note to submitters and reviewers: documentation-only changes may reflect
changes in other repos that can result in new or different output from
REST endpoints. In turn, these may require new tests or changes to existing tests.

_Have you added/modified unit tests to test the changes?_

No unit tests have been added/modified.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Comparative unit tests pass.

### Changelog

_Are you changing the functionality of an endpoint? If so, please give a one line summary for the public facing changelog._

eg. [/xenobiology/orthologs] Added the ability to look up orthologs and paralogs from klingons and andorians

N/A
