### PR TITLE
Update docs pointer to latest version (for 115)

### DIFF
--- a/lib/EnsEMBL/REST.pm
+++ b/lib/EnsEMBL/REST.pm
@@ -64,7 +64,7 @@ use Catalyst qw/
 /;
 
 
-our $VERSION = '15.10';
+our $VERSION = '15.11';
 
 # Configure the application.
 #


### PR DESCRIPTION
### Description

Update docs pointer to latest version for release 115, before branching code

### Benefits

Updated Changelog

### Possible Drawbacks

None

### Testing

Test suite passing

### Changelog

- `[/genetree/id/:id]` Update to format modes `nh_format`, dropping the unsupported `njtree` mode, and adding new modes `genome_gene_stable_id` and `genome_product_stable_id` alongside the existing `gene_stable_id`
- [/genetree/member/id/:species/:id] Update to format modes `nh_format`, dropping the unsupported `njtree` mode, and adding new modes `genome_gene_stable_id` and `genome_product_stable_id` alongside the existing `gene_stable_id`
- [/genetree/member/symbol/:species/:symbol] Update to format modes `nh_format`, dropping the unsupported `njtree` mode, and adding new modes `genome_gene_stable_id` and `genome_product_stable_id` alongside the existing `gene_stable_id`
