### PR TITLE
VEP: Update dbNSFP README URL to 4.9c (e114)

### DIFF
--- a/ensembl_rest.conf.default
+++ b/ensembl_rest.conf.default
@@ -160,7 +160,7 @@ jsonp=1
     compara_species_set_group=mammals
     compara_compact=1
 
-    dbnsfp_readme=https://usf.box.com/s/h9mqovab0on1r3hpopwypcjr9i9mf0s3
+    dbnsfp_readme=https://usf.box.com/s/py6pfknr4h6464do2dw322oe2ux09hpd
  
     genetree_stable_id=ENSGT00390000003602
     compara_gene_stable_id=ENSG00000173786

--- a/ensembl_rest_testing.conf
+++ b/ensembl_rest_testing.conf
@@ -58,7 +58,7 @@ jsonp=1
     compara_compact=1
     compara_gene_stable_id=ENSG00000173786
 
-    dbnsfp_readme=https://usf.box.com/s/h9mqovab0on1r3hpopwypcjr9i9mf0s3
+    dbnsfp_readme=https://usf.box.com/s/py6pfknr4h6464do2dw322oe2ux09hpd
 
     genetree_stable_id=???
     


### PR DESCRIPTION
### Description

[ENSVAR-6368](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6368): Update dbNSFP README URL to 4.9c

Updates URL of README file for dbNSFP on VEP endpoint documentation

@dglemos

### Changelog

[/vep] Update dbNSFP data to 4.9c
