### PR TITLE
Chcadd

### DIFF
--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -451,6 +451,13 @@ sub _configure_plugins {
 
           push @params, $param;
         }
+        elsif(lc $module eq 'cadd' && $c->stash->{species} eq "Gallus_gallus_GCA_000002315.5"){
+          next unless $param =~ /^snv_chicken_rjf=/;
+
+          my $param_aux = $param;
+          $param_aux =~ s/snv_chicken_rjf=//;
+          $param = 'snv=' . $param_aux;
+        }
         elsif(lc $module eq 'cadd' && ($user_config->{$module} eq "snv_indels" || $user_config->{$module} eq "1")){
           next unless ($param =~ /^snv=/ || $param =~ /^indels=/);
           push @params, $param;

--- a/lib/EnsEMBL/REST/Controller/VEP.pm
+++ b/lib/EnsEMBL/REST/Controller/VEP.pm
@@ -451,12 +451,14 @@ sub _configure_plugins {
 
           push @params, $param;
         }
-        elsif(lc $module eq 'cadd' && $c->stash->{species} eq "Gallus_gallus_GCA_000002315.5"){
+        elsif(lc $module eq 'cadd' && $c->stash->{species} eq "gallus_gallus_gca000002315v5"){
           next unless $param =~ /^snv_chicken_rjf=/;
 
           my $param_aux = $param;
           $param_aux =~ s/snv_chicken_rjf=//;
           $param = 'snv=' . $param_aux;
+
+          push @params, $param;
         }
         elsif(lc $module eq 'cadd' && ($user_config->{$module} eq "snv_indels" || $user_config->{$module} eq "1")){
           next unless ($param =~ /^snv=/ || $param =~ /^indels=/);

--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -302,7 +302,7 @@
       </Phenotypes>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa and chicken red jungle fowl), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
         example=snv_indels,<wbr>1
       </CADD>
@@ -662,7 +662,7 @@
       </Phenotypes>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa and chicken red jungle fowl), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
         example=snv_indels,<wbr>1
       </CADD>
@@ -1010,7 +1010,7 @@
       </Phenotypes>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa and chicken red jungle fowl), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
         example=snv_indels,<wbr>1
       </CADD>
@@ -1352,7 +1352,7 @@
       </Phenotypes>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa and chicken red jungle fowl), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
         example=snv_indels,<wbr>1
       </CADD>
@@ -1705,7 +1705,7 @@
       </Phenotypes>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa and chicken red jungle fowl), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
         example=snv_indels,<wbr>1
       </CADD>
@@ -2066,7 +2066,7 @@
       </Phenotypes>
       <CADD>
         type=Boolean
-        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
+        description=Include CADD (Combined Annotation Dependent Depletion) deleteriousness scores for single nucleotide variants (also supports sus_scrofa and chicken red jungle fowl), indels and structural variants (only supported in GRCh38). Following options can be given: <b>snv</b>, <b>indels</b>, <b>snv_indels</b>, and <b>sv</b>. Providing 1 is also supported which is same as providing <b>snv_indels</b>. Caution to be taken while using snv, indels or snv_indels options with structural variants as input. It can match unnecessary huge amount of lines in annotation file and in such cases no CADD annotation will be made. See <a target="_blank" href="https://cadd.gs.washington.edu/">license</a>. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/CADD.pm">plugin details</a>)
         default=0
         example=snv_indels,<wbr>1
       </CADD>


### PR DESCRIPTION
### Description

Add CADD option for chicken red jungle fowl.
[ENSVAR-6855](https://embl.atlassian.net/browse/ENSVAR-6855)

### Use case

User wants to know CADD scores for a variant in chicken rjf.

### Benefits

Addition to CADD annotation feature in VEP endpoints.

### Possible Drawbacks

N/A

### Testing

Tested in codon with a REST setup.
example url - http://<node where rest is running>:3000/vep/Gallus_gallus_GCA000002315v5/id/rs731438019?content-type=application/json&CADD=snv

### Changelog

[vep/:species/hgvs/:hgvs_notation]
[vep/:species/id/:id]
[vep/:species/region/:region/:allele]

All of these endpoint will now return CADD result (if available) if used with parameter `CADD=snv` or `CADD=1`
