### PR TITLE
Deprecate plugin 114

### DIFF
--- a/lib/EnsEMBL/REST.pm
+++ b/lib/EnsEMBL/REST.pm
@@ -64,7 +64,7 @@ use Catalyst qw/
 /;
 
 
-our $VERSION = '15.9';
+our $VERSION = '15.8';
 
 # Configure the application.
 #

--- a/lib/EnsEMBL/REST.pm
+++ b/lib/EnsEMBL/REST.pm
@@ -64,7 +64,7 @@ use Catalyst qw/
 /;
 
 
-our $VERSION = '15.8';
+our $VERSION = '15.9';
 
 # Configure the application.
 #

--- a/lib/EnsEMBL/REST/Model/ga4gh/Beacon.pm
+++ b/lib/EnsEMBL/REST/Model/ga4gh/Beacon.pm
@@ -768,7 +768,6 @@ sub configure_vep {
     'Mastermind' => '0,0,1',
     'GO' => '1',
     'Phenotypes' => '1',
-    'DisGeNET' => 'disease=1',
     'CADD' => '1',
     'EVE' => '1',
     'SpliceAI' => '1'
@@ -928,7 +927,6 @@ sub get_dataset_allele_response {
     my @clinical; # clinicalInterpretations (part of variantLevelData)
     my %unique_phenotypes;
     my $var;
-    my $disgenet = [];
     my $frequency = [];
     my $cadd = [];
 
@@ -984,7 +982,6 @@ sub get_dataset_allele_response {
 
         $molecular_interactions = $vep_consequence_results->{molecular_interactions};
         $gene_ontology = $vep_consequence_results->{gene_ontology};
-        $disgenet = $vep_consequence_results->{disgenet};
         $cadd = $vep_consequence_results->{cadd};
 
         # Frequency data from gnomAD
@@ -1049,7 +1046,6 @@ sub get_dataset_allele_response {
 
     $result_details->{variantLevelData}->{clinicalInterpretations} = \@clinical if (scalar @clinical > 0);
 
-    $result_details->{variantLevelData}->{phenotypicEffects} = $disgenet if (scalar @{$disgenet} > 0);
     $result_details->{variantLevelData}->{pathogenicityPredictions} = $cadd if (scalar @{$cadd} > 0);
 
     $result_details->{FrequencyInPopulations}->{frequencies} = $frequency if (scalar @{$frequency} > 0);
@@ -1114,8 +1110,6 @@ sub get_vep_molecular_attribs {
   my %molecular_interactions;
   my @intact_data;
   my @phenotypes;
-  my %unique_disgenet;
-  my @disgenet_data;
   my @cadd_scores;
   my %cadd_unique;
 
@@ -1136,24 +1130,6 @@ sub get_vep_molecular_attribs {
           $cons->{id} = $go->{'go_term'};
           $cons->{label} = $go->{'description'};
           $gene_ontology{$go->{'go_term'}} = $cons if !$gene_ontology{$go->{'go_term'}};
-        }
-      }
-
-      # DisGeNET
-      if($transcript_consequences->{'disgenet'}) {
-        foreach my $disgenet (@{$transcript_consequences->{'disgenet'}}) {
-          my $key = $disgenet->{score} . '-' . $disgenet->{pmid} . '-' . $disgenet->{diseaseName};
-          if(!$unique_disgenet{$key}) {
-            my $disgenet_obj;
-            $disgenet_obj->{annotatedWith}->{toolName} = 'DisGeNET';
-            $disgenet_obj->{annotatedWith}->{version} = 'v7';
-            $disgenet_obj->{conditionId} = $disgenet->{diseaseName};
-            $disgenet_obj->{evidenceType}->{id} = "isDefinedBy";
-            $disgenet_obj->{evidenceType}->{label} = 'PMID:' . $disgenet->{pmid};
-            $disgenet_obj->{score} = $disgenet->{score};
-            push @disgenet_data, $disgenet_obj;
-            $unique_disgenet{$key} = 1;
-          }
         }
       }
 
@@ -1183,7 +1159,6 @@ sub get_vep_molecular_attribs {
 
   $results{molecular_interactions} = \%molecular_interactions;
   $results{gene_ontology} = \@gene_ontology_list;
-  $results{disgenet} = \@disgenet_data;
   $results{cadd} = \@cadd_scores;
 
   return (\%results);

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -300,11 +300,6 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <DisGeNET>
-        type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DisGeNET.pm">plugin details</a>)
-        default=0
-      </DisGeNET>
       <Mastermind>
         type=Boolean
         description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
@@ -670,11 +665,6 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <DisGeNET>
-        type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DisGeNET.pm">plugin details</a>)
-        default=0
-      </DisGeNET>
       <Mastermind>
         type=Boolean
         description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
@@ -1028,11 +1018,6 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <DisGeNET>
-        type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DisGeNET.pm">plugin details</a>)
-        default=0
-      </DisGeNET>
       <Mastermind>
         type=Boolean
         description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
@@ -1380,11 +1365,6 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <DisGeNET>
-        type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DisGeNET.pm">plugin details</a>)
-        default=0
-      </DisGeNET>
       <Mastermind>
         type=Boolean
         description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
@@ -1743,11 +1723,6 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <DisGeNET>
-        type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DisGeNET.pm">plugin details</a>)
-        default=0
-      </DisGeNET>
       <Mastermind>
         type=Boolean
         description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
@@ -2114,11 +2089,6 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <DisGeNET>
-        type=Boolean
-        description=Retrieves Variant-Disease-PMID associations from the DisGeNET database (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/DisGeNET.pm">plugin details</a>)
-        default=0
-      </DisGeNET>
       <Mastermind>
         type=Boolean
         description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)


### PR DESCRIPTION
Same as https://github.com/Ensembl/ensembl-rest/pull/670

**Description**

Deprecating the VEP plugin: DisGeNET

**Use case**

The DisGeNET data is not freely available anymore.
The plugin does not make sense without the data.

**Benefits**

**Possible Drawbacks**

Users won't be able to run the plugin in the future.

**Testing**

Have you added/modified unit tests to test the changes?

If so, do the tests pass/fail?

Have you run the entire test suite and no regression was detected?
no regression detected

**Changelog**

[/vep] DisGeNET plugin is deprecated
[/ga4gh/beacon/query] Beacon does not return DisGeNET scores anymore