### PR TITLE
Deprecate Mastermind plugin

### DIFF
--- a/lib/EnsEMBL/REST/Model/ga4gh/Beacon.pm
+++ b/lib/EnsEMBL/REST/Model/ga4gh/Beacon.pm
@@ -765,7 +765,6 @@ sub configure_vep {
   # VEP plugins to run
   my $plugins_to_use = {
     'IntAct' => 'all=1',
-    'Mastermind' => '0,0,1',
     'GO' => '1',
     'Phenotypes' => '1',
     'CADD' => '1',

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -300,11 +300,6 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <Mastermind>
-        type=Boolean
-        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
-        default=0
-      </Mastermind>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
@@ -665,11 +660,6 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <Mastermind>
-        type=Boolean
-        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
-        default=0
-      </Mastermind>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
@@ -1018,11 +1008,6 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <Mastermind>
-        type=Boolean
-        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
-        default=0
-      </Mastermind>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
@@ -1365,11 +1350,6 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <Mastermind>
-        type=Boolean
-        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
-        default=0
-      </Mastermind>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
@@ -1723,11 +1703,6 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <Mastermind>
-        type=Boolean
-        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
-        default=0
-      </Mastermind>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
@@ -2089,11 +2064,6 @@
         description=Retrieves overlapping phenotype information (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Phenotypes.pm">plugin details</a>)
         default=0
       </Phenotypes>
-      <Mastermind>
-        type=Boolean
-        description= Variants that have clinical evidence cited in the medical literature reported by <a target="_blank" href="https://www.genomenon.com/mastermind">Mastermind Genomic Search Engine</a> (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/Mastermind.pm">plugin details</a>)
-        default=0
-      </Mastermind>
       <CADD>
         type=Boolean
         description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)


### PR DESCRIPTION
### Description

Deprecating the VEP plugin: Mastermind. [ENSVAR-6664](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6664)

### Use case

Some part of the Mastermind data is not freely available anymore.

### Benefits

### Possible Drawbacks

Users won't be able to run the plugin in the future.

### Testing

N/A

### Changelog

[/vep] Mastermind plugin is deprecated
[/ga4gh/beacon/query] Beacon does not return Mastermind scores anymore
