### PR TITLE
Add doc for ProtVar plugin

### DIFF
--- a/root/documentation/vep.conf
+++ b/root/documentation/vep.conf
@@ -2151,7 +2151,7 @@
       </Phenotypes>
       <ProtVar>
         type=Boolean
-        description=Retrieves data from ProtVar resource providing contextualised information for missense variation such as destabilization of protein structure, overlapping protein pocket, and protein-protein interaction interface. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/ProtVar.pm">plugin details</a>)
+        description=Retrieves data from the ProtVar resource, providing contextualised information for missense variation, including destabilisation of protein structures, overlapping protein pockets, and protein-protein interaction interfaces. (<a target="_blank" href="https://raw.githubusercontent.com/ensembl-variation/VEP_plugins/main/ProtVar.pm">plugin details</a>)
         default=0
       </ProtVar>
       <CADD>


### PR DESCRIPTION
### Description

A new plugin added to REST VEP endpoints. This PR adds documentation for that.

### Use case

New plugin for VEP.

### Benefits

New plugin for VEP.

### Possible Drawbacks

N/A

### Testing

Tested in local REST server

### Changelog

[/vep/:species/hgvs/] new plugin option added: ProtVar
[/vep/:species/id/] new plugin option added: ProtVar
[/vep/:species/region/] new plugin option added: ProtVar
