### PR TITLE
Changes for release 114/61 - updated version and docs

### DIFF
--- a/lib/EnsEMBL/REST.pm
+++ b/lib/EnsEMBL/REST.pm
@@ -64,7 +64,7 @@ use Catalyst qw/
 /;
 
 
-our $VERSION = '15.9';
+our $VERSION = '15.10';
 
 # Configure the application.
 #


### PR DESCRIPTION
### Description

Sister to PR #682 

Update docs pointer to latest version.
Updated REST version

### Benefits

Updated Changelog 

### Possible Drawbacks

None

### Testing

N/A

### Changelog

# 15.10 - 2025-05
## Updated endpoints
* `[/vep]` Add Paralogues plugin
* `[/vep]` Update dbNSFP data to 4.9c
* `[/ga4gh/beacon/query]` Beacon does not return DisGeNET scores anymore
* `[/ga4gh/beacon/query]` Beacon does not return Mastermind scores anymore

## Deprecated endpoints
* `[/vep]` DisGeNET plugin is deprecated
* `[/vep]` Mastermind plugin is deprecated
