### PR TITLE
Revert regulatory summary and filter EMARs

### DIFF
--- a/lib/EnsEMBL/REST/Model/Overlap.pm
+++ b/lib/EnsEMBL/REST/Model/Overlap.pm
@@ -160,15 +160,7 @@ sub to_hash {
   my ($self, $features, $feature_type) = @_;
   my @hashed;
   foreach my $feature (@{$features}) {
-
-    my $hash;
-    
-    if (lc($feature_type)  eq 'regulatory') {
-      $hash = $feature->summary_as_hash_2(); 
-    } else {
-      $hash = $feature->summary_as_hash();
-    }
-  
+    my $hash = $feature->summary_as_hash();
     foreach my $key (@KNOWN_NUMERICS) {
       my $v = $hash->{$key};
       $hash->{$key} = ($v*1) if defined $v;
@@ -188,6 +180,9 @@ sub to_hash {
       if (defined($hash->{description}) && !$hash->{description}) {
         $hash->{description} = $feature->{$feature_type}->{hdescription} if defined($feature->{$feature_type}->{hdescription});
       }
+    }
+    if (lc($feature_type) eq 'regulatory') {
+      next if ($hash->{description} eq 'Epigenetically modified accessible region');
     }
     push(@hashed, $hash);
   }

--- a/t/overlap.t
+++ b/t/overlap.t
@@ -304,13 +304,13 @@ my $base = '/overlap/region/homo_sapiens';
   my $region = '1:76429380..76430144';
   cmp_deeply(json_GET("$base/$region?feature=regulatory", 'Get regulatory_feature'), [{
     id => 'ENSR00000105157',
-    extended_end => 76430144,        
-    extended_start => 76429380,
-    description => 'open_chromatin_region',
+    bound_end => 76430144,
+    bound_start => 76429380,
+    description => 'Open chromatin region',
     end => 76430144,
     feature_type => 'regulatory',
     seq_region_name => 1,
-    source => 'Ensembl',
+    source => 'Regulatory_Build',
     start => 76429380,
     strand => 0
   }], 'Getting regulatory_feature as JSON');


### PR DESCRIPTION
### Description

PR sister to #664 - this one for `main`

#### Overlap endpoint [feature=regulatory]

Ensembl Widget compatibility changes:
- Revert regulatory summary function (`summary_as_hash`);
- Filter EMARs reg. features;

### Changelog
payload:
```bash
{
    "strand": 0,
    "seq_region_name": "7",
    "source": "Ensembl",
    "extended_end": 140624542,
    "start": 140624521,
    "id": "ENSR7_53843KH",
    "description": "CTCF_binding_site",
    "feature_type": "regulatory",
    "end": 140624542,
    "extended_start": 140624521
 }
```

reverted to:
```bash
{
    "seq_region_name": "7",
    "source": "Regulatory_Build",
    "description": "CTCF binding site",
    "bound_start": 140624521,
    "strand": 0,
    "feature_type": "regulatory",
    "id": "ENSR7_53843KH",
    "start": 140624521,
    "bound_end": 140624542,
    "end": 140624542
 }
```
