### PR TITLE
Update NH gene-tree format modes

### DIFF
--- a/root/documentation/compara.conf
+++ b/root/documentation/compara.conf
@@ -279,7 +279,7 @@
         default=protein
       </sequence>
       <nh_format>
-        type=Enum(full, display_label_composite, simple, species, species_short_name, ncbi_taxon, ncbi_name, njtree, phylip)
+        type=Enum(full, display_label_composite, simple, species, species_short_name, ncbi_taxon, ncbi_name, phylip, gene_stable_id, genome_gene_stable_id, genome_product_stable_id)
         description=The format of a NH (New Hampshire) request.
         default=simple
       </nh_format>
@@ -395,7 +395,7 @@
         default=protein
       </sequence>
       <nh_format>
-        type=Enum(full, display_label_composite, simple, species, species_short_name, ncbi_taxon, ncbi_name, njtree, phylip)
+        type=Enum(full, display_label_composite, simple, species, species_short_name, ncbi_taxon, ncbi_name, phylip, gene_stable_id, genome_gene_stable_id, genome_product_stable_id)
         description=The format of a NH (New Hampshire) request.
         default=simple
       </nh_format>
@@ -500,7 +500,7 @@
         default=protein
       </sequence>
       <nh_format>
-        type=Enum(full, display_label_composite, simple, species, species_short_name, ncbi_taxon, ncbi_name, njtree, phylip)
+        type=Enum(full, display_label_composite, simple, species, species_short_name, ncbi_taxon, ncbi_name, phylip, gene_stable_id, genome_gene_stable_id, genome_product_stable_id)
         description=The format of a NH (New Hampshire) request.
         default=simple
       </nh_format>


### PR DESCRIPTION
### Description

This PR would update the list of `nh_format` modes of gene-tree REST endpoints:
- https://rest.ensembl.org/documentation/info/genetree
- https://rest.ensembl.org/documentation/info/genetree_species_member_id
- https://rest.ensembl.org/documentation/info/genetree_member_symbol

In particular, it would:
- add new `nh_format` modes `genome_gene_stable_id` and `genome_product_stable_id`;
- add existing format mode `gene_stable_id`; and
- remove unsupported format mode `njtree`.

Examples:
- gene-tree request for NH tree in `gene_stable_id` mode: https://rest.ensembl.org/genetree/id/ENSGT00390000003602?content-type=text/x-nh;nh_format=gene_stable_id
- gene-tree request for NH tree in `njtree` mode: https://rest.ensembl.org/genetree/id/ENSGT00390000003602?content-type=text/x-nh;nh_format=njtree

### Use case

This change will enable users to access an unambiguous NH tree even in the case where that tree has members with clashing stable IDs.

### Benefits

Users will be presented with more up-to-date options to access gene trees in NH format.

### Possible Drawbacks

No drawbacks anticipated.

### Testing

All Compara unit tests passed locally.

### Changelog

This PR would not change endpoint functionality.
