### PR TITLE
[115] Fix EMARs exclusions (release/115)

### DIFF
--- a/lib/EnsEMBL/REST/Model/Overlap.pm
+++ b/lib/EnsEMBL/REST/Model/Overlap.pm
@@ -190,7 +190,7 @@ sub to_hash {
       }
     }
     if (lc($feature_type) eq 'regulatory') {
-      next if ($hash->{description} eq 'Epigenetically modified accessible region');
+      next if (!defined $hash->{description});
     }
     push(@hashed, $hash);
   }


### PR DESCRIPTION
### Description

EMAR reg. features are excluded from REST. 
This fix identifies these features by checking if the description is `undef`.